### PR TITLE
🔧 ci: update Docker image tagging for enterprise edition

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,9 +50,9 @@ jobs:
     outputs:
       # On main: outputs SHA tag (what's actually pushed)
       # On release/*: outputs version tag (what's actually pushed)
-      api-image-tag: packmind/api-${{ vars.PACKMIND_EDITION }}:${{ steps.get-image-tag.outputs.tag }}
-      frontend-image-tag: packmind/frontend-${{ vars.PACKMIND_EDITION }}:${{ steps.get-image-tag.outputs.tag }}
-      mcp-image-tag: packmind/mcp-${{ vars.PACKMIND_EDITION }}:${{ steps.get-image-tag.outputs.tag }}
+      api-image-tag: packmind/api${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-image-tag.outputs.tag }}
+      frontend-image-tag: packmind/frontend${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-image-tag.outputs.tag }}
+      mcp-image-tag: packmind/mcp${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-image-tag.outputs.tag }}
       version: ${{ steps.get-version.outputs.version }}
 
     steps:
@@ -72,13 +72,27 @@ jobs:
         id: get-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      - name: Set image naming strategy
+        id: set-image-naming
+        run: |
+          if [ "${{ vars.PACKMIND_EDITION }}" = "oss" ]; then
+            echo "name_suffix=" >> $GITHUB_OUTPUT
+            echo "version_suffix=" >> $GITHUB_OUTPUT
+          elif [ "${{ vars.PACKMIND_EDITION }}" = "proprietary" ]; then
+            echo "name_suffix=" >> $GITHUB_OUTPUT
+            echo "version_suffix=-enterprise" >> $GITHUB_OUTPUT
+          else
+            echo "name_suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
+            echo "version_suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine image tag
         id: get-image-tag
         run: |
-          # On release/* tags: use semantic version (e.g., 1.4.2)
+          # On release/* tags: use semantic version (e.g., 1.4.2 or 1.4.2-enterprise)
           # On main branch: use commit SHA
           if [[ "${{ github.ref }}" == refs/tags/release/* ]]; then
-            echo "tag=${{ steps.get-version.outputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}" >> $GITHUB_OUTPUT
           else
             echo "tag=${{ github.sha }}" >> $GITHUB_OUTPUT
           fi
@@ -140,6 +154,8 @@ jobs:
           VERSION: ${{ steps.get-version.outputs.version }}
           SHA: ${{ github.sha }}
           EDITION: ${{ vars.PACKMIND_EDITION }}
+          IMAGE_NAME_SUFFIX: ${{ steps.set-image-naming.outputs.name_suffix }}
+          VERSION_SUFFIX: ${{ steps.set-image-naming.outputs.version_suffix }}
         run: |
           docker buildx bake \
             --file docker-bake.hcl \
@@ -153,7 +169,7 @@ jobs:
         with:
           command: cves
           organization: packmind
-          image: packmind/api-${{ vars.PACKMIND_EDITION }}:${{ steps.get-version.outputs.version }}
+          image: packmind/api${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}
           only-severities: critical,high
           exit-code: true
 
@@ -162,7 +178,7 @@ jobs:
         with:
           command: cves
           organization: packmind
-          image: packmind/frontend-${{ vars.PACKMIND_EDITION }}:${{ steps.get-version.outputs.version }}
+          image: packmind/frontend${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}
           only-severities: critical,high
           exit-code: true
 
@@ -171,7 +187,7 @@ jobs:
         with:
           command: cves
           organization: packmind
-          image: packmind/mcp-${{ vars.PACKMIND_EDITION }}:${{ steps.get-version.outputs.version }}
+          image: packmind/mcp${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}
           only-severities: critical,high
           exit-code: true
 
@@ -210,9 +226,9 @@ jobs:
           }
 
           # Push only SHA-tagged images (version tags are reserved for releases)
-          retry_push "packmind/api-${{ vars.PACKMIND_EDITION }}:${{ github.sha }}"
-          retry_push "packmind/frontend-${{ vars.PACKMIND_EDITION }}:${{ github.sha }}"
-          retry_push "packmind/mcp-${{ vars.PACKMIND_EDITION }}:${{ github.sha }}"
+          retry_push "packmind/api${{ steps.set-image-naming.outputs.name_suffix }}:${{ github.sha }}"
+          retry_push "packmind/frontend${{ steps.set-image-naming.outputs.name_suffix }}:${{ github.sha }}"
+          retry_push "packmind/mcp${{ steps.set-image-naming.outputs.name_suffix }}:${{ github.sha }}"
 
       # Release tags: Rebuild with multi-platform and push
       - name: Build and push multi-platform images (release)
@@ -221,6 +237,8 @@ jobs:
           VERSION: ${{ steps.get-version.outputs.version }}
           SHA: ${{ github.sha }}
           EDITION: ${{ vars.PACKMIND_EDITION }}
+          IMAGE_NAME_SUFFIX: ${{ steps.set-image-naming.outputs.name_suffix }}
+          VERSION_SUFFIX: ${{ steps.set-image-naming.outputs.version_suffix }}
         run: |
           docker buildx bake \
             --file docker-bake.hcl \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,18 @@ jobs:
         id: get-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Set image suffix
-        id: set-image-suffix
+      - name: Set image name and version suffix
+        id: set-image-naming
         run: |
           if [ "${{ vars.PACKMIND_EDITION }}" = "oss" ]; then
-            echo "suffix=" >> $GITHUB_OUTPUT
+            echo "name_suffix=" >> $GITHUB_OUTPUT
+            echo "version_suffix=" >> $GITHUB_OUTPUT
+          elif [ "${{ vars.PACKMIND_EDITION }}" = "proprietary" ]; then
+            echo "name_suffix=" >> $GITHUB_OUTPUT
+            echo "version_suffix=-enterprise" >> $GITHUB_OUTPUT
           else
-            echo "suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
+            echo "name_suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
+            echo "version_suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Create GitHub Release
@@ -41,9 +46,9 @@ jobs:
             ## Docker Images
 
             The following Docker images have been built and pushed to Docker Hub:
-            - `packmind/api${{ steps.set-image-suffix.outputs.suffix }}:${{ steps.get-version.outputs.version }}`
-            - `packmind/frontend${{ steps.set-image-suffix.outputs.suffix }}:${{ steps.get-version.outputs.version }}`
-            - `packmind/mcp${{ steps.set-image-suffix.outputs.suffix }}:${{ steps.get-version.outputs.version }}`
+            - `packmind/api${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}`
+            - `packmind/frontend${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}`
+            - `packmind/mcp${{ steps.set-image-naming.outputs.name_suffix }}:${{ steps.get-version.outputs.version }}${{ steps.set-image-naming.outputs.version_suffix }}`
 
             All images are also available with the `latest` tag.
           draft: false

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -25,6 +25,20 @@ variable "EDITION" {
   default = "oss"
 }
 
+variable "IMAGE_NAME_SUFFIX" {
+  // For OSS: empty string (results in packmind/api)
+  // For proprietary: empty string (results in packmind/api)
+  // For others: -${EDITION} (results in packmind/api-${EDITION})
+  default = ""
+}
+
+variable "VERSION_SUFFIX" {
+  // For OSS: empty string (results in version like 1.4.2)
+  // For proprietary: -enterprise (results in version like 1.4.2-enterprise)
+  // For others: -${EDITION} (results in version like 1.4.2-${EDITION})
+  default = ""
+}
+
 // ============================================================================
 // Groups
 // ============================================================================
@@ -60,9 +74,9 @@ target "api" {
     EDITION = "${EDITION}"
   }
   tags = [
-    "${REGISTRY}/api-${EDITION}:${VERSION}",
-    "${REGISTRY}/api-${EDITION}:latest",
-    notequal("", SHA) ? "${REGISTRY}/api-${EDITION}:${SHA}" : "",
+    "${REGISTRY}/api${IMAGE_NAME_SUFFIX}:${VERSION}${VERSION_SUFFIX}",
+    "${REGISTRY}/api${IMAGE_NAME_SUFFIX}:latest",
+    notequal("", SHA) ? "${REGISTRY}/api${IMAGE_NAME_SUFFIX}:${SHA}" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -79,9 +93,9 @@ target "frontend" {
   inherits   = ["_common"]
   dockerfile = "dockerfile/Dockerfile.frontend"
   tags = [
-    "${REGISTRY}/frontend-${EDITION}:${VERSION}",
-    "${REGISTRY}/frontend-${EDITION}:latest",
-    notequal("", SHA) ? "${REGISTRY}/frontend-${EDITION}:${SHA}" : "",
+    "${REGISTRY}/frontend${IMAGE_NAME_SUFFIX}:${VERSION}${VERSION_SUFFIX}",
+    "${REGISTRY}/frontend${IMAGE_NAME_SUFFIX}:latest",
+    notequal("", SHA) ? "${REGISTRY}/frontend${IMAGE_NAME_SUFFIX}:${SHA}" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -98,9 +112,9 @@ target "mcp" {
   inherits   = ["_common"]
   dockerfile = "dockerfile/Dockerfile.mcp"
   tags = [
-    "${REGISTRY}/mcp-${EDITION}:${VERSION}",
-    "${REGISTRY}/mcp-${EDITION}:latest",
-    notequal("", SHA) ? "${REGISTRY}/mcp-${EDITION}:${SHA}" : "",
+    "${REGISTRY}/mcp${IMAGE_NAME_SUFFIX}:${VERSION}${VERSION_SUFFIX}",
+    "${REGISTRY}/mcp${IMAGE_NAME_SUFFIX}:latest",
+    notequal("", SHA) ? "${REGISTRY}/mcp${IMAGE_NAME_SUFFIX}:${SHA}" : "",
   ]
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
## Explanation

Update Docker image tagging strategy for enterprise edition. Images are now tagged with `-enterprise` suffix on the version tag instead of the image name.

**Changes:**
- OSS images: `packmind/api:1.4.2` (unchanged)
- Enterprise images: `packmind/api:1.4.2-enterprise` (previously `packmind/api-proprietary:1.4.2`)

This affects release notes, Docker builds, and CVE scanning workflows.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: None
- Frontend / Backend / Both: Infrastructure (CI/CD, Docker)
- Breaking changes (if any): Docker image naming convention changed for enterprise edition (built on a private repo)

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
Verified workflow syntax and variable substitution logic. Actual image builds will be tested when the workflow runs on main/release branches.

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

- Review the conditional logic in `.github/workflows/release.yml` and `.github/workflows/docker.yml` for proper handling of OSS vs proprietary editions
- Verify that `docker-bake.hcl` variable substitution works correctly with the new `IMAGE_NAME_SUFFIX` and `VERSION_SUFFIX` variables

