### PR TITLE
🐛 fix(e2e): use data-testid for API key auth method selection

### DIFF
--- a/apps/e2e-tests/src/infra/pages/UserSettingsPage.ts
+++ b/apps/e2e-tests/src/infra/pages/UserSettingsPage.ts
@@ -17,9 +17,10 @@ export class UserSettingsPage
   async getApiKey(): Promise<string> {
     // Navigate to Authenticate tab
     await this.page.getByRole('tab', { name: '2. Authenticate' }).click();
-    // Select API key auth method, with a more resilient selector and wait pattern
-    await this.page.waitForSelector('text=API key', { timeout: 20000 });
-    await this.page.click('text=API key');
+    // Select API key auth method
+    await this.page
+      .getByTestId(CliAuthenticationDataTestIds.AuthMethodApiKey)
+      .click();
     // Generate API key
     await this.page
       .getByTestId(CliAuthenticationDataTestIds.GenerateApiKeyCTA)

--- a/apps/frontend/src/domain/accounts/components/LocalEnvironmentSetup/components/AuthMethodSelector.tsx
+++ b/apps/frontend/src/domain/accounts/components/LocalEnvironmentSetup/components/AuthMethodSelector.tsx
@@ -1,10 +1,19 @@
 import React from 'react';
 import { PMHStack, PMRadioCard } from '@packmind/ui';
+import { CliAuthenticationDataTestIds } from '@packmind/frontend';
 import { AuthMethod, IAuthMethodSelectorProps } from '../types';
 
-const AUTH_OPTIONS: { value: AuthMethod; label: string }[] = [
-  { value: 'login-command', label: 'Login command' },
-  { value: 'api-key', label: 'API key' },
+const AUTH_OPTIONS: { value: AuthMethod; label: string; testId: string }[] = [
+  {
+    value: 'login-command',
+    label: 'Login command',
+    testId: CliAuthenticationDataTestIds.AuthMethodLoginCommand,
+  },
+  {
+    value: 'api-key',
+    label: 'API key',
+    testId: CliAuthenticationDataTestIds.AuthMethodApiKey,
+  },
 ];
 
 export const AuthMethodSelector: React.FC<IAuthMethodSelectorProps> = ({
@@ -21,7 +30,11 @@ export const AuthMethodSelector: React.FC<IAuthMethodSelectorProps> = ({
   >
     <PMHStack gap={2} alignItems="stretch" justify="center">
       {AUTH_OPTIONS.map((option) => (
-        <PMRadioCard.Item key={option.value} value={option.value}>
+        <PMRadioCard.Item
+          key={option.value}
+          value={option.value}
+          data-testid={option.testId}
+        >
           <PMRadioCard.ItemHiddenInput />
           <PMRadioCard.ItemControl>
             <PMRadioCard.ItemText>{option.label}</PMRadioCard.ItemText>

--- a/packages/frontend/src/domains/account/components/CliAuthenticationDataTestIds.ts
+++ b/packages/frontend/src/domains/account/components/CliAuthenticationDataTestIds.ts
@@ -4,4 +4,6 @@ export enum CliAuthenticationDataTestIds {
   EnvironmentVariableTab = 'CliAuthenticationDataTestIds.EnvironmentVariableTab',
   GenerateApiKeyCTA = 'CliAuthenticationDataTestIds.GenerateApiKeyCTA',
   ApiKeyInput = 'CliAuthenticationDataTestIds.ApiKeyTextarea',
+  AuthMethodLoginCommand = 'CliAuthenticationDataTestIds.AuthMethodLoginCommand',
+  AuthMethodApiKey = 'CliAuthenticationDataTestIds.AuthMethodApiKey',
 }


### PR DESCRIPTION
- Add AuthMethodLoginCommand and AuthMethodApiKey to CliAuthenticationDataTestIds enum
- Add data-testid attributes to AuthMethodSelector radio items
- Replace ambiguous 'text=API key' selector with getByTestId in E2E test

## Explanation

<!-- Describe the changes in this pull request -->

<!-- Reference any existing issue, drop the section otherwise -->
Relates to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

<!-- Help reviewers understand scope -->

- Domain packages affected:
- Frontend / Backend / Both:
- Breaking changes (if any):

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
<!-- Describe specific test scenarios -->


## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

<!-- Anything reviewers should pay special attention to? -->
<!-- Areas where you'd like specific feedback? -->

