### PR TITLE
Add CLI update limitation notices to documentation

### DIFF
--- a/apps/doc/concepts/commands-management.mdx
+++ b/apps/doc/concepts/commands-management.mdx
@@ -109,6 +109,12 @@ The workflow ensures your command includes:
 
 **Updating commands** is possible from the web app, on the dedicated section of the commands.
 
+<Info>
+  **CLI update support** — The CLI currently allows creating commands but not
+  yet updating them. You can update commands through the web app. CLI support for
+  updating commands is coming in Q1 2026.
+</Info>
+
 ## Commands Versions
 
 Every time you update a command, this creates a new version.

--- a/apps/doc/concepts/standards-management.mdx
+++ b/apps/doc/concepts/standards-management.mdx
@@ -84,6 +84,12 @@ You can update your standard later to add and remove rules. Each rule can be doc
 Every time you update a standard, this creates a new version.
 This keeps track of the history of your changes, and it's useful to keep track of which versions are currently distributed to Git repositories.
 
+<Info>
+  **CLI update support** — The CLI currently allows creating standards but not
+  yet updating them. You can update standards through the web app or MCP server.
+  CLI support for updating standards is coming in Q1 2026.
+</Info>
+
 ## Where Standards Appear After Distribution
 
 Once you distribute a package containing standards, they appear in specific locations in your repository depending on which AI assistants your organization has enabled. Standards are automatically loaded by your AI assistant—you don't need to do anything special to activate them.

--- a/apps/doc/tools/cli.mdx
+++ b/apps/doc/tools/cli.mdx
@@ -714,6 +714,12 @@ Available standards:
     Description: TypeScript coding conventions...
 ```
 
+<Info>
+  **Updating standards via CLI** — The CLI currently supports creating standards
+  but not yet updating existing ones. To update a standard, use the web app or
+  MCP server. CLI support for updating standards is coming in Q1 2026.
+</Info>
+
 ### Create a Standard from a Playbook File
 
 ```bash
@@ -815,6 +821,12 @@ Available commands:
     Name: Setup Database Migration
     URL: https://app.packmind.com/org/my-org/space/global/commands/def456
 ```
+
+<Info>
+  **Updating commands via CLI** — The CLI currently supports creating commands
+  but not yet updating existing ones. To update a command, use the web app. CLI
+  support for updating commands is coming in Q1 2026.
+</Info>
 
 ### Create a Command from a Playbook File
 


### PR DESCRIPTION
## Explanation

This PR adds informational notices to the documentation to clarify current limitations regarding CLI support for updating standards and commands. The notices inform users that while the CLI supports creating standards and commands, updating existing ones is not yet available via CLI and must be done through the web app or MCP server.

Three documentation files have been updated with consistent `<Info>` callout blocks:
- `apps/doc/tools/cli.mdx`: Added notices in the standards and commands CLI sections
- `apps/doc/concepts/standards-management.mdx`: Added notice in the standards management overview
- `apps/doc/concepts/commands-management.mdx`: Added notice in the commands management overview

All notices indicate that CLI support for updates is planned for Q1 2026.

## Type of Change

- [x] Documentation

## Affected Components

- Domain packages affected: Documentation only
- Frontend / Backend / Both: N/A
- Breaking changes: None

## Testing

- [x] Manual review of documentation changes
- No testing needed - documentation-only changes

## TODO List

- [x] Documentation Updated
- [ ] CHANGELOG Updated (if applicable for docs-only changes)

## Reviewer Notes

These are purely informational additions to help users understand current CLI limitations. The notices are consistent across all three documentation files and provide clear guidance on alternative methods (web app, MCP server) and timeline for future CLI support.

https://claude.ai/code/session_01QgaPPukuS2aGmQbRY7awYB