### PR TITLE
Refacto/introduce diff mode to unified markdown viewer

### DIFF
--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -1,0 +1,17 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+import path from 'path';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  addons: [],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {
+      builder: {
+        viteConfigPath: path.resolve(__dirname, 'vite.config.ts'),
+      },
+    },
+  },
+};
+
+export default config;

--- a/apps/frontend/.storybook/preview.tsx
+++ b/apps/frontend/.storybook/preview.tsx
@@ -1,0 +1,35 @@
+import type { Preview } from '@storybook/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { UIProvider } from '@packmind/ui';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      staleTime: Infinity,
+    },
+  },
+});
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <UIProvider>
+          <Story />
+        </UIProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/apps/frontend/.storybook/vite.config.ts
+++ b/apps/frontend/.storybook/vite.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig } from 'vite';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import path from 'path';
+
+export default defineConfig(() => {
+  // Determine edition mode (defaults to OSS if not explicitly set to 'proprietary')
+  const isOssMode = process.env.PACKMIND_EDITION !== 'proprietary';
+
+  // Configure resolve aliases based on edition
+  const resolveAliases = isOssMode
+    ? {
+        '@packmind/proprietary/frontend': path.resolve(
+          __dirname,
+          '../src/domain/editions/stubs',
+        ),
+      }
+    : {
+        '@packmind/proprietary/frontend': path.resolve(__dirname, '../src'),
+      };
+
+  return {
+    root: path.resolve(__dirname, '..'),
+    cacheDir: '../../../node_modules/.vite/apps/frontend-storybook',
+    assetsInclude: ['**/*.svg', '**/*.png'],
+    define: {
+      __PACKMIND_EDITION__: JSON.stringify(
+        process.env.PACKMIND_EDITION || 'oss',
+      ),
+    },
+    resolve: {
+      alias: resolveAliases,
+    },
+    plugins: [nxViteTsPaths()],
+  };
+});

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -26,6 +26,23 @@
       "options": {
         "command": "nx dev frontend"
       }
+    },
+    "storybook": {
+      "executor": "nx:run-commands",
+      "continuous": true,
+      "options": {
+        "cwd": "apps/frontend",
+        "command": "storybook dev -p 6006"
+      }
+    },
+    "build-storybook": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "outputs": ["{projectRoot}/storybook-static"],
+      "options": {
+        "cwd": "apps/frontend",
+        "command": "storybook build"
+      }
     }
   }
 }

--- a/apps/frontend/src/domain/change-proposals/components/StandardReviewDetail/ProposalReviewPanel.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/StandardReviewDetail/ProposalReviewPanel.tsx
@@ -31,7 +31,6 @@ import {
 import { HighlightedText, HighlightedRuleBox } from '../HighlightedContent';
 import { UnifiedMarkdownViewer } from '../UnifiedMarkdownViewer';
 import { useDiffNavigation } from '../../hooks/useDiffNavigation';
-import { renderMarkdownDiffOrPreview } from '../SkillReviewDetail/SkillContent/renderMarkdownDiffOrPreview';
 
 interface ProposalReviewPanelProps {
   selectedStandard: Standard | undefined;
@@ -244,15 +243,24 @@ export function ProposalReviewPanel({
                 ? renderDiffText(payload.oldValue, payload.newValue)
                 : selectedStandard.name}
             </PMText>
-            {renderMarkdownDiffOrPreview(
-              isDescriptionDiff,
-              showPreview,
-              payload,
-              selectedStandard.description,
-              {
-                previewPaddingVariant: 'none',
-                defaultPaddingVariant: 'none',
-              },
+            {isDescriptionDiff ? (
+              <UnifiedMarkdownViewer
+                key={showPreview ? 'preview' : 'diff'}
+                oldValue={payload.oldValue}
+                newValue={payload.newValue}
+                proposalNumbers={[
+                  proposalNumberMap.get(reviewingProposal.id) ?? 0,
+                ]}
+                displayMode={showPreview ? 'unified' : 'diff'}
+              />
+            ) : (
+              <MarkdownEditorProvider>
+                <MarkdownEditor
+                  defaultValue={selectedStandard.description}
+                  readOnly
+                  paddingVariant="none"
+                />
+              </MarkdownEditorProvider>
             )}
 
             {/* Rules Section */}

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -33,22 +33,6 @@ const meta: Meta<typeof MultiViewer> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const SimpleTextChange: Story = {
-  args: {
-    oldValue: 'This was my content',
-    newValue: 'This is my updated content',
-    proposalNumbers: [1],
-  },
-};
-
-export const MultipleProposals: Story = {
-  args: {
-    oldValue: 'This is my content',
-    newValue: 'This is my updated content',
-    proposalNumbers: [1, 2, 3],
-  },
-};
-
 export const MarkdownFormatting: Story = {
   args: {
     oldValue: `# My title
@@ -90,6 +74,22 @@ function hello() {
 }
 \`\`\``,
     proposalNumbers: [1],
+  },
+};
+
+export const TagChanges: Story = {
+  args: {
+    oldValue: '# My title\n\nThis was my content',
+    newValue: '## My title\n\nThis is my **content**',
+    proposalNumbers: [1],
+  },
+};
+
+export const MultipleProposals: Story = {
+  args: {
+    oldValue: 'This is my content',
+    newValue: 'This is my updated content',
+    proposalNumbers: [1, 2, 3],
   },
 };
 

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof UnifiedMarkdownViewer> = {
   argTypes: {
     displayMode: {
       control: 'radio',
-      options: ['unified', 'diff'],
+      options: ['unified', 'diff', 'plain'],
       description: 'Display mode for the markdown viewer',
       value: 'unified',
     },
@@ -41,7 +41,9 @@ export const MarkdownFormatting: Story = {
   args: {
     oldValue: `# Heading
 
-This is a paragraph with plain text.`,
+This is a paragraph with plain text.
+
+This used to be a line.`,
     newValue: `# Updated Heading
 
 This is a paragraph with **bold** text.`,

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -49,7 +49,16 @@ There was a line here.
 
 My list:
  - one item
- - another item`,
+ - another item
+ 
+# Code example
+
+\`\`\`javascript
+function hello() {
+  console.log('Hello');
+}
+\`\`\` 
+`,
     newValue: `# My title
 
 This is my updated content
@@ -59,7 +68,15 @@ This is my updated content
 My list:
  - first item
  - a new item
- - another item`,
+ - another item
+ 
+ # Example
+
+\`\`\`javascript
+function hello() {
+  console.log('Hello, ' + name);
+}
+\`\`\``,
     proposalNumbers: [1],
   },
 };

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UnifiedMarkdownViewer } from './UnifiedMarkdownViewer';
+
+const meta: Meta<typeof UnifiedMarkdownViewer> = {
+  title: 'ChangeProposals/UnifiedMarkdownViewer',
+  component: UnifiedMarkdownViewer,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SimpleTextChange: Story = {
+  args: {
+    oldValue: 'This was my content',
+    newValue: 'This is my updated content',
+    proposalNumbers: [1],
+  },
+};
+
+export const MultipleProposals: Story = {
+  args: {
+    oldValue: 'This is my content',
+    newValue: 'This is my updated content',
+    proposalNumbers: [1, 2, 3],
+  },
+};
+
+export const MarkdownFormatting: Story = {
+  args: {
+    oldValue: `# Heading
+
+This is a paragraph with bold text.`,
+    newValue: `# Updated Heading
+
+This is a paragraph with **bold** text.`,
+    proposalNumbers: [1],
+  },
+};
+
+export const CodeBlock: Story = {
+  args: {
+    oldValue: `# Example
+
+\`\`\`javascript
+function hello() {
+  console.log('Hello');
+}
+\`\`\``,
+    newValue: `# Example
+
+\`\`\`javascript
+function hello(name) {
+  console.log('Hello, ' + name);
+}
+\`\`\``,
+    proposalNumbers: [1],
+  },
+};
+
+export const ListChanges: Story = {
+  args: {
+    oldValue: `# Todo List
+
+- Item 1
+- Item 2
+- Item 3`,
+    newValue: `# Todo List
+
+- Item 1
+- Updated Item 2
+- Item 3
+- Item 4`,
+    proposalNumbers: [1],
+  },
+};

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -8,16 +8,17 @@ const MultiViewer: React.FunctionComponent<
   Omit<UnifiedMarkdownViewerProps, 'displayMode'>
 > = (props) => {
   return (
-    <>
-      <h1>Unified view</h1>
-      <UnifiedMarkdownViewer {...props} displayMode={'unified'} />
+    <div style={{ display: 'flex', flexDirection: 'row', gap: '2em' }}>
+      <div style={{ width: '50%' }}>
+        <h1>Unified view</h1>
+        <UnifiedMarkdownViewer {...props} displayMode={'unified'} />
+      </div>
 
-      <h1>Diff view</h1>
-      <UnifiedMarkdownViewer {...props} displayMode={'diff'} />
-
-      <h1>Plain view</h1>
-      <UnifiedMarkdownViewer {...props} displayMode={'plain'} />
-    </>
+      <div style={{ flex: '1 1 0px' }}>
+        <h1>Diff view</h1>
+        <UnifiedMarkdownViewer {...props} displayMode={'diff'} />
+      </div>
+    </div>
   );
 };
 

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -39,14 +39,27 @@ export const MultipleProposals: Story = {
 
 export const MarkdownFormatting: Story = {
   args: {
-    oldValue: `# Heading
+    oldValue: `# My title
 
-This is a paragraph with plain text.
+This was my content
 
-This used to be a line.`,
-    newValue: `# Updated Heading
+There was a line here.
 
-This is a paragraph with **bold** text.`,
+## My sub-heading
+
+My list:
+ - one item
+ - another item`,
+    newValue: `# My title
+
+This is my updated content
+
+## My sub-heading
+
+My list:
+ - first item
+ - a new item
+ - another item`,
     proposalNumbers: [1],
   },
 };
@@ -85,5 +98,32 @@ export const ListChanges: Story = {
 - Item 3
 - Item 4`,
     proposalNumbers: [1],
+  },
+};
+
+export const ComplexChanges: Story = {
+  args: {
+    oldValue: `# My title
+
+This was my content
+
+There was a line here.
+
+## My sub-heading
+
+My list:
+ - one item
+ - another item`,
+    newValue: `# My title
+
+This is my updated content
+
+## My sub-heading
+
+My list:
+ - first item
+ - a new item
+ - another item`,
+    proposalNumbers: [1, 2],
   },
 };

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -8,6 +8,14 @@ const meta: Meta<typeof UnifiedMarkdownViewer> = {
     layout: 'padded',
   },
   tags: ['autodocs'],
+  argTypes: {
+    displayMode: {
+      control: 'radio',
+      options: ['unified', 'diff'],
+      description: 'Display mode for the markdown viewer',
+      value: 'unified',
+    },
+  },
 };
 
 export default meta;
@@ -33,7 +41,7 @@ export const MarkdownFormatting: Story = {
   args: {
     oldValue: `# Heading
 
-This is a paragraph with bold text.`,
+This is a paragraph with plain text.`,
     newValue: `# Updated Heading
 
 This is a paragraph with **bold** text.`,

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.stories.tsx
@@ -1,21 +1,33 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { UnifiedMarkdownViewer } from './UnifiedMarkdownViewer';
+import {
+  UnifiedMarkdownViewer,
+  UnifiedMarkdownViewerProps,
+} from './UnifiedMarkdownViewer';
 
-const meta: Meta<typeof UnifiedMarkdownViewer> = {
+const MultiViewer: React.FunctionComponent<
+  Omit<UnifiedMarkdownViewerProps, 'displayMode'>
+> = (props) => {
+  return (
+    <>
+      <h1>Unified view</h1>
+      <UnifiedMarkdownViewer {...props} displayMode={'unified'} />
+
+      <h1>Diff view</h1>
+      <UnifiedMarkdownViewer {...props} displayMode={'diff'} />
+
+      <h1>Plain view</h1>
+      <UnifiedMarkdownViewer {...props} displayMode={'plain'} />
+    </>
+  );
+};
+
+const meta: Meta<typeof MultiViewer> = {
   title: 'ChangeProposals/UnifiedMarkdownViewer',
-  component: UnifiedMarkdownViewer,
+  component: MultiViewer,
   parameters: {
     layout: 'padded',
   },
   tags: ['autodocs'],
-  argTypes: {
-    displayMode: {
-      control: 'radio',
-      options: ['unified', 'diff', 'plain'],
-      description: 'Display mode for the markdown viewer',
-      value: 'unified',
-    },
-  },
 };
 
 export default meta;

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.tsx
@@ -6,7 +6,7 @@ import {
   IDiffMarkdownEditorProps,
 } from '../../../shared/components/editor/DiffMarkdownEditor';
 
-interface UnifiedMarkdownViewerProps {
+export interface UnifiedMarkdownViewerProps {
   oldValue: string;
   newValue: string;
   proposalNumbers: number[];

--- a/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.tsx
+++ b/apps/frontend/src/domain/change-proposals/components/UnifiedMarkdownViewer.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { PMBox } from '@packmind/ui';
 import { MilkdownProvider } from '@milkdown/react';
-import { DiffMarkdownEditor } from '../../../shared/components/editor/DiffMarkdownEditor';
+import {
+  DiffMarkdownEditor,
+  IDiffMarkdownEditorProps,
+} from '../../../shared/components/editor/DiffMarkdownEditor';
 
 interface UnifiedMarkdownViewerProps {
   oldValue: string;
   newValue: string;
   proposalNumbers: number[];
+  displayMode?: IDiffMarkdownEditorProps['displayMode'];
 }
 
 /**
@@ -18,6 +22,7 @@ export function UnifiedMarkdownViewer({
   oldValue,
   newValue,
   proposalNumbers,
+  displayMode,
 }: UnifiedMarkdownViewerProps) {
   return (
     <PMBox data-diff-section>
@@ -26,6 +31,7 @@ export function UnifiedMarkdownViewer({
           oldValue={oldValue}
           newValue={newValue}
           proposalNumbers={proposalNumbers}
+          displayMode={displayMode ?? 'unified'}
           paddingVariant="none"
         />
       </MilkdownProvider>

--- a/apps/frontend/src/domain/change-proposals/utils/buildInlineDiffMarkdown.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/buildInlineDiffMarkdown.ts
@@ -1,0 +1,13 @@
+import { buildDiffHtml } from './markdownDiff';
+
+/**
+ * Builds inline diff markdown content for the "diff" display mode.
+ * Uses buildDiffHtml to generate HTML with <ins> and <del> tags
+ * showing additions and deletions inline.
+ */
+export function buildInlineDiffMarkdown(
+  oldValue: string,
+  newValue: string,
+): string {
+  return buildDiffHtml(oldValue, newValue);
+}

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
@@ -385,5 +385,39 @@ New paragraph
         ]),
       );
     });
+
+    it('detects heading level changes', () => {
+      const oldValue = '# My title';
+      const newValue = '## My title';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'heading',
+          level: '##',
+          content: 'My title',
+          status: 'updated',
+          diffContent: '# --My title--\n## ++My title++',
+        }),
+      ]);
+    });
+
+    it('detects heading level and content changes', () => {
+      const oldValue = '# Old title';
+      const newValue = '## New title';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'heading',
+          level: '##',
+          content: 'New title',
+          status: 'updated',
+          diffContent: '# --Old title--\n## ++New title++',
+        }),
+      ]);
+    });
   });
 });

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
@@ -1,0 +1,355 @@
+import { parseAndDiffMarkdown } from './markdownBlockDiff';
+
+describe('markdownBlockDiff', () => {
+  describe('parseAndDiffMarkdown', () => {
+    it('parses and diffs a simple text change', () => {
+      const oldValue = 'This was my content';
+      const newValue = 'This is my updated content';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'paragraph',
+          content: 'This is my updated content',
+          status: 'updated',
+          diffContent: expect.stringMatching(
+            /This <del>was<\/del><ins>is<\/ins> my <ins>updated <\/ins>content/,
+          ),
+        }),
+      ]);
+    });
+
+    it('handles heading blocks with level tracking', () => {
+      const oldValue = '# My title';
+      const newValue = '# My updated title';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'heading',
+          level: '#',
+          content: 'My updated title',
+          status: 'updated',
+          diffContent: expect.stringContaining('<ins>updated </ins>'),
+        }),
+      ]);
+    });
+
+    it('preserves unchanged blocks', () => {
+      const markdown = '# My title\n\nSome content that stays the same';
+
+      const result = parseAndDiffMarkdown(markdown, markdown);
+
+      expect(result).toEqual([
+        expect.objectContaining({ status: 'unchanged' }),
+        expect.objectContaining({ status: 'unchanged' }),
+      ]);
+    });
+
+    it('marks added blocks correctly', () => {
+      const oldValue = '# Title';
+      const newValue = '# Title\n\nNew paragraph';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'heading',
+            status: 'unchanged',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'New paragraph',
+            status: 'added',
+            diffContent: '<ins>New paragraph</ins>',
+          }),
+        ]),
+      );
+    });
+
+    it('marks deleted blocks correctly', () => {
+      const oldValue = '# Title\n\nParagraph to delete';
+      const newValue = '# Title';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'heading',
+            status: 'unchanged',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'Paragraph to delete',
+            status: 'deleted',
+            diffContent: '<del>Paragraph to delete</del>',
+          }),
+        ]),
+      );
+    });
+
+    it('handles the complex user story example correctly', () => {
+      const oldValue = `# My title
+
+This was my content
+
+There was a line here.
+
+## My sub-heading
+
+My list:
+ - one item
+ - another item`;
+
+      const newValue = `# My title
+
+This is my updated content
+
+## My sub-heading
+
+My list:
+ - first item
+ - a new item
+ - another item`;
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'heading',
+            level: '#',
+            content: 'My title',
+            status: 'unchanged',
+          }),
+          expect.objectContaining({
+            type: 'heading',
+            level: '##',
+            content: 'My sub-heading',
+            status: 'unchanged',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'This is my updated content',
+            status: 'updated',
+            diffContent: expect.stringMatching(
+              /<del>was<\/del>.*<ins>is<\/ins>/,
+            ),
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'There was a line here.',
+            status: 'deleted',
+            diffContent: '<del>There was a line here.</del>',
+          }),
+          expect.objectContaining({
+            type: 'list',
+            status: 'updated',
+            items: expect.arrayContaining([
+              expect.objectContaining({
+                content: 'one item',
+                status: 'deleted',
+              }),
+              expect.objectContaining({
+                content: 'first item',
+                status: 'added',
+              }),
+              expect.objectContaining({
+                content: 'a new item',
+                status: 'added',
+              }),
+              expect.objectContaining({
+                content: 'another item',
+                status: 'unchanged',
+              }),
+            ]),
+          }),
+        ]),
+      );
+    });
+
+    it('handles multiple heading levels', () => {
+      const oldValue = '# H1\n## H2\n### H3';
+      const newValue = '# H1\n## Updated H2\n### H3';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'heading',
+          level: '#',
+          status: 'unchanged',
+        }),
+        expect.objectContaining({
+          type: 'heading',
+          level: '##',
+          content: 'Updated H2',
+          status: 'updated',
+        }),
+        expect.objectContaining({
+          type: 'heading',
+          level: '###',
+          status: 'unchanged',
+        }),
+      ]);
+    });
+
+    it('computes word-level diffs for code blocks', () => {
+      const oldValue = '```js\nconst x = 1;\n```';
+      const newValue = '```js\nconst x = 2;\n```';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'code',
+          status: 'updated',
+          diffContent: expect.stringMatching(/<del>1<\/del>.*<ins>2<\/ins>/),
+        }),
+      ]);
+    });
+
+    it('tracks list item additions', () => {
+      const oldValue = '- item 1\n- item 2';
+      const newValue = '- item 1\n- item 2\n- item 3';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'list',
+          status: 'updated',
+          items: [
+            expect.objectContaining({ status: 'unchanged' }),
+            expect.objectContaining({ status: 'unchanged' }),
+            expect.objectContaining({
+              status: 'added',
+              diffContent: '<ins>item 3</ins>',
+            }),
+          ],
+        }),
+      ]);
+    });
+
+    it('tracks list item deletions', () => {
+      const oldValue = '- item 1\n- item 2\n- item 3';
+      const newValue = '- item 1\n- item 3';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'list',
+          status: 'updated',
+          items: [
+            expect.objectContaining({ status: 'unchanged' }),
+            expect.objectContaining({
+              status: 'deleted',
+              diffContent: '<del>item 2</del>',
+            }),
+            expect.objectContaining({ status: 'unchanged' }),
+          ],
+        }),
+      ]);
+    });
+
+    it('returns empty array for empty markdown', () => {
+      const result = parseAndDiffMarkdown('', '');
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles transition from empty to content', () => {
+      const result = parseAndDiffMarkdown('', '# New heading');
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'heading',
+          status: 'added',
+        }),
+      ]);
+    });
+
+    it('escapes HTML to prevent XSS', () => {
+      const oldValue = 'Content with <script>alert("xss")</script>';
+      const newValue = 'Content with <div>safe</div>';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result[0].diffContent).toEqual(
+        expect.not.stringContaining('<script>'),
+      );
+    });
+
+    it('matches similar paragraphs by content for word-level diffing', () => {
+      const oldValue = `This was my content
+
+There was a line here.`;
+      const newValue = `This is my updated content`;
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'This is my updated content',
+            status: 'updated',
+            diffContent: expect.stringMatching(
+              /<del>was<\/del>.*<ins>is<\/ins>.*<ins>updated <\/ins>/,
+            ),
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            content: 'There was a line here.',
+            status: 'deleted',
+          }),
+        ]),
+      );
+    });
+
+    it('handles complex markdown with mixed changes', () => {
+      const oldValue = `# Title
+
+Paragraph 1
+
+Paragraph 2
+
+- List item 1
+- List item 2`;
+
+      const newValue = `# Title
+
+Paragraph 1 updated
+
+New paragraph
+
+- List item 1
+- List item 2 updated
+- List item 3`;
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'heading',
+            status: 'unchanged',
+          }),
+          expect.objectContaining({
+            type: 'paragraph',
+            status: expect.not.stringMatching('unchanged'),
+          }),
+          expect.objectContaining({
+            type: 'list',
+            status: expect.not.stringMatching('unchanged'),
+          }),
+        ]),
+      );
+    });
+  });
+});

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
@@ -14,7 +14,7 @@ describe('markdownBlockDiff', () => {
           content: 'This is my updated content',
           status: 'updated',
           diffContent: expect.stringMatching(
-            /This <del>was<\/del><ins>is<\/ins> my <ins>updated <\/ins>content/,
+            /This --was--\+\+is\+\+ my \+\+updated \+\+content/,
           ),
         }),
       ]);
@@ -32,7 +32,7 @@ describe('markdownBlockDiff', () => {
           level: '#',
           content: 'My updated title',
           status: 'updated',
-          diffContent: expect.stringContaining('<ins>updated </ins>'),
+          diffContent: expect.stringContaining('++updated ++'),
         }),
       ]);
     });
@@ -64,7 +64,7 @@ describe('markdownBlockDiff', () => {
             type: 'paragraph',
             content: 'New paragraph',
             status: 'added',
-            diffContent: '<ins>New paragraph</ins>',
+            diffContent: '++New paragraph++',
           }),
         ]),
       );
@@ -86,7 +86,7 @@ describe('markdownBlockDiff', () => {
             type: 'paragraph',
             content: 'Paragraph to delete',
             status: 'deleted',
-            diffContent: '<del>Paragraph to delete</del>',
+            diffContent: '--Paragraph to delete--',
           }),
         ]),
       );
@@ -136,15 +136,13 @@ My list:
             type: 'paragraph',
             content: 'This is my updated content',
             status: 'updated',
-            diffContent: expect.stringMatching(
-              /<del>was<\/del>.*<ins>is<\/ins>/,
-            ),
+            diffContent: expect.stringMatching(/--was--.*\+\+is\+\+/),
           }),
           expect.objectContaining({
             type: 'paragraph',
             content: 'There was a line here.',
             status: 'deleted',
-            diffContent: '<del>There was a line here.</del>',
+            diffContent: '--There was a line here.--',
           }),
           expect.objectContaining({
             type: 'list',
@@ -209,7 +207,7 @@ My list:
           type: 'code',
           status: 'updated',
           language: 'js',
-          diffContent: expect.stringMatching(/<del>1<\/del>.*<ins>2<\/ins>/),
+          diffContent: expect.stringMatching(/--1--.*\+\+2\+\+/),
           lineDiff: expect.stringContaining('-const x = 1;'),
         }),
       ]);
@@ -264,7 +262,7 @@ function hello(name) {
             expect.objectContaining({ status: 'unchanged' }),
             expect.objectContaining({
               status: 'added',
-              diffContent: '<ins>item 3</ins>',
+              diffContent: '++item 3++',
             }),
           ],
         }),
@@ -285,7 +283,7 @@ function hello(name) {
             expect.objectContaining({ status: 'unchanged' }),
             expect.objectContaining({
               status: 'deleted',
-              diffContent: '<del>item 2</del>',
+              diffContent: '--item 2--',
             }),
             expect.objectContaining({ status: 'unchanged' }),
           ],
@@ -336,7 +334,7 @@ There was a line here.`;
             content: 'This is my updated content',
             status: 'updated',
             diffContent: expect.stringMatching(
-              /<del>was<\/del>.*<ins>is<\/ins>.*<ins>updated <\/ins>/,
+              /--was--.*\+\+is\+\+.*\+\+updated \+\+/,
             ),
           }),
           expect.objectContaining({

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.spec.ts
@@ -208,7 +208,43 @@ My list:
         expect.objectContaining({
           type: 'code',
           status: 'updated',
+          language: 'js',
           diffContent: expect.stringMatching(/<del>1<\/del>.*<ins>2<\/ins>/),
+          lineDiff: expect.stringContaining('-const x = 1;'),
+        }),
+      ]);
+    });
+
+    it('includes additions in line diff for code blocks', () => {
+      const oldValue = '```js\nconst x = 1;\n```';
+      const newValue = '```js\nconst x = 2;\n```';
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result[0].lineDiff).toContain('+const x = 2;');
+    });
+
+    it('computes line-level diffs for multi-line code blocks', () => {
+      const oldValue = `\`\`\`javascript
+function hello() {
+  console.log('Hello');
+}
+\`\`\``;
+
+      const newValue = `\`\`\`javascript
+function hello(name) {
+  console.log('Hello, ' + name);
+}
+\`\`\``;
+
+      const result = parseAndDiffMarkdown(oldValue, newValue);
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          type: 'code',
+          status: 'updated',
+          language: 'javascript',
+          lineDiff: expect.stringContaining('-function hello() {'),
         }),
       ]);
     });

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
@@ -373,26 +373,47 @@ export function parseAndDiffMarkdown(
               });
             } else {
               // Text blocks (heading, paragraph, code)
-              const diffHtml = buildWordDiffHtml(
-                oldBlock.content,
-                newBlock.content,
-              );
+              // For headings with different levels, mark as complete replacement
+              if (
+                oldBlock.type === 'heading' &&
+                newBlock.type === 'heading' &&
+                oldBlock.level !== newBlock.level
+              ) {
+                result.push({
+                  ...newBlock,
+                  status: 'updated',
+                  diffContent: `${oldBlock.level || '#'} --${oldBlock.content}--\n${newBlock.level || '#'} ++${newBlock.content}++`,
+                });
+              } else {
+                // For headings with same level, include level markers in diff
+                // For other blocks, just use content
+                const oldText =
+                  oldBlock.type === 'heading'
+                    ? `${oldBlock.level || '#'} ${oldBlock.content}`
+                    : oldBlock.content;
+                const newText =
+                  newBlock.type === 'heading'
+                    ? `${newBlock.level || '#'} ${newBlock.content}`
+                    : newBlock.content;
 
-              // For code blocks, also compute line-level diff
-              const updatedBlock: MarkdownBlock = {
-                ...newBlock,
-                status: 'updated',
-                diffContent: diffHtml,
-              };
+                const diffHtml = buildWordDiffHtml(oldText, newText);
 
-              if (newBlock.type === 'code') {
-                updatedBlock.lineDiff = buildLineDiff(
-                  oldBlock.content,
-                  newBlock.content,
-                );
+                // For code blocks, also compute line-level diff
+                const updatedBlock: MarkdownBlock = {
+                  ...newBlock,
+                  status: 'updated',
+                  diffContent: diffHtml,
+                };
+
+                if (newBlock.type === 'code') {
+                  updatedBlock.lineDiff = buildLineDiff(
+                    oldBlock.content,
+                    newBlock.content,
+                  );
+                }
+
+                result.push(updatedBlock);
               }
-
-              result.push(updatedBlock);
             }
           } else {
             // Different block types - mark as deleted and added
@@ -424,26 +445,47 @@ export function parseAndDiffMarkdown(
                 items: diffListItems(oldBlock.items, newBlock.items),
               });
             } else {
-              const diffHtml = buildWordDiffHtml(
-                oldBlock.content,
-                newBlock.content,
-              );
+              // For headings with different levels, mark as complete replacement
+              if (
+                oldBlock.type === 'heading' &&
+                newBlock.type === 'heading' &&
+                oldBlock.level !== newBlock.level
+              ) {
+                result.push({
+                  ...newBlock,
+                  status: 'updated',
+                  diffContent: `${oldBlock.level || '#'} --${oldBlock.content}--\n${newBlock.level || '#'} ++${newBlock.content}++`,
+                });
+              } else {
+                // For headings with same level, include level markers in diff
+                // For other blocks, just use content
+                const oldText =
+                  oldBlock.type === 'heading'
+                    ? `${oldBlock.level || '#'} ${oldBlock.content}`
+                    : oldBlock.content;
+                const newText =
+                  newBlock.type === 'heading'
+                    ? `${newBlock.level || '#'} ${newBlock.content}`
+                    : newBlock.content;
 
-              // For code blocks, also compute line-level diff
-              const updatedBlock: MarkdownBlock = {
-                ...newBlock,
-                status: 'updated',
-                diffContent: diffHtml,
-              };
+                const diffHtml = buildWordDiffHtml(oldText, newText);
 
-              if (newBlock.type === 'code') {
-                updatedBlock.lineDiff = buildLineDiff(
-                  oldBlock.content,
-                  newBlock.content,
-                );
+                // For code blocks, also compute line-level diff
+                const updatedBlock: MarkdownBlock = {
+                  ...newBlock,
+                  status: 'updated',
+                  diffContent: diffHtml,
+                };
+
+                if (newBlock.type === 'code') {
+                  updatedBlock.lineDiff = buildLineDiff(
+                    oldBlock.content,
+                    newBlock.content,
+                  );
+                }
+
+                result.push(updatedBlock);
               }
-
-              result.push(updatedBlock);
             }
           }
 

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
@@ -1,0 +1,437 @@
+import { marked, Token, Tokens } from 'marked';
+import { diffArrays, diffWords } from 'diff';
+
+/**
+ * Status of a markdown block after diff computation
+ */
+export type BlockStatus = 'unchanged' | 'added' | 'deleted' | 'updated';
+
+/**
+ * Type of markdown block
+ */
+export type BlockType =
+  | 'heading'
+  | 'paragraph'
+  | 'list'
+  | 'code'
+  | 'text'
+  | 'other';
+
+/**
+ * Represents a parsed markdown block with diff information
+ */
+export interface MarkdownBlock {
+  /** Type of the block */
+  type: BlockType;
+  /** Clean content (for unified/plain views) */
+  content: string;
+  /** Diff HTML content with <ins>/<del> tags (for tooltips and diff view) */
+  diffContent: string;
+  /** Status after diff computation */
+  status: BlockStatus;
+  /** Heading level (e.g., '#', '##') - only for heading blocks */
+  level?: string;
+  /** List items - only for list blocks */
+  items?: MarkdownBlock[];
+  /** Original markdown raw text */
+  raw: string;
+}
+
+/**
+ * Parse markdown string into structured blocks
+ */
+function parseMarkdownBlocks(markdown: string): MarkdownBlock[] {
+  marked.setOptions({ breaks: true, gfm: true });
+  const tokens = marked.lexer(markdown).filter((t) => t.type !== 'space');
+
+  return tokens.map((token) => {
+    const block: MarkdownBlock = {
+      type: getBlockType(token),
+      content: extractCleanContent(token),
+      diffContent: '',
+      status: 'unchanged',
+      raw: token.raw,
+    };
+
+    // Add heading level if it's a heading
+    if (token.type === 'heading') {
+      const heading = token as Tokens.Heading;
+      block.level = '#'.repeat(heading.depth);
+    }
+
+    // Parse list items if it's a list
+    if (token.type === 'list') {
+      const list = token as Tokens.List;
+      block.items = list.items.map((item) => ({
+        type: 'text',
+        content: item.text,
+        diffContent: '',
+        status: 'unchanged',
+        raw: item.raw,
+      }));
+    }
+
+    return block;
+  });
+}
+
+/**
+ * Get block type from marked token
+ */
+function getBlockType(token: Token): BlockType {
+  if (token.type === 'heading') return 'heading';
+  if (token.type === 'paragraph') return 'paragraph';
+  if (token.type === 'list') return 'list';
+  if (token.type === 'code') return 'code';
+  if (token.type === 'text') return 'text';
+  return 'other';
+}
+
+/**
+ * Extract clean text content from a token
+ */
+function extractCleanContent(token: Token): string {
+  if (token.type === 'heading') {
+    return (token as Tokens.Heading).text;
+  }
+  if (token.type === 'paragraph') {
+    return (token as Tokens.Paragraph).text;
+  }
+  if (token.type === 'code') {
+    return (token as Tokens.Code).text;
+  }
+  if (token.type === 'text') {
+    return (token as Tokens.Text).text;
+  }
+  if (token.type === 'list') {
+    const list = token as Tokens.List;
+    return list.items.map((item) => item.text).join('\n');
+  }
+  return token.raw;
+}
+
+/**
+ * Build diff HTML from two text strings using word-level diffing
+ */
+function buildWordDiffHtml(oldText: string, newText: string): string {
+  const changes = diffWords(oldText, newText);
+  return changes
+    .map((change) => {
+      if (change.added) return `<ins>${escapeHtml(change.value)}</ins>`;
+      if (change.removed) return `<del>${escapeHtml(change.value)}</del>`;
+      return escapeHtml(change.value);
+    })
+    .join('');
+}
+
+/**
+ * Escape HTML special characters
+ */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/**
+ * Calculate similarity between two strings (0-1, higher is more similar)
+ * Uses a simple word overlap metric
+ */
+function calculateSimilarity(str1: string, str2: string): number {
+  const words1 = str1.toLowerCase().split(/\s+/);
+  const words2 = str2.toLowerCase().split(/\s+/);
+
+  const set1 = new Set(words1);
+  const set2 = new Set(words2);
+
+  const intersection = new Set([...set1].filter((x) => set2.has(x)));
+  const union = new Set([...set1, ...set2]);
+
+  if (union.size === 0) return 0;
+  return intersection.size / union.size;
+}
+
+/**
+ * Try to match deleted and added blocks based on similarity
+ * Returns pairs of [oldBlock, newBlock] and unpaired blocks
+ */
+function matchBlocksBySimilarity(
+  oldBlocks: MarkdownBlock[],
+  newBlocks: MarkdownBlock[],
+): {
+  matched: Array<[MarkdownBlock, MarkdownBlock]>;
+  unmatchedOld: MarkdownBlock[];
+  unmatchedNew: MarkdownBlock[];
+} {
+  const matched: Array<[MarkdownBlock, MarkdownBlock]> = [];
+  const usedOld = new Set<number>();
+  const usedNew = new Set<number>();
+
+  // For each old block, find the best matching new block
+  for (let i = 0; i < oldBlocks.length; i++) {
+    const oldBlock = oldBlocks[i];
+    let bestMatch = -1;
+    let bestSimilarity = 0.3; // Minimum threshold for matching
+
+    for (let j = 0; j < newBlocks.length; j++) {
+      if (usedNew.has(j)) continue;
+
+      const newBlock = newBlocks[j];
+
+      // Only match blocks of the same type
+      if (oldBlock.type !== newBlock.type) continue;
+
+      const similarity = calculateSimilarity(
+        oldBlock.content,
+        newBlock.content,
+      );
+
+      if (similarity > bestSimilarity) {
+        bestSimilarity = similarity;
+        bestMatch = j;
+      }
+    }
+
+    if (bestMatch !== -1) {
+      matched.push([oldBlock, newBlocks[bestMatch]]);
+      usedOld.add(i);
+      usedNew.add(bestMatch);
+    }
+  }
+
+  const unmatchedOld = oldBlocks.filter((_, i) => !usedOld.has(i));
+  const unmatchedNew = newBlocks.filter((_, i) => !usedNew.has(i));
+
+  return { matched, unmatchedOld, unmatchedNew };
+}
+
+/**
+ * Compare two list blocks and return diff information for items
+ */
+function diffListItems(
+  oldItems: MarkdownBlock[],
+  newItems: MarkdownBlock[],
+): MarkdownBlock[] {
+  const oldTexts = oldItems.map((item) => item.content.trim());
+  const newTexts = newItems.map((item) => item.content.trim());
+  const changes = diffArrays(oldTexts, newTexts);
+
+  let oldIdx = 0;
+  let newIdx = 0;
+  const result: MarkdownBlock[] = [];
+
+  for (const change of changes) {
+    const count = change.count ?? change.value.length;
+
+    if (!change.added && !change.removed) {
+      // Unchanged items
+      for (let i = 0; i < count; i++) {
+        result.push({
+          ...newItems[newIdx++],
+          status: 'unchanged',
+        });
+        oldIdx++;
+      }
+    } else if (change.removed) {
+      // Deleted items - mark for deletion
+      for (let i = 0; i < count; i++) {
+        const oldItem = oldItems[oldIdx++];
+        result.push({
+          ...oldItem,
+          status: 'deleted',
+          diffContent: `<del>${escapeHtml(oldItem.content)}</del>`,
+        });
+      }
+    } else {
+      // Added items
+      for (let i = 0; i < count; i++) {
+        const newItem = newItems[newIdx++];
+        result.push({
+          ...newItem,
+          status: 'added',
+          diffContent: `<ins>${escapeHtml(newItem.content)}</ins>`,
+        });
+      }
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Normalize raw markdown for comparison by trimming whitespace
+ */
+function normalizeRaw(raw: string): string {
+  return raw.trim();
+}
+
+/**
+ * Create a comparison key for a block (type + content)
+ */
+function createBlockKey(block: MarkdownBlock): string {
+  return `${block.type}:${normalizeRaw(block.raw)}`;
+}
+
+/**
+ * Parse markdown and compute diffs between old and new versions.
+ * Returns structured blocks with both clean content and diff information.
+ *
+ * @param oldValue - Original markdown content
+ * @param newValue - New markdown content
+ * @returns Array of MarkdownBlock with diff information
+ */
+export function parseAndDiffMarkdown(
+  oldValue: string,
+  newValue: string,
+): MarkdownBlock[] {
+  const oldBlocks = parseMarkdownBlocks(oldValue);
+  const newBlocks = parseMarkdownBlocks(newValue);
+
+  // Use normalized keys for block-level diffing to avoid whitespace issues
+  const oldKeys = oldBlocks.map(createBlockKey);
+  const newKeys = newBlocks.map(createBlockKey);
+  const changes = diffArrays(oldKeys, newKeys);
+
+  let oldIdx = 0;
+  let newIdx = 0;
+  const result: MarkdownBlock[] = [];
+
+  for (let ci = 0; ci < changes.length; ci++) {
+    const change = changes[ci];
+    const count = change.count ?? change.value.length;
+
+    if (!change.added && !change.removed) {
+      // Unchanged blocks
+      for (let i = 0; i < count; i++) {
+        result.push({
+          ...newBlocks[newIdx++],
+          status: 'unchanged',
+        });
+        oldIdx++;
+      }
+    } else if (change.removed) {
+      const next = changes[ci + 1];
+
+      if (next && next.added) {
+        // Modified blocks - check if we can do word-level diff
+        const nextCount = next.count ?? next.value.length;
+
+        if (count === 1 && nextCount === 1) {
+          // Single block modified - do word-level diff
+          const oldBlock = oldBlocks[oldIdx++];
+          const newBlock = newBlocks[newIdx++];
+
+          if (oldBlock.type === newBlock.type) {
+            // Same block type - compute word-level diff
+            if (newBlock.type === 'list' && oldBlock.items && newBlock.items) {
+              // Special handling for lists
+              result.push({
+                ...newBlock,
+                status: 'updated',
+                items: diffListItems(oldBlock.items, newBlock.items),
+              });
+            } else {
+              // Text blocks (heading, paragraph, code)
+              const diffHtml = buildWordDiffHtml(
+                oldBlock.content,
+                newBlock.content,
+              );
+              result.push({
+                ...newBlock,
+                status: 'updated',
+                diffContent: diffHtml,
+              });
+            }
+          } else {
+            // Different block types - mark as deleted and added
+            result.push({
+              ...oldBlock,
+              status: 'deleted',
+              diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+            });
+            result.push({
+              ...newBlock,
+              status: 'added',
+              diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+            });
+          }
+        } else {
+          // Multiple blocks changed - try to match them by similarity
+          const deletedBlocks = oldBlocks.slice(oldIdx, oldIdx + count);
+          const addedBlocks = newBlocks.slice(newIdx, newIdx + nextCount);
+
+          const { matched, unmatchedOld, unmatchedNew } =
+            matchBlocksBySimilarity(deletedBlocks, addedBlocks);
+
+          // Process matched pairs with word-level diff
+          for (const [oldBlock, newBlock] of matched) {
+            if (newBlock.type === 'list' && oldBlock.items && newBlock.items) {
+              result.push({
+                ...newBlock,
+                status: 'updated',
+                items: diffListItems(oldBlock.items, newBlock.items),
+              });
+            } else {
+              const diffHtml = buildWordDiffHtml(
+                oldBlock.content,
+                newBlock.content,
+              );
+              result.push({
+                ...newBlock,
+                status: 'updated',
+                diffContent: diffHtml,
+              });
+            }
+          }
+
+          // Process unmatched deletions
+          for (const oldBlock of unmatchedOld) {
+            result.push({
+              ...oldBlock,
+              status: 'deleted',
+              diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+            });
+          }
+
+          // Process unmatched additions
+          for (const newBlock of unmatchedNew) {
+            result.push({
+              ...newBlock,
+              status: 'added',
+              diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+            });
+          }
+
+          oldIdx += count;
+          newIdx += nextCount;
+        }
+        ci++; // Skip the next (added) change
+      } else {
+        // Pure deletion
+        for (let i = 0; i < count; i++) {
+          const oldBlock = oldBlocks[oldIdx++];
+          result.push({
+            ...oldBlock,
+            status: 'deleted',
+            diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+          });
+        }
+      }
+    } else {
+      // Pure additions
+      for (let i = 0; i < count; i++) {
+        const newBlock = newBlocks[newIdx++];
+        result.push({
+          ...newBlock,
+          status: 'added',
+          diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/markdownBlockDiff.ts
@@ -25,7 +25,7 @@ export interface MarkdownBlock {
   type: BlockType;
   /** Clean content (for unified/plain views) */
   content: string;
-  /** Diff HTML content with <ins>/<del> tags (for tooltips and diff view) */
+  /** Diff content with ++/-- markers (for tooltips and diff view) */
   diffContent: string;
   /** Line-level diff with +/- prefixes for code blocks (for diff mode rendering) */
   lineDiff?: string;
@@ -121,15 +121,16 @@ function extractCleanContent(token: Token): string {
 }
 
 /**
- * Build diff HTML from two text strings using word-level diffing
+ * Build diff markup from two text strings using word-level diffing
+ * Uses custom markdown-style syntax: ++ for additions, -- for deletions
  */
 function buildWordDiffHtml(oldText: string, newText: string): string {
   const changes = diffWords(oldText, newText);
   return changes
     .map((change) => {
-      if (change.added) return `<ins>${escapeHtml(change.value)}</ins>`;
-      if (change.removed) return `<del>${escapeHtml(change.value)}</del>`;
-      return escapeHtml(change.value);
+      if (change.added) return `++${change.value}++`;
+      if (change.removed) return `--${change.value}--`;
+      return change.value;
     })
     .join('');
 }
@@ -279,7 +280,7 @@ function diffListItems(
         result.push({
           ...oldItem,
           status: 'deleted',
-          diffContent: `<del>${escapeHtml(oldItem.content)}</del>`,
+          diffContent: `--${oldItem.content}--`,
         });
       }
     } else {
@@ -289,7 +290,7 @@ function diffListItems(
         result.push({
           ...newItem,
           status: 'added',
-          diffContent: `<ins>${escapeHtml(newItem.content)}</ins>`,
+          diffContent: `++${newItem.content}++`,
         });
       }
     }
@@ -398,12 +399,12 @@ export function parseAndDiffMarkdown(
             result.push({
               ...oldBlock,
               status: 'deleted',
-              diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+              diffContent: `--${oldBlock.content}--`,
             });
             result.push({
               ...newBlock,
               status: 'added',
-              diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+              diffContent: `++${newBlock.content}++`,
             });
           }
         } else {
@@ -451,7 +452,7 @@ export function parseAndDiffMarkdown(
             result.push({
               ...oldBlock,
               status: 'deleted',
-              diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+              diffContent: `--${oldBlock.content}--`,
             });
           }
 
@@ -460,7 +461,7 @@ export function parseAndDiffMarkdown(
             result.push({
               ...newBlock,
               status: 'added',
-              diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+              diffContent: `++${newBlock.content}++`,
             });
           }
 
@@ -475,7 +476,7 @@ export function parseAndDiffMarkdown(
           result.push({
             ...oldBlock,
             status: 'deleted',
-            diffContent: `<del>${escapeHtml(oldBlock.content)}</del>`,
+            diffContent: `--${oldBlock.content}--`,
           });
         }
       }
@@ -486,7 +487,7 @@ export function parseAndDiffMarkdown(
         result.push({
           ...newBlock,
           status: 'added',
-          diffContent: `<ins>${escapeHtml(newBlock.content)}</ins>`,
+          diffContent: `++${newBlock.content}++`,
         });
       }
     }

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
@@ -21,7 +21,7 @@ describe('rebuildMarkdownFromBlocks', () => {
       );
     });
 
-    it('adds "Show code changes" trigger for updated code blocks', () => {
+    it('adds "[See code change]" marker for updated code blocks', () => {
       const oldValue = `\`\`\`javascript
 function hello() {
   console.log('Hello');
@@ -41,7 +41,7 @@ function hello(name) {
         mode: 'unified',
       });
 
-      expect(result).toContain('Show code changes');
+      expect(result).toMatch(/\[See code change\]\(#CODE_DIFF:.*\)/);
     });
 
     it('rebuilds list markdown preserving structure', () => {

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
@@ -136,6 +136,20 @@ function hello(name) {
       expect(result).toMatch(/# .*--Old--.*\+\+New\+\+(?![\s\S]*<h1>)/);
     });
 
+    it('renders heading level changes without duplicating level markers', () => {
+      const oldValue = '# My title';
+      const newValue = '## My title';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+        mode: 'diff',
+      });
+
+      expect(result).toBe('# --My title--\n## ++My title++\n');
+    });
+
     it('includes deleted blocks in output', () => {
       const oldValue = '# Title\n\nParagraph to delete';
       const newValue = '# Title';

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
@@ -1,0 +1,217 @@
+import { rebuildMarkdownFromBlocks } from './rebuildMarkdownFromBlocks';
+import { parseAndDiffMarkdown } from './markdownBlockDiff';
+
+describe('rebuildMarkdownFromBlocks', () => {
+  describe('unified mode (markdown output)', () => {
+    it('rebuilds markdown with clean content, excluding deleted blocks', () => {
+      const oldValue = '# Title\n\nOld paragraph\n\nAnother paragraph';
+      const newValue = '# Title\n\nNew paragraph';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toEqual(
+        expect.stringMatching(
+          /# Title[\s\S]*New paragraph(?![\s\S]*Old paragraph)(?![\s\S]*Another paragraph)/,
+        ),
+      );
+    });
+
+    it('rebuilds list markdown preserving structure', () => {
+      const oldValue = '- item 1\n- item 2';
+      const newValue = '- item 1\n- item 2\n- item 3';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toMatch(/- item 1[\s\S]*- item 2[\s\S]*- item 3/);
+    });
+
+    it('excludes deleted list items from output', () => {
+      const oldValue = '- item 1\n- item 2\n- item 3';
+      const newValue = '- item 1\n- item 3';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toEqual(
+        expect.stringMatching(/- item 1[\s\S]*- item 3(?![\s\S]*- item 2)/),
+      );
+    });
+
+    it('preserves code block formatting', () => {
+      const oldValue = '```js\nconst x = 1;\n```';
+      const newValue = '```js\nconst x = 2;\n```';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toMatch(/```[\s\S]*const x = 2;[\s\S]*```/);
+    });
+  });
+
+  describe('diff mode (HTML output)', () => {
+    it('generates HTML with inline diff markers', () => {
+      const oldValue = 'Old text';
+      const newValue = 'New text';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+      });
+
+      expect(result).toMatch(
+        /<p>.*<del>Old<\/del>.*<ins>New<\/ins>.*text.*<\/p>/,
+      );
+    });
+
+    it('renders list items with diff HTML markers', () => {
+      const oldValue = '- item 1\n- item 2';
+      const newValue = '- item 1\n- item 2\n- item 3';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+      });
+
+      expect(result).toMatch(
+        /<ul>[\s\S]*<li>.*item 1.*<\/li>[\s\S]*<li>.*item 2.*<\/li>[\s\S]*<li>.*<ins>item 3<\/ins>.*<\/li>[\s\S]*<\/ul>/,
+      );
+    });
+
+    it('renders headings with proper HTML structure', () => {
+      const oldValue = '# Old Title';
+      const newValue = '# New Title';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+      });
+
+      expect(result).toMatch(/<h1>.*<del>Old<\/del>.*<ins>New<\/ins>.*<\/h1>/);
+    });
+
+    it('includes deleted blocks in output', () => {
+      const oldValue = '# Title\n\nParagraph to delete';
+      const newValue = '# Title';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+      });
+
+      expect(result).toMatch(/<del>Paragraph to delete<\/del>/);
+    });
+  });
+
+  describe('plain mode', () => {
+    it('produces clean markdown without diff markers', () => {
+      const oldValue = 'Old content';
+      const newValue = 'New content';
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toEqual(
+        expect.stringMatching(
+          /New content(?![\s\S]*Old content)(?![\s\S]*<ins>)(?![\s\S]*<del>)/,
+        ),
+      );
+    });
+  });
+
+  describe('complex scenarios', () => {
+    it('handles the user story example in unified mode', () => {
+      const oldValue = `# My title
+
+This was my content
+
+There was a line here.
+
+## My sub-heading
+
+My list:
+ - one item
+ - another item`;
+
+      const newValue = `# My title
+
+This is my updated content
+
+## My sub-heading
+
+My list:
+ - first item
+ - a new item
+ - another item`;
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: false,
+        useDiffContent: false,
+      });
+
+      expect(result).toEqual(
+        expect.stringMatching(
+          /# My title[\s\S]*This is my updated content[\s\S]*## My sub-heading[\s\S]*- another item(?![\s\S]*There was a line here)/,
+        ),
+      );
+    });
+
+    it('handles the user story example in diff mode', () => {
+      const oldValue = `# My title
+
+This was my content
+
+There was a line here.
+
+## My sub-heading
+
+My list:
+ - one item
+ - another item`;
+
+      const newValue = `# My title
+
+This is my updated content
+
+## My sub-heading
+
+My list:
+ - first item
+ - a new item
+ - another item`;
+
+      const blocks = parseAndDiffMarkdown(oldValue, newValue);
+      const result = rebuildMarkdownFromBlocks(blocks, {
+        includeDeleted: true,
+        useDiffContent: true,
+      });
+
+      expect(result).toEqual(
+        expect.stringMatching(
+          /<h1>My title<\/h1>[\s\S]*<del>There was a line here\.<\/del>[\s\S]*<ul>[\s\S]*<li>/,
+        ),
+      );
+    });
+  });
+});

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.spec.ts
@@ -102,7 +102,7 @@ function hello(name) {
       });
 
       expect(result).toMatch(
-        /<del>Old<\/del>[\s\S]*<ins>New<\/ins>[\s\S]*text(?![\s\S]*<p>)/,
+        /--Old--[\s\S]*\+\+New\+\+[\s\S]*text(?![\s\S]*<p>)/,
       );
     });
 
@@ -118,7 +118,7 @@ function hello(name) {
       });
 
       expect(result).toMatch(
-        /- item 1[\s\S]*- item 2[\s\S]*- <ins>item 3<\/ins>(?![\s\S]*<ul>)(?![\s\S]*<li>)/,
+        /- item 1[\s\S]*- item 2[\s\S]*- \+\+item 3\+\+(?![\s\S]*<ul>)(?![\s\S]*<li>)/,
       );
     });
 
@@ -133,9 +133,7 @@ function hello(name) {
         mode: 'diff',
       });
 
-      expect(result).toMatch(
-        /# .*<del>Old<\/del>.*<ins>New<\/ins>(?![\s\S]*<h1>)/,
-      );
+      expect(result).toMatch(/# .*--Old--.*\+\+New\+\+(?![\s\S]*<h1>)/);
     });
 
     it('includes deleted blocks in output', () => {
@@ -149,7 +147,7 @@ function hello(name) {
         mode: 'diff',
       });
 
-      expect(result).toMatch(/<del>Paragraph to delete<\/del>(?![\s\S]*<p>)/);
+      expect(result).toMatch(/--Paragraph to delete--(?![\s\S]*<p>)/);
     });
 
     it('renders code blocks with line-level diff syntax', () => {
@@ -190,7 +188,7 @@ function hello(name) {
 
       expect(result).toEqual(
         expect.stringMatching(
-          /New content(?![\s\S]*Old content)(?![\s\S]*<ins>)(?![\s\S]*<del>)/,
+          /New content(?![\s\S]*Old content)(?![\s\S]*\+\+)(?![\s\S]*--)/,
         ),
       );
     });
@@ -267,7 +265,7 @@ My list:
       });
 
       expect(result).toMatch(
-        /# My title[\s\S]*<del>There was a line here\.<\/del>[\s\S]*- (?![\s\S]*<h1>)(?![\s\S]*<ul>)(?![\s\S]*<li>)/,
+        /# My title[\s\S]*--There was a line here\.--[\s\S]*- (?![\s\S]*<h1>)(?![\s\S]*<ul>)(?![\s\S]*<li>)/,
       );
     });
   });

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
@@ -40,8 +40,15 @@ export function rebuildMarkdownFromBlocks(
 
     switch (block.type) {
       case 'heading':
-        // Always use markdown syntax for headings
-        parts.push(`${block.level || '#'} ${content}\n`);
+        // For headings, check if diffContent already includes level markers
+        // (happens when heading level changes, e.g., "#--text--\n##++text++")
+        if (options.useDiffContent && content.startsWith('#')) {
+          // diffContent already includes heading levels, use as-is
+          parts.push(`${content}\n`);
+        } else {
+          // Normal heading or unified mode, prepend level
+          parts.push(`${block.level || '#'} ${content}\n`);
+        }
         break;
 
       case 'paragraph':

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
@@ -82,15 +82,12 @@ export function rebuildMarkdownFromBlocks(
             block.status === 'updated' &&
             block.lineDiff
           ) {
-            // Add a special HTML comment that will be detected by the editor
-            // The lineDiff is base64 encoded to avoid breaking the HTML
+            // Add plain markdown with diff markers and encoded diff data in link
             const encodedDiff =
               typeof btoa !== 'undefined'
                 ? btoa(block.lineDiff)
                 : Buffer.from(block.lineDiff).toString('base64');
-            parts.push(
-              `<!-- CODE_DIFF:${encodedDiff} -->\n<span class="code-diff-trigger" data-line-diff="${encodedDiff}">Show code changes</span>\n`,
-            );
+            parts.push(`[See code change](#CODE_DIFF:${encodedDiff})\n`);
           }
         }
         break;

--- a/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
+++ b/apps/frontend/src/domain/change-proposals/utils/rebuildMarkdownFromBlocks.ts
@@ -1,0 +1,130 @@
+import { MarkdownBlock } from './markdownBlockDiff';
+
+/**
+ * Rebuilds markdown content from structured blocks.
+ * Used to generate content for different display modes.
+ */
+export interface RebuildOptions {
+  /** Whether to include deleted blocks */
+  includeDeleted: boolean;
+  /** Whether to use diffContent (with <ins>/<del> tags) or clean content */
+  useDiffContent: boolean;
+}
+
+/**
+ * Rebuild markdown from structured blocks for rendering in different modes.
+ *
+ * @param blocks - Array of MarkdownBlock from parseAndDiffMarkdown
+ * @param options - Options controlling what to include
+ * @returns Markdown or HTML string ready for rendering
+ */
+export function rebuildMarkdownFromBlocks(
+  blocks: MarkdownBlock[],
+  options: RebuildOptions,
+): string {
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    // Skip deleted blocks unless includeDeleted is true
+    if (block.status === 'deleted' && !options.includeDeleted) {
+      continue;
+    }
+
+    // Use diffContent if available and requested, otherwise use content
+    const content =
+      options.useDiffContent && block.diffContent
+        ? block.diffContent
+        : block.content;
+
+    switch (block.type) {
+      case 'heading':
+        if (options.useDiffContent) {
+          // For diff mode, render as HTML heading
+          const level = block.level?.length || 1;
+          parts.push(`<h${level}>${content}</h${level}>\n`);
+        } else {
+          // For unified/plain mode, use markdown syntax
+          parts.push(`${block.level || '#'} ${content}\n`);
+        }
+        break;
+
+      case 'paragraph':
+        if (options.useDiffContent) {
+          // For diff mode, render as HTML paragraph
+          parts.push(`<p>${content}</p>\n`);
+        } else {
+          // For unified/plain mode, use plain text with blank line separator
+          parts.push(`${content}\n`);
+        }
+        break;
+
+      case 'list':
+        if (options.useDiffContent) {
+          // For diff mode, render as HTML list
+          parts.push(renderListAsDiffHtml(block));
+        } else {
+          // For unified/plain mode, use markdown list syntax
+          parts.push(renderListAsMarkdown(block, options.includeDeleted));
+        }
+        break;
+
+      case 'code':
+        if (options.useDiffContent) {
+          // For diff mode, render as HTML code block
+          parts.push(`<pre><code>${content}</code></pre>\n`);
+        } else {
+          // For unified/plain mode, use markdown code block
+          parts.push(`\`\`\`\n${content}\n\`\`\`\n`);
+        }
+        break;
+
+      default:
+        // For other types, just add the raw content
+        parts.push(block.raw);
+    }
+
+    // Add blank line between blocks for markdown mode
+    if (!options.useDiffContent && block.type !== 'heading') {
+      parts.push('\n');
+    }
+  }
+
+  return parts.join('');
+}
+
+/**
+ * Render a list block as markdown
+ */
+function renderListAsMarkdown(
+  block: MarkdownBlock,
+  includeDeleted: boolean,
+): string {
+  if (!block.items || block.items.length === 0) {
+    return '';
+  }
+
+  const items = block.items
+    .filter((item) => includeDeleted || item.status !== 'deleted')
+    .map((item) => `- ${item.content}`)
+    .join('\n');
+
+  return items + '\n';
+}
+
+/**
+ * Render a list block as HTML with diff tags
+ */
+function renderListAsDiffHtml(block: MarkdownBlock): string {
+  if (!block.items || block.items.length === 0) {
+    return '';
+  }
+
+  const items = block.items
+    .map((item) => {
+      const content = item.diffContent || item.content;
+      return `<li>${content}</li>`;
+    })
+    .join('\n');
+
+  return `<ul>\n${items}\n</ul>\n`;
+}

--- a/apps/frontend/src/shared/components/editor/DiffMarkdownEditor.tsx
+++ b/apps/frontend/src/shared/components/editor/DiffMarkdownEditor.tsx
@@ -155,9 +155,9 @@ export const DiffMarkdownEditor: React.FC<IDiffMarkdownEditorProps> = ({
         editorRef.current?.querySelector('.ProseMirror');
       if (!proseMirrorEditor) return;
 
-      // Get all text-containing elements
+      // Get all text-containing elements (exclude li since content is in p inside)
       const contentElements = proseMirrorEditor.querySelectorAll(
-        'p, h1, h2, h3, h4, h5, h6, li, code',
+        'p, h1, h2, h3, h4, h5, h6, code',
       );
 
       if (contentElements.length === 0) return;

--- a/apps/frontend/src/shared/components/editor/DiffMarkdownEditor.tsx
+++ b/apps/frontend/src/shared/components/editor/DiffMarkdownEditor.tsx
@@ -620,7 +620,6 @@ export const DiffMarkdownEditor: React.FC<IDiffMarkdownEditorProps> = ({
   return (
     <PMBox data-milkdown-padding-variant={paddingVariant} css={markdownDiffCss}>
       <Milkdown />
-      <pre>{editorContent}</pre>
     </PMBox>
   );
 };


### PR DESCRIPTION
## Explanation

Provide a single editor to preview markdown content including updates.

It has three modes:
 - diff: shows the changes as a git diff

<img width="851" height="845" alt="Capture d’écran 2026-02-27 à 13 51 54" src="https://github.com/user-attachments/assets/d7f66a68-4e59-4cd8-a30e-2cfc14981ce7" />

 - unified: shows the updated content and integrate tooltip to see the changes
<img width="910" height="704" alt="Capture d’écran 2026-02-27 à 13 52 43" src="https://github.com/user-attachments/assets/895b849e-4792-4525-b750-431c640b0cf3" />

 - plain: just show the updated content as plain markdown.



## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

<!-- Help reviewers understand scope -->

- Domain packages affected:
- Frontend / Backend / Both:
- Breaking changes (if any):

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
<!-- Describe specific test scenarios -->


## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

<!-- Anything reviewers should pay special attention to? -->
<!-- Areas where you'd like specific feedback? -->

