### PR TITLE
Add Lightpanda as an alternative headless browser for E2E tests

### DIFF
--- a/apps/e2e-tests/package.json
+++ b/apps/e2e-tests/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "e2e": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=false npx playwright test"
+    "e2e": "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=false npx playwright test",
+    "e2e:lightpanda": "playwright test --config=playwright.lightpanda.config.ts"
   }
 }

--- a/apps/e2e-tests/playwright.lightpanda.config.ts
+++ b/apps/e2e-tests/playwright.lightpanda.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
     // video and screenshot disabled — Lightpanda has no rendering engine
     video: 'off',
     screenshot: 'off',
+    // Empty locale prevents Playwright from calling Emulation.setUserAgentOverride,
+    // which Lightpanda does not implement. Playwright's default is "en-US" which
+    // triggers that CDP command unconditionally (crPage.js: if options.locale → _updateUserAgent).
+    locale: '',
   },
   projects: [
     {

--- a/apps/e2e-tests/playwright.lightpanda.config.ts
+++ b/apps/e2e-tests/playwright.lightpanda.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+const isCI = !!process.env.CI;
+
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src' }),
+  reporter: [['html', { open: isCI ? 'never' : 'on-failure' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    // video and screenshot disabled — Lightpanda has no rendering engine
+    video: 'off',
+    screenshot: 'off',
+  },
+  projects: [
+    {
+      name: 'lightpanda',
+    },
+  ],
+});

--- a/apps/e2e-tests/src/fixtures/packmindTest.ts
+++ b/apps/e2e-tests/src/fixtures/packmindTest.ts
@@ -10,14 +10,16 @@ import { PageFactory } from '../infra/PageFactory';
 // Override the built-in browser fixture to support Lightpanda via CDP
 const testBase = base.extend<Record<string, never>, { browser: Browser }>({
   browser: [
-    async (_fixtures, use) => {
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
       const wsEndpoint = process.env['LIGHTPANDA_WS_ENDPOINT'];
       if (wsEndpoint) {
         const browser = await chromium.connectOverCDP({
           endpointURL: wsEndpoint,
         });
         await use(browser as unknown as Browser);
-        await browser.disconnect();
+        // Browser.disconnect() does not exist on CDP-connected browsers in playwright-core.
+        // The connection closes naturally when the worker process exits; Lightpanda keeps running.
       } else {
         const browser = await chromium.launch();
         await use(browser);

--- a/apps/e2e-tests/src/fixtures/packmindTest.ts
+++ b/apps/e2e-tests/src/fixtures/packmindTest.ts
@@ -1,4 +1,5 @@
-import { test as base } from '@playwright/test';
+import { test as base, Browser } from '@playwright/test';
+import { chromium } from 'playwright-core';
 import { v4 as uuidv4 } from 'uuid';
 import { IPackmindApi } from '../domain/api/IPackmindApi';
 import { PackmindApi } from '../infra/api/PackmindApi';
@@ -6,7 +7,28 @@ import { SignUpWithOrganizationCommand } from '@packmind/types';
 import { IDashboardPage, IPageFactory } from '../domain/pages';
 import { PageFactory } from '../infra/PageFactory';
 
-export const testWithUserData = base.extend<{
+// Override the built-in browser fixture to support Lightpanda via CDP
+const testBase = base.extend<Record<string, never>, { browser: Browser }>({
+  browser: [
+    async (_fixtures, use) => {
+      const wsEndpoint = process.env['LIGHTPANDA_WS_ENDPOINT'];
+      if (wsEndpoint) {
+        const browser = await chromium.connectOverCDP({
+          endpointURL: wsEndpoint,
+        });
+        await use(browser as unknown as Browser);
+        await browser.disconnect();
+      } else {
+        const browser = await chromium.launch();
+        await use(browser);
+        await browser.close();
+      }
+    },
+    { scope: 'worker' },
+  ],
+});
+
+export const testWithUserData = testBase.extend<{
   userData: SignUpWithOrganizationCommand;
 }>({
   // eslint-disable-next-line no-empty-pattern

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -317,8 +317,7 @@ services:
     environment:
       LIGHTPANDA_DISABLE_TELEMETRY: 'true'
     healthcheck:
-      test:
-        ['CMD-SHELL', 'wget -qO- http://127.0.0.1:9222/json/version || exit 1']
+      test: ['CMD', 'bash', '-c', '</dev/tcp/127.0.0.1/9222']
       interval: 2s
       timeout: 2s
       retries: 15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -309,6 +309,20 @@ services:
       run-migrations:
         condition: service_completed_successfully
 
+  lightpanda:
+    profiles:
+      - e2e-lightpanda
+    image: lightpanda/browser:nightly
+    container_name: ${COMPOSE_PROJECT_NAME:-dev}-lightpanda
+    environment:
+      LIGHTPANDA_DISABLE_TELEMETRY: 'true'
+    healthcheck:
+      test:
+        ['CMD-SHELL', 'wget -qO- http://127.0.0.1:9222/json/version || exit 1']
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
   run-e2e-tests:
     image: mcr.microsoft.com/playwright:v1.56.1-jammy
     container_name: ${COMPOSE_PROJECT_NAME:-dev}-run-e2e-tests-${PACKMIND_EDITION:-oss}
@@ -329,6 +343,31 @@ services:
       BASE_URL: http://frontend:4200
       CI: 'true'
     depends_on:
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
+
+  run-e2e-tests-lightpanda:
+    image: mcr.microsoft.com/playwright:v1.56.1-jammy
+    container_name: ${COMPOSE_PROJECT_NAME:-dev}-run-e2e-tests-lightpanda-${PACKMIND_EDITION:-oss}
+    profiles:
+      - e2e-lightpanda
+    volumes:
+      - .:/packmind
+      - dev-node_modules:/packmind/node_modules
+      - dev-dist:/packmind/dist
+      - dev-tmp:/packmind/tmp
+      - dev-nx-sock:/nx-sock
+    working_dir: /packmind/apps/e2e-tests
+    entrypoint: npm run e2e:lightpanda
+    environment:
+      BASE_URL: http://frontend:4200
+      CI: 'true'
+      LIGHTPANDA_WS_ENDPOINT: ws://lightpanda:9222
+    depends_on:
+      lightpanda:
+        condition: service_healthy
       frontend:
         condition: service_healthy
       backend:


### PR DESCRIPTION
## Explanation

[Lightpanda](https://github.com/lightpanda-io/browser) is an open-source headless browser written in Zig. It exposes a CDP (Chrome DevTools Protocol) endpoint and is designed to be significantly faster and lighter than Chromium. This PR wires it up as an opt-in alternative to the existing Chromium E2E runner.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

**Docker Compose (`docker-compose.yml`)**
- `lightpanda` service — `lightpanda/browser:nightly` image, under the `e2e-lightpanda` profile. Healthcheck uses `bash -c </dev/tcp/127.0.0.1/9222` (the image ships no wget/curl).
- `run-e2e-tests-lightpanda` service — mirrors `run-e2e-tests` but sets `LIGHTPANDA_WS_ENDPOINT` and depends on `lightpanda` being healthy first.

**Playwright config (`playwright.lightpanda.config.ts`)**
- `video: 'off'`, `screenshot: 'off'` — Lightpanda has no rendering engine.
 - `locale: ''` — Playwright's built-in locale fixture defaults to "en-US", which makes `crPage.js` call `mulation.setUserAgentOverride` during page initialisation. Lightpanda does not implement that CDP command and returns `UnknownMethod`. An empty string is  falsy so the conditional is skipped.
- Single `lightpanda` project (no device preset needed for a CDP connection).

**Fixture (`src/fixtures/packmindTest.ts`)**
- Worker-scoped `browser` fixture override: when `LIGHTPANDA_WS_ENDPOINT` is set, `chromium.connectOverCDP()` is used instead of `chromium.launch()`. All downstream fixtures (`testWithUserSignedUp`, `testWithApi`) inherit this automatically.
- `Browser.disconnect()` does not exist on CDP-connected browsers in playwright-core 1.56 — the IPC connection closes naturally when the worker exits.

**npm script (`apps/e2e-tests/package.json`)**
- "e2e:lightpanda": "playwright test --config=playwright.lightpanda.config.ts"

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**

Start Lightpanda + full dev stack
```
docker compose --profile e2e-lightpanda up
```
Or run tests manually once the stack is up
```
LIGHTPANDA_WS_ENDPOINT=ws://localhost:9222 npm run e2e:lightpanda
```

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

The CDP integration is fully wired up and Playwright successfully connects to Lightpanda. Tests navigate to the frontend, but the frontend JS bundle throws `ReferenceError: TextEncoderStream is not defined` — Lightpanda's nightly build does not yet   implement `TextEncoderStream` (part of the Web Streams Encoding API). This causes Lightpanda to crash on the first page load.

The fix belongs in Lightpanda, not in our test suite. Once Lightpanda implements `TextEncoderStream` (and likely `TextDecoderStream`), the tests should run without further changes on our side.