### PR TITLE
Prepare doc for next release

### DIFF
--- a/apps/doc/concepts/packages-management.mdx
+++ b/apps/doc/concepts/packages-management.mdx
@@ -58,10 +58,6 @@ Once you've created packages, you can distribute them using either of these meth
 Download package content directly to your machine using the CLI:
 
 ```bash
-packmind-cli install --list
-```
-
-```bash
 packmind-cli install backend-api frontend-web
 ```
 

--- a/apps/doc/getting-started/gs-cli-setup.mdx
+++ b/apps/doc/getting-started/gs-cli-setup.mdx
@@ -45,7 +45,7 @@ After installation, the `packmind-cli` command will be available globally.
 **npx** (no installation required):
 
 ```bash
-npx @packmind/cli install --list
+npx @packmind/cli login
 ```
 
 This runs the CLI directly without installing it, always using the latest version.

--- a/apps/doc/getting-started/gs-distribute.mdx
+++ b/apps/doc/getting-started/gs-distribute.mdx
@@ -37,13 +37,13 @@ Use the Packmind CLI to install packages locally:
 **List available packages:**
 
 ```bash
-packmind-cli install --list
+packmind-cli packages list
 ```
 
 **View package details:**
 
 ```bash
-packmind-cli install --show <package-slug>
+packmind-cli packages show <package-slug>
 ```
 
 **Install one or more packages:**

--- a/apps/doc/governance/distribution.mdx
+++ b/apps/doc/governance/distribution.mdx
@@ -77,6 +77,8 @@ For example:
 
 ```bash
 packmind-cli install backend-standards frontend-react
+# Note: when using multiple spaces, you will need to prefix the packages with the space slug
+packmind-cli install @backend/standards @frontend/react
 ```
 
 This will:
@@ -106,7 +108,7 @@ The CLI approach is ideal for:
 
 - **CI/CD pipelines** - Automate distribution as part of your deployment process
 - **Local development** - Quickly install packages without leaving your terminal
-- **Monorepos** - Use `packmind-cli install --recursive` to install packages for all `packmind.json` files in the repository
+- **Monorepos** - Use `packmind-cli install` to install packages for all `packmind.json` files in the repository
 - **Self-hosted Git instances** - Distribute to repositories that aren't connected to the app
 
 ## Removing Packages

--- a/apps/doc/tools/cli.mdx
+++ b/apps/doc/tools/cli.mdx
@@ -72,7 +72,7 @@ After installation, the `packmind-cli` command will be available globally.
 **npx** (no installation required):
 
 ```bash
-npx @packmind/cli install --list
+npx @packmind/cli login
 ```
 
 This runs the CLI directly without installing it, always using the latest version.
@@ -224,7 +224,7 @@ source ~/.zshrc
 - name: Install Packmind packages
   env:
     PACKMIND_API_KEY_V3: ${{ secrets.PACKMIND_API_KEY_V3 }}
-  run: packmind-cli install -r
+  run: packmind-cli install
 ```
 
 <Tip>
@@ -445,13 +445,13 @@ Download commands, standards, and skills from packages to your local machine.
 ### List Available Packages
 
 ```bash
-packmind-cli install --list
+packmind-cli packages list
 ```
 
 ### View Package Details
 
 ```bash
-packmind-cli install --show <package-slug>
+packmind-cli packages show <package-slug>
 ```
 
 ### View Workspace Status
@@ -519,11 +519,6 @@ To scope the recursive install to a specific directory, use the `--path` option:
 ```bash
 packmind-cli install --path apps/frontend
 ```
-
-<Warning>
-  The `-r` / `--recursive` flag is deprecated. Install is now recursive by
-  default. Using the flag still works but will print a deprecation warning.
-</Warning>
 
 <Tip>
   **AI Agent Rendering** — The files created by the install command depend on


### PR DESCRIPTION
Update documentation about `install` command for the next release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples to reflect new command structure and namespace
  * Package management commands reorganized under `packmind-cli packages` prefix (list and show)
  * Recursive installation behavior is now default; explicit flags no longer needed
  * Updated authentication and installation examples across setup and distribution guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->