### PR TITLE
🐛 fix(nginx): move PID file to writable directory for clean shutdown

### DIFF
--- a/dockerfile/Dockerfile.frontend
+++ b/dockerfile/Dockerfile.frontend
@@ -14,11 +14,10 @@ RUN apk add --no-cache bash=5.3.3-r1 gettext=0.24.1-r1 && \
              /var/cache/nginx/uwsgi_temp \
              /var/cache/nginx/scgi_temp && \
     # Set permissions
-    touch /run/nginx.pid && \
+    touch /home/packmind/nginx.pid && \
     chown -R packmind:packmind /var/cache/nginx/ \
                                /var/log/nginx/ \
                                /etc/nginx \
-                               /run/nginx.pid \
                                /home/packmind
 
 

--- a/dockerfile/nginx.compose.conf
+++ b/dockerfile/nginx.compose.conf
@@ -1,6 +1,6 @@
 worker_processes auto;
 error_log /var/log/nginx/error.log notice;
-pid /run/nginx.pid;
+pid /home/packmind/nginx.pid;
 
 events {
     worker_connections 1024;

--- a/dockerfile/nginx.k8s.conf
+++ b/dockerfile/nginx.k8s.conf
@@ -1,6 +1,6 @@
 worker_processes auto;
 error_log /var/log/nginx/error.log notice;
-pid /run/nginx.pid;
+pid /home/packmind/nginx.pid;
 
 
 events {

--- a/dockerfile/nginx.k8s.no-ingress.conf
+++ b/dockerfile/nginx.k8s.no-ingress.conf
@@ -1,6 +1,6 @@
 worker_processes auto;
 error_log /var/log/nginx/error.log notice;
-pid /run/nginx.pid;
+pid /home/packmind/nginx.pid;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
## Explanation

Move the nginx PID file from `/run/nginx.pid` to `/home/packmind/nginx.pid` to fix `Permission Denied` errors on graceful shutdown.

On pod shutdown (SIGQUIT), nginx calls `unlink()` on the PID file, which requires write permission on the **parent directory**. `/run/` is root-owned, so the call fails even though the file itself is owned by `packmind`. Moving to `/home/packmind/` (already owned by `packmind`) resolves this.

**Impact:** eliminates ~119 `[alert] unlink() "/run/nginx.pid" failed (13: Permission denied)` log entries per week.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none
- Frontend / Backend / Both: Frontend (Docker/nginx config only)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
1. Build the frontend Docker image
2. Run container and confirm nginx starts with PID file at `/home/packmind/nginx.pid`
3. Stop container (SIGQUIT) and verify no `unlink` permission error in logs

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

Pure config change across 4 files — no code logic modified. The recursive `chown ... /home/packmind` in the Dockerfile already covers the new PID file location, so `/run/nginx.pid` was removed from the explicit `chown` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)