### PR TITLE
Add --skip-installed-at flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,3 @@ apps/mcp-server/key.pem
 # GitLab Duo skills (managed locally)
 .gitlab/
 
-# Packmind lock file
-packmind-lock.json

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,7 @@
 ## Added
 
 - Support new Claude Code skill frontmatter fields: `when_to_use`, `paths`, and `shell` (validated to `bash` or `powershell`)
+- Added `--skip-installed-at` flag on `install` command to avoid merge issues when working with multiple branches.
 
 ## Changed
 

--- a/apps/cli/src/application/useCases/InstallUseCase.ts
+++ b/apps/cli/src/application/useCases/InstallUseCase.ts
@@ -68,9 +68,11 @@ export class InstallUseCase implements IInstallUseCase {
       lockfileVersion: 1,
       packageSlugs: [],
       agents: [],
-      installedAt: new Date().toISOString(),
       artifacts: {},
     };
+    if (!command.skipInstalledAt) {
+      effectiveLockFile.installedAt = new Date().toISOString();
+    }
 
     let packagesSlugs: string[];
     let normalizedPackages: string[] = [];

--- a/apps/cli/src/application/useCases/InstallUseCase.ts
+++ b/apps/cli/src/application/useCases/InstallUseCase.ts
@@ -144,6 +144,23 @@ export class InstallUseCase implements IInstallUseCase {
 
     const uniqueFiles = Array.from(uniqueFilesMap.values());
 
+    if (command.skipInstalledAt) {
+      for (const file of uniqueFiles) {
+        if (file.path === 'packmind-lock.json' && file.content) {
+          try {
+            const lockFileData = JSON.parse(file.content) as Record<
+              string,
+              unknown
+            >;
+            delete lockFileData.installedAt;
+            file.content = JSON.stringify(lockFileData, null, 2) + '\n';
+          } catch {
+            // If parsing fails, keep original content
+          }
+        }
+      }
+    }
+
     // Count artifact types
     for (const file of uniqueFiles) {
       if (

--- a/apps/cli/src/domain/useCases/IInstallUseCase.ts
+++ b/apps/cli/src/domain/useCases/IInstallUseCase.ts
@@ -3,6 +3,7 @@ import { IPublicUseCase } from '@packmind/types';
 export type IInstallCommand = {
   baseDirectory?: string;
   packages?: string[];
+  skipInstalledAt?: boolean;
 };
 
 export type IInstallResult = {

--- a/apps/cli/src/infra/commands/InstallCommand.ts
+++ b/apps/cli/src/infra/commands/InstallCommand.ts
@@ -217,12 +217,14 @@ export async function installHandler({
   list,
   show,
   status,
+  skipInstalledAt,
 }: {
   installPath: string;
   packages: string[];
   list: boolean;
   show: string;
   status: boolean;
+  skipInstalledAt: boolean;
 }): Promise<void> {
   const packmindLogger = new PackmindLogger('PackmindCLI', LogLevel.INFO);
   const packmindCliHexa = new PackmindCliHexa(packmindLogger);
@@ -301,6 +303,7 @@ export async function installHandler({
       const result = await packmindCliHexa.install({
         baseDirectory: dir,
         packages: packages.length > 0 ? packages : undefined,
+        skipInstalledAt,
       });
       results.push(result);
 
@@ -381,6 +384,11 @@ export const installCommand = command({
       long: 'show',
       description: '[Deprecated] Show details of a specific package',
       defaultValue: () => '',
+    }),
+    skipInstalledAt: flag({
+      long: 'skip-installed-at',
+      description:
+        'Omit the installedAt timestamp from the packmind-lock.json file',
     }),
   },
   handler: installHandler,

--- a/apps/cli/src/infra/repositories/LockFileRepository.spec.ts
+++ b/apps/cli/src/infra/repositories/LockFileRepository.spec.ts
@@ -128,10 +128,6 @@ describe('LockFileRepository', () => {
           '{"lockfileVersion":1,"agents":[],"installedAt":"2026-01-01","artifacts":{}}',
         ],
         [
-          'missing installedAt',
-          '{"lockfileVersion":1,"packageSlugs":[],"agents":[],"artifacts":{}}',
-        ],
-        [
           'missing agents',
           '{"lockfileVersion":1,"packageSlugs":[],"installedAt":"2026-01-01","artifacts":{}}',
         ],

--- a/apps/cli/src/infra/repositories/LockFileRepository.ts
+++ b/apps/cli/src/infra/repositories/LockFileRepository.ts
@@ -40,7 +40,6 @@ export class LockFileRepository implements ILockFileRepository {
     const obj = data as Record<string, unknown>;
 
     return (
-      typeof obj.installedAt === 'string' &&
       Array.isArray(obj.packageSlugs) &&
       Array.isArray(obj.agents) &&
       (obj.targetId === undefined || typeof obj.targetId === 'string') &&

--- a/packages/deployments/src/application/useCases/InstallPackagesUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/InstallPackagesUseCase.spec.ts
@@ -299,6 +299,38 @@ describe('InstallPackagesUseCase', () => {
 
       expect(eventEmitterService.emit).toHaveBeenCalledTimes(1);
     });
+
+    describe('when the incoming lock file has installedAt', () => {
+      it('includes installedAt in the produced lock file', async () => {
+        command.packmindLockFile = {
+          ...emptyLockFile,
+          installedAt: new Date().toISOString(),
+        };
+
+        await useCase.execute(command);
+
+        const builtLockFile =
+          lockFileService.buildLockFile.mock.results[0].value;
+        expect('installedAt' in builtLockFile).toBe(true);
+      });
+    });
+
+    describe('when the incoming lock file does not have installedAt', () => {
+      it('omits installedAt from the produced lock file', async () => {
+        command.packmindLockFile = {
+          lockfileVersion: emptyLockFile.lockfileVersion,
+          packageSlugs: emptyLockFile.packageSlugs,
+          agents: emptyLockFile.agents,
+          artifacts: emptyLockFile.artifacts,
+        };
+
+        await useCase.execute(command);
+
+        const lockFileModificationCall =
+          lockFileService.createLockFileModification.mock.calls[0][0];
+        expect('installedAt' in lockFileModificationCall).toBe(false);
+      });
+    });
   });
 
   describe('when user has no access to some packages', () => {

--- a/packages/deployments/src/application/useCases/InstallPackagesUseCase.ts
+++ b/packages/deployments/src/application/useCases/InstallPackagesUseCase.ts
@@ -286,6 +286,10 @@ export class InstallPackagesUseCase extends AbstractMemberUseCase<
       artifactPackageIds,
     });
 
+    if (!('installedAt' in command.packmindLockFile)) {
+      delete lockFile.installedAt;
+    }
+
     // Preserve inaccessible artifacts from the previous lock file
     for (const [key, entry] of Object.entries(
       command.packmindLockFile.artifacts,

--- a/packages/types/src/deployments/PackmindLockFile.ts
+++ b/packages/types/src/deployments/PackmindLockFile.ts
@@ -22,7 +22,7 @@ export type PackmindLockFile = {
   lockfileVersion: number;
   packageSlugs: string[];
   agents: CodingAgent[];
-  installedAt: string;
+  installedAt?: string;
   targetId?: string;
   artifacts: Record<string, PackmindLockFileEntry>;
 };

--- a/packmind-lock.json
+++ b/packmind-lock.json
@@ -1,0 +1,1297 @@
+{
+  "lockfileVersion": 1,
+  "packageSlugs": [
+    "@backend/generic",
+    "@cli/generic",
+    "@frontend/generic",
+    "@frontend/playground",
+    "@global/generic",
+    "@testing/cli-e2e"
+  ],
+  "agents": [
+    "agents_md",
+    "claude",
+    "copilot",
+    "cursor",
+    "gitlab_duo",
+    "packmind"
+  ],
+  "artifacts": {
+    "command:creating-end-user-documentation-for-packmind": {
+      "name": "Creating End-User Documentation for Packmind",
+      "type": "command",
+      "id": "51fa2ad4-cb4d-4f27-a7d3-8aa55c91ff18",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/creating-end-user-documentation-for-packmind.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/creating-end-user-documentation-for-packmind.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/creating-end-user-documentation-for-packmind.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/creating-end-user-documentation-for-packmind.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:update-handoff": {
+      "name": "Update Handoff",
+      "type": "command",
+      "id": "fc2294fd-2bcd-4b09-a610-8dbad8459276",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/update-handoff.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/update-handoff.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/update-handoff.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/update-handoff.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:create-handoff": {
+      "name": "Create handoff",
+      "type": "command",
+      "id": "f7907029-f0c1-4c32-b488-bfac6fbaab1c",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/create-handoff.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/create-handoff.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/create-handoff.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/create-handoff.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:resume-handoff": {
+      "name": "Resume handoff",
+      "type": "command",
+      "id": "05c8b199-25d7-4cf6-9fe5-4835e1e3ae5e",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/resume-handoff.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/resume-handoff.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/resume-handoff.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/resume-handoff.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:create-new-package-in-monorepo": {
+      "name": "Create New Package",
+      "type": "command",
+      "id": "021984f7-09bf-48e5-81ac-70c7e68b13bf",
+      "version": 4,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/create-new-package-in-monorepo.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/create-new-package-in-monorepo.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/create-new-package-in-monorepo.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/create-new-package-in-monorepo.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:create-or-update-model-and-typeorm-schemas": {
+      "name": "Create or update model and TypeORM schemas",
+      "type": "command",
+      "id": "d63a7443-51c4-4c08-8afc-1027f37215c7",
+      "version": 2,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/create-or-update-model-and-typeorm-schemas.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/create-or-update-model-and-typeorm-schemas.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/create-or-update-model-and-typeorm-schemas.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/create-or-update-model-and-typeorm-schemas.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:how-to-write-typeorm-migrations-in-packmind": {
+      "name": "How to Write TypeORM Migrations in Packmind",
+      "type": "command",
+      "id": "52933de0-1479-44ba-82f0-ec203c97bdb9",
+      "version": 2,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/how-to-write-typeorm-migrations-in-packmind.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/how-to-write-typeorm-migrations-in-packmind.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/how-to-write-typeorm-migrations-in-packmind.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/how-to-write-typeorm-migrations-in-packmind.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:repository-implementation-and-testing-pattern": {
+      "name": "Repository Implementation and Testing Pattern",
+      "type": "command",
+      "id": "44474dab-be7d-4d3d-85ee-6f91f0a93410",
+      "version": 2,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/repository-implementation-and-testing-pattern.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/repository-implementation-and-testing-pattern.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/repository-implementation-and-testing-pattern.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/repository-implementation-and-testing-pattern.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:gateway-pattern-implementation-in-packmind-frontend": {
+      "name": "Gateway Pattern Implementation in Packmind Frontend",
+      "type": "command",
+      "id": "6a7ef532-bf72-4350-8d9f-1f85e2cfbb1d",
+      "version": 1,
+      "spaceId": "347c9957-dd09-4c5e-a3d0-21e9785524f1",
+      "packageIds": [
+        "1a736454-c819-4060-8371-d34701181d0e"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/gateway-pattern-implementation-in-packmind-frontend.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/gateway-pattern-implementation-in-packmind-frontend.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/gateway-pattern-implementation-in-packmind-frontend.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/gateway-pattern-implementation-in-packmind-frontend.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "command:wrapping-chakra-ui-with-slot-components": {
+      "name": "Wrapping Chakra UI with Slot Components",
+      "type": "command",
+      "id": "b1d36697-c69c-479e-b995-8a74db6eaf2e",
+      "version": 1,
+      "spaceId": "347c9957-dd09-4c5e-a3d0-21e9785524f1",
+      "packageIds": [
+        "1a736454-c819-4060-8371-d34701181d0e"
+      ],
+      "files": [
+        {
+          "path": ".packmind/commands/wrapping-chakra-ui-with-slot-components.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/prompts/wrapping-chakra-ui-with-slot-components.prompt.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/commands/wrapping-chakra-ui-with-slot-components.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/commands/wrapping-chakra-ui-with-slot-components.md",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "standard:changelog": {
+      "name": "Changelog",
+      "type": "standard",
+      "id": "68528136-4310-4910-848c-89c9fce93739",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/standards/changelog.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/instructions/packmind-changelog.instructions.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/rules/packmind/standard-changelog.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/rules/packmind/standard-changelog.mdc",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "standard:typescript-good-practices": {
+      "name": "Typescript good practices",
+      "type": "standard",
+      "id": "e26dc800-20ca-4378-beb7-aa1c773864e3",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".packmind/standards/typescript-good-practices.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/instructions/packmind-typescript-good-practices.instructions.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/rules/packmind/standard-typescript-good-practices.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/rules/packmind/standard-typescript-good-practices.mdc",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "standard:compliance-logging-personal-information": {
+      "name": "Compliance - Logging Personal Information",
+      "type": "standard",
+      "id": "d984a9be-3e6d-4c22-a9e0-ad693f2a57a9",
+      "version": 3,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".packmind/standards/compliance-logging-personal-information.md",
+          "agent": "packmind"
+        },
+        {
+          "path": ".github/instructions/packmind-compliance-logging-personal-information.instructions.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/rules/packmind/standard-compliance-logging-personal-information.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/rules/packmind/standard-compliance-logging-personal-information.mdc",
+          "agent": "cursor"
+        }
+      ]
+    },
+    "skill:datadog-analysis": {
+      "name": "datadog-analysis",
+      "type": "skill",
+      "id": "0bddffe8-a496-4cf2-85f5-5525453eb54b",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/datadog-analysis/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/datadog-analysis/references/datadog_mcp.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/datadog-analysis/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/datadog-analysis/references/datadog_mcp.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/datadog-analysis/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/datadog-analysis/references/datadog_mcp.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/datadog-analysis/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/datadog-analysis/references/datadog_mcp.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:create-em-spec": {
+      "name": "create-em-spec",
+      "type": "skill",
+      "id": "17153f49-2878-4351-b43b-c71704c17b89",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/create-em-spec/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/create-em-spec/inputs/github-issue.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/create-em-spec/inputs/miro-screenshots.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/create-em-spec/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/create-em-spec/inputs/github-issue.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/create-em-spec/inputs/miro-screenshots.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/create-em-spec/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/create-em-spec/inputs/github-issue.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/create-em-spec/inputs/miro-screenshots.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/create-em-spec/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/create-em-spec/inputs/github-issue.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/create-em-spec/inputs/miro-screenshots.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:qa-review": {
+      "name": "qa-review",
+      "type": "skill",
+      "id": "468a3a08-d963-4c26-a600-c0bb755cdb14",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/qa-review/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/qa-review/agents/code-map-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/qa-review/agents/code-review-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/qa-review/agents/functional-coverage-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/qa-review/em_template.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/qa-review/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/qa-review/agents/code-map-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/qa-review/agents/code-review-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/qa-review/agents/functional-coverage-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/qa-review/em_template.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/qa-review/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/qa-review/agents/code-map-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/qa-review/agents/code-review-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/qa-review/agents/functional-coverage-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/qa-review/em_template.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/qa-review/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/qa-review/agents/code-map-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/qa-review/agents/code-review-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/qa-review/agents/functional-coverage-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/qa-review/em_template.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:doc-audit": {
+      "name": "doc-audit",
+      "type": "skill",
+      "id": "7683e9a7-4d61-40be-a993-9de987dba976",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/doc-audit/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/doc-audit/references/section-audit-instructions.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/doc-audit/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/doc-audit/references/section-audit-instructions.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/doc-audit/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/doc-audit/references/section-audit-instructions.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/doc-audit/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/doc-audit/references/section-audit-instructions.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:playbook-audit": {
+      "name": "playbook-audit",
+      "type": "skill",
+      "id": "a5199979-194b-436a-999c-88703ff3dd31",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/playbook-audit/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/playbook-audit/references/commands-vs-skills-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/playbook-audit/references/report-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/playbook-audit/references/standards-vs-commands-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/playbook-audit/references/standards-vs-skills-agent.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/playbook-audit/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/playbook-audit/references/commands-vs-skills-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/playbook-audit/references/report-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/playbook-audit/references/standards-vs-commands-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/playbook-audit/references/standards-vs-skills-agent.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/playbook-audit/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/playbook-audit/references/commands-vs-skills-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/playbook-audit/references/report-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/playbook-audit/references/standards-vs-commands-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/playbook-audit/references/standards-vs-skills-agent.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/playbook-audit/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/playbook-audit/references/commands-vs-skills-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/playbook-audit/references/report-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/playbook-audit/references/standards-vs-commands-agent.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/playbook-audit/references/standards-vs-skills-agent.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:ux-microcopy": {
+      "name": "ux-microcopy",
+      "type": "skill",
+      "id": "e8211a60-03b4-41ed-b75e-94c999a7b226",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/ux-microcopy/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/ux-microcopy/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/ux-microcopy/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/ux-microcopy/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:git-commit-guidelines": {
+      "name": "git-commit-guidelines",
+      "type": "skill",
+      "id": "f1133c02-d615-4520-9c51-3adf3e6932eb",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/git-commit-guidelines/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/git-commit-guidelines/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/git-commit-guidelines/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/git-commit-guidelines/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:release-app": {
+      "name": "release-app",
+      "type": "skill",
+      "id": "0ae1ae43-bbab-4af9-a693-854d61d7cf46",
+      "version": 1,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/release-app/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/release-app/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/release-app/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/release-app/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:feature-flags-audit": {
+      "name": "feature-flags-audit",
+      "type": "skill",
+      "id": "dd6d38fe-3685-4256-855b-9467c5cf1c67",
+      "version": 2,
+      "spaceId": "02d1f9c9-a449-4794-b911-186cccd48884",
+      "packageIds": [
+        "c0b4f2b0-abda-4156-9d3b-5c3fac1efca8"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/feature-flags-audit/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/feature-flags-audit/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/feature-flags-audit/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/feature-flags-audit/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:adding-ai-agent-rendering-system": {
+      "name": "adding-ai-agent-rendering-system",
+      "type": "skill",
+      "id": "3fd90109-62dc-47de-803e-b311442808b2",
+      "version": 1,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/adding-ai-agent-rendering-system/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/adding-ai-agent-rendering-system/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/adding-ai-agent-rendering-system/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/adding-ai-agent-rendering-system/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:hexagonal-architecture": {
+      "name": "hexagonal-architecture",
+      "type": "skill",
+      "id": "3d5936bf-be09-4bd3-800d-60191185d2f5",
+      "version": 3,
+      "spaceId": "5eb1119c-7a81-4cf1-b7e5-3d9b94d6b98d",
+      "packageIds": [
+        "405f9c33-c86f-40fb-a7f2-51890f6b1aea"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/hexagonal-architecture/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/adapter.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/hexa-facade.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/contract.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/event.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/listener.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/port.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/layers/application-layer.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/repository.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/schema.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/service.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/components/usecase.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/layers/domain-layer.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".github/skills/hexagonal-architecture/layers/infrastructure-layer.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/adapter.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/hexa-facade.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/contract.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/event.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/listener.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/port.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/layers/application-layer.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/repository.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/schema.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/service.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/components/usecase.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/layers/domain-layer.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".claude/skills/hexagonal-architecture/layers/infrastructure-layer.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/adapter.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/hexa-facade.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/contract.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/event.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/listener.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/port.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/layers/application-layer.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/repository.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/schema.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/service.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/components/usecase.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/layers/domain-layer.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".cursor/skills/hexagonal-architecture/layers/infrastructure-layer.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/adapter.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/hexa-facade.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/contract.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/event.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/listener.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/port.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/layers/application-layer.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/repository.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/schema.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/service.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/components/usecase.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/layers/domain-layer.md",
+          "agent": "gitlab_duo"
+        },
+        {
+          "path": ".gitlab/duo/skills/hexagonal-architecture/layers/infrastructure-layer.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:working-with-playground-app": {
+      "name": "working-with-playground-app",
+      "type": "skill",
+      "id": "7e03d40b-9ae6-4a85-92b5-8183b9e8c558",
+      "version": 2,
+      "spaceId": "347c9957-dd09-4c5e-a3d0-21e9785524f1",
+      "packageIds": [
+        "ba8e2fbe-f00a-4490-9618-57b10d22470c"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/working-with-playground-app/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/working-with-playground-app/references/frontend-domain-structure.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/working-with-playground-app/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/working-with-playground-app/references/frontend-domain-structure.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/working-with-playground-app/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/working-with-playground-app/references/frontend-domain-structure.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/working-with-playground-app/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/working-with-playground-app/references/frontend-domain-structure.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:working-with-pm-design-kit": {
+      "name": "working-with-pm-design-kit",
+      "type": "skill",
+      "id": "549a5890-64d0-428f-9e00-65ad4157837a",
+      "version": 2,
+      "spaceId": "347c9957-dd09-4c5e-a3d0-21e9785524f1",
+      "packageIds": [
+        "ba8e2fbe-f00a-4490-9618-57b10d22470c"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/working-with-pm-design-kit/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".github/skills/working-with-pm-design-kit/references/component-catalog.md",
+          "agent": "copilot"
+        },
+        {
+          "path": ".claude/skills/working-with-pm-design-kit/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/working-with-pm-design-kit/references/component-catalog.md",
+          "agent": "claude"
+        },
+        {
+          "path": ".cursor/skills/working-with-pm-design-kit/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/working-with-pm-design-kit/references/component-catalog.md",
+          "agent": "cursor"
+        },
+        {
+          "path": ".gitlab/duo/skills/working-with-pm-design-kit/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/working-with-pm-design-kit/references/component-catalog.md",
+          "agent": "gitlab_duo"
+        }
+      ]
+    },
+    "skill:cli-e2e-test-authoring": {
+      "name": "cli-e2e-test-authoring",
+      "type": "skill",
+      "id": "32da0e0f-5d0d-474e-9ae9-315378ef0463",
+      "version": 3,
+      "spaceId": "87658623-3c00-4018-9240-a713cf50d70f",
+      "packageIds": [
+        "55cfbdf0-0ce1-403b-8bd5-96344836f315"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/cli-e2e-test-authoring/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/cli-e2e-test-authoring/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/cli-e2e-test-authoring/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/cli-e2e-test-authoring/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    },
+    "skill:release-cli": {
+      "name": "release-cli",
+      "type": "skill",
+      "id": "20e7ef2b-d978-4065-b0be-bc3293e8a81b",
+      "version": 1,
+      "spaceId": "44d5cfee-46a6-495f-802e-bfd12dcdc953",
+      "packageIds": [
+        "7404d3b4-4ef5-4d7f-b32f-b3b40787a381"
+      ],
+      "files": [
+        {
+          "path": ".github/skills/release-cli/SKILL.md",
+          "agent": "copilot",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".claude/skills/release-cli/SKILL.md",
+          "agent": "claude",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".cursor/skills/release-cli/SKILL.md",
+          "agent": "cursor",
+          "isSkillDefinition": true
+        },
+        {
+          "path": ".gitlab/duo/skills/release-cli/SKILL.md",
+          "agent": "gitlab_duo",
+          "isSkillDefinition": true
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Explanation

The `installedAt`property in the `packmind-lock.json` may cause issue when working with multiple branches.

This PR adds a `--skip-installed-at`flag on the `packmind-cli install` command. 
Also, in the backend, if the packmind-lock file that was sent does not contain a `installedAt` property, the file which is sent back is also free of the property.

This should allows a smooth transition for removing the `installedAt` property completelly (we can't do this as current releases of the `cli` fail trying to run install with a lock file that does not contain this property. 

<!-- Reference any existing issue, drop the section otherwise -->
Relates to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

<!-- Help reviewers understand scope -->

- Domain packages affected:
- Frontend / Backend / Both:
- Breaking changes (if any):

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
<!-- Describe specific test scenarios -->


## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

<!-- Anything reviewers should pay special attention to? -->
<!-- Areas where you'd like specific feedback? -->

