### PR TITLE
Skip SonarQube job for proprietary editions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -76,6 +76,7 @@ jobs:
         run: npm run prettier:check
 
   sonarqube:
+    if: vars.PACKMIND_EDITION != 'proprietary'
     runs-on: ${{ vars.ACTION_RUNNER_TAG || 'self-hosted' }}
     timeout-minutes: ${{ github.actor == 'dependabot[bot]' && 15 || 30 }}
     strategy:


### PR DESCRIPTION
## Explanation

Added a conditional check to skip the SonarQube job when running on proprietary editions of the codebase. This prevents unnecessary SonarQube analysis from running in proprietary builds where it may not be applicable or desired.

## Type of Change

- [x] Improvement/Enhancement

## Affected Components

- Domain packages affected: CI/CD pipeline
- Frontend / Backend / Both: N/A (workflow configuration)
- Breaking changes (if any): None

## Testing

- [x] No testing needed

The change is a simple conditional guard in the GitHub Actions workflow. The existing CI pipeline will validate that the workflow syntax remains correct.

## TODO List

- [x] CHANGELOG Updated (N/A - workflow configuration change)
- [x] Documentation Updated (N/A - self-explanatory configuration)

## Reviewer Notes

This change uses the `vars.PACKMIND_EDITION` variable to conditionally execute the SonarQube job. Ensure that this variable is properly configured in the repository settings for both standard and proprietary editions.

https://claude.ai/code/session_01ErfYJ9ToNf6NrKZjxoPcEr