### PR TITLE
♻️ refactor(e2e): unify test user email prefixes

### DIFF
--- a/apps/cli-e2e-tests/src/helpers/describeWithExtraUser.ts
+++ b/apps/cli-e2e-tests/src/helpers/describeWithExtraUser.ts
@@ -22,7 +22,7 @@ export type ExtraUserOptions = {
 
 function getDefaultOptions(): ExtraUserOptions {
   return {
-    email: `user-${uuidv4()}@example.com`,
+    email: `test-${uuidv4()}@example.com`,
     role: 'member',
   };
 }

--- a/apps/e2e-tests/src/features/auth/InvitationWorkflow.spec.ts
+++ b/apps/e2e-tests/src/features/auth/InvitationWorkflow.spec.ts
@@ -7,7 +7,7 @@ testWithUserSignedUp.describe('Invitation Workflow', () => {
   testWithUserSignedUp(
     'admin invites a new user who successfully activates their account',
     async ({ dashboardPage, page }) => {
-      const invitedEmail = `invited-${uuidv4()}@example.com`;
+      const invitedEmail = `test-invited-${uuidv4()}@example.com`;
       const newUserPassword = uuidv4();
 
       // Navigate to settings / users

--- a/apps/e2e-tests/src/fixtures/packmindTest.ts
+++ b/apps/e2e-tests/src/fixtures/packmindTest.ts
@@ -13,7 +13,7 @@ export const testWithUserData = base.extend<{
   underFeatureFlag: [false, { option: true }],
   userData: async ({ underFeatureFlag }, use) => {
     await use({
-      email: `someone-${uuidv4()}@${underFeatureFlag ? 'packmind' : 'example'}.com`,
+      email: `test-${uuidv4()}@${underFeatureFlag ? 'packmind' : 'example'}.com`,
       password: `${uuidv4()}!!`,
       method: 'password',
     });


### PR DESCRIPTION
## Explanation

Standardize test user email generation across `apps/e2e-tests/` (Playwright) and `apps/cli-e2e-tests/` (Jest). Previously we had three competing prefixes — `someone-`, `invited-`, and `user-` — making test data hard to recognize in shared dev/staging environments.

After this PR:
- **All test users** are prefixed with `test-`.
- **Users created via the deliberate invitation flow only** (the `InvitationWorkflow` spec) keep a more specific `test-invited-` prefix.

Each test still appends a UUID, so uniqueness is preserved.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [x] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none (test apps only)
- Frontend / Backend / Both: neither — test fixtures only
- Breaking changes (if any): none

Files touched (3 lines):
- `apps/e2e-tests/src/fixtures/packmindTest.ts` — `someone-` → `test-` (central fixture, covers every signed-up user in the Playwright suite)
- `apps/e2e-tests/src/features/auth/InvitationWorkflow.spec.ts` — `invited-` → `test-invited-`
- `apps/cli-e2e-tests/src/helpers/describeWithExtraUser.ts` — `user-` → `test-`

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**
- `rg` sweep confirms no remaining `someone-`, `invited-${uuid}`, or `user-${uuid}` references in either e2e folder.
- `nx lint e2e-tests` and `nx lint cli-e2e-tests` both pass.
- Verified the prefixes were used only at email-generation sites — no assertions, regex filters, page-object selectors, or cleanup scripts depend on them, so existing tests continue to pass unchanged.
- The git author email `test@packmind.com` in `setupGitRepo.ts` is a synthetic git identity (not a Packmind user) and is intentionally left untouched.

## TODO List

- [ ] CHANGELOG Updated — N/A (internal test refactor, no user-facing change)
- [ ] Documentation Updated — N/A

## Reviewer Notes

Please double-check the rule mapping in case there are environments or scripts (outside these two apps) that filter test users by the legacy `someone-` / `invited-` / `user-` prefixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)