### PR TITLE
feat(auto-update): add GitLab CI workflow and documentation

### DIFF
--- a/.cursor/skills/packmind-update-playbook-v2/packmind-versions/0.24.0/apply-changes.md
+++ b/.cursor/skills/packmind-update-playbook-v2/packmind-versions/0.24.0/apply-changes.md
@@ -42,11 +42,6 @@ Determine which agent context you are running in. The agent directories are:
 
 **Important**: Packmind packages can be installed in subdirectories, not just the repo root. Search for `**/packmind-lock.json` across the entire project tree to find all installed locations. Each lock file lists all files per artifact with their agent — use the path matching your agent.
 
-Before writing or editing any artifact, read the corresponding creation procedure for content format and structure guidance:
-- Standard: [create-standard-procedure.md](../../references/create-standard-procedure.md)
-- Command: [create-command-procedure.md](../../references/create-command-procedure.md)
-- Skill: [create-skill-procedure.md](../../references/create-skill-procedure.md)
-
 **For updated artifacts**, find and edit the file at your agent's path. The lock file tells you the exact relative path. Remember that artifacts may live in nested project directories (e.g. `packages/api/.claude/rules/packmind/`, `apps/backend/.claude/commands/`).
 
 **For new artifacts**, write files at the agent-specific location within the directory that contains the relevant `packmind-lock.json`:

--- a/.cursor/skills/packmind-update-playbook/packmind-versions/0.23.0/apply-changes.md
+++ b/.cursor/skills/packmind-update-playbook/packmind-versions/0.23.0/apply-changes.md
@@ -92,6 +92,8 @@ Ask the user: **"These changes will be submitted as: '<intent description>'. Con
 
 Run `packmind-cli playbook submit -m "<intent description>"` to submit all staged changes as proposals for human review.
 
+> **The `-m` flag is mandatory.** Without it, the CLI opens an interactive text editor (vim/nano) waiting for the message — this blocks an AI agent indefinitely. Always pass the message inline with `-m`.
+
 The message should be a concise summary of the intent (max 1024 characters). If this command fails, show the full error output, stop, and ask the user how to proceed — do not retry silently.
 
 ##### Step 5: Report and continue

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { RecipesHexa, recipesSchemas } from '@packmind/recipes';
 import { SpacesHexa, spacesSchemas } from '@packmind/spaces';
 import { StandardsHexa, standardsSchemas } from '@packmind/standards';
 import { SkillsHexa, skillsSchemas } from '@packmind/skills';
+import { TelemetryHexa } from '@packmind/telemetry';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { HooksModule } from './hooks/hooks.module';
@@ -62,6 +63,7 @@ import { HexaRegistryModule } from './shared/HexaRegistryModule';
 import { PlaybookModule } from './organizations/playbook/playbook.module';
 import { PublicSkillsModule } from './skills/skills.module';
 import { SSEModule } from './sse/sse.module';
+import { TelemetryModule } from './telemetry/telemetry.module';
 import { TrialModule } from './trial/trial.module';
 
 const logger = new PackmindLogger('AppModule', LogLevel.INFO);
@@ -119,6 +121,7 @@ const logger = new PackmindLogger('AppModule', LogLevel.INFO);
         PlaybookChangeApplierHexa,
         CodingAgentHexa,
         DeploymentsHexa,
+        TelemetryHexa,
       ],
       services: [
         JobsService, // Infrastructure service for background jobs
@@ -134,6 +137,7 @@ const logger = new PackmindLogger('AppModule', LogLevel.INFO);
     ImportLegacyModule,
     TrialModule,
     PublicSkillsModule,
+    TelemetryModule,
     // RouterModule configuration for organization-scoped routes
     // This must come after OrganizationsModule and its child modules are imported
     RouterModule.register([
@@ -144,6 +148,10 @@ const logger = new PackmindLogger('AppModule', LogLevel.INFO);
       {
         path: 'skills',
         module: PublicSkillsModule,
+      },
+      {
+        path: 'telemetry',
+        module: TelemetryModule,
       },
       {
         path: 'organizations/:orgId',

--- a/apps/api/src/app/shared/HexaInjection.ts
+++ b/apps/api/src/app/shared/HexaInjection.ts
@@ -14,6 +14,7 @@ import {
   LLM_ADAPTER_TOKEN,
   PLAYBOOK_CHANGE_MANAGEMENT_ADAPTER_TOKEN,
   PLAYBOOK_CHANGE_APPLIER_ADAPTER_TOKEN,
+  TELEMETRY_ADAPTER_TOKEN,
 } from './HexaRegistryModule';
 
 /**
@@ -82,3 +83,4 @@ export const InjectPlaybookChangeManagementAdapter = () =>
   Inject(PLAYBOOK_CHANGE_MANAGEMENT_ADAPTER_TOKEN);
 export const InjectPlaybookChangeApplierAdapter = () =>
   Inject(PLAYBOOK_CHANGE_APPLIER_ADAPTER_TOKEN);
+export const InjectTelemetryAdapter = () => Inject(TELEMETRY_ADAPTER_TOKEN);

--- a/apps/api/src/app/shared/HexaRegistryModule.ts
+++ b/apps/api/src/app/shared/HexaRegistryModule.ts
@@ -22,6 +22,7 @@ import { SkillsHexa } from '@packmind/skills';
 import { SpacesManagementHexa } from '@packmind/spaces-management';
 import { SpacesHexa } from '@packmind/spaces';
 import { StandardsHexa } from '@packmind/standards';
+import { TelemetryHexa } from '@packmind/telemetry';
 import {
   IAccountsPort,
   ICodingAgentPort,
@@ -36,6 +37,7 @@ import {
   ISpacesManagementPort,
   ISpacesPort,
   IStandardsPort,
+  ITelemetryPort,
 } from '@packmind/types';
 import { DataSource } from 'typeorm';
 import { ApiKeyServiceProvider } from './ApiKeyServiceProvider';
@@ -87,6 +89,7 @@ export const PLAYBOOK_CHANGE_MANAGEMENT_ADAPTER_TOKEN =
   'PLAYBOOK_CHANGE_MANAGEMENT_ADAPTER';
 export const PLAYBOOK_CHANGE_APPLIER_ADAPTER_TOKEN =
   'PLAYBOOK_CHANGE_APPLIER_ADAPTER';
+export const TELEMETRY_ADAPTER_TOKEN = 'TELEMETRY_ADAPTER';
 
 /**
  * NestJS Module for integrating HexaRegistry with dependency injection.
@@ -138,6 +141,7 @@ export class HexaRegistryModule {
         LLM_ADAPTER_TOKEN,
         PLAYBOOK_CHANGE_MANAGEMENT_ADAPTER_TOKEN,
         PLAYBOOK_CHANGE_APPLIER_ADAPTER_TOKEN,
+        TELEMETRY_ADAPTER_TOKEN,
       ],
     };
   }
@@ -405,6 +409,21 @@ export class HexaRegistryModule {
           return playbookChangeApplierHexa.getAdapter();
         } catch {
           // PlaybookChangeApplierHexa not available
+        }
+        return null;
+      },
+      inject: [HEXA_REGISTRY_TOKEN],
+    });
+
+    // Telemetry adapter
+    providers.push({
+      provide: TELEMETRY_ADAPTER_TOKEN,
+      useFactory: (registry: HexaRegistry): ITelemetryPort | null => {
+        try {
+          const telemetryHexa = registry.get(TelemetryHexa);
+          return telemetryHexa.getAdapter();
+        } catch {
+          // TelemetryHexa not available
         }
         return null;
       },

--- a/apps/api/src/app/shared/PackmindApp.spec.ts
+++ b/apps/api/src/app/shared/PackmindApp.spec.ts
@@ -16,6 +16,7 @@ import { SkillsHexa } from '@packmind/skills';
 import { SpacesManagementHexa } from '@packmind/spaces-management';
 import { SpacesHexa } from '@packmind/spaces';
 import { StandardsHexa } from '@packmind/standards';
+import { TelemetryHexa } from '@packmind/telemetry';
 import { DataSource } from 'typeorm';
 import { ApiKeyServiceProvider } from './ApiKeyServiceProvider';
 import { getPackmindAppDefinition, initializePackmindApp } from './PackmindApp';
@@ -66,6 +67,7 @@ describe('PackmindApp API', () => {
         PlaybookChangeApplierHexa,
         CodingAgentHexa,
         DeploymentsHexa,
+        TelemetryHexa,
         ...apiHexaPlugins,
       ]);
     });

--- a/apps/api/src/app/shared/PackmindApp.ts
+++ b/apps/api/src/app/shared/PackmindApp.ts
@@ -26,6 +26,7 @@ import { SkillsHexa } from '@packmind/skills';
 import { SpacesManagementHexa } from '@packmind/spaces-management';
 import { SpacesHexa } from '@packmind/spaces';
 import { StandardsHexa } from '@packmind/standards';
+import { TelemetryHexa } from '@packmind/telemetry';
 import { DataSource } from 'typeorm';
 import { apiHexaPlugins } from '@packmind/plugins';
 
@@ -84,6 +85,7 @@ export function getPackmindAppDefinition(): PackmindAppDefinition {
       PlaybookChangeApplierHexa,
       CodingAgentHexa,
       DeploymentsHexa,
+      TelemetryHexa, // No cross-domain deps beyond AccountsHexa
       ...apiHexaPlugins,
     ],
     services: [JobsService, PackmindEventEmitterService],

--- a/apps/api/src/app/telemetry/telemetry.controller.ts
+++ b/apps/api/src/app/telemetry/telemetry.controller.ts
@@ -1,0 +1,111 @@
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  DefaultValuePipe,
+  Get,
+  HttpCode,
+  HttpStatus,
+  ParseIntPipe,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { LogLevel, PackmindLogger } from '@packmind/logger';
+import { AuthenticatedRequest } from '@packmind/node-utils';
+import { TelemetryService } from './telemetry.service';
+
+const origin = 'TelemetryController';
+
+const PII_MASK_LENGTH = 6;
+
+function maskUserId(userId: string): string {
+  return `${userId.slice(0, PII_MASK_LENGTH)}*`;
+}
+
+/**
+ * OTLP/HTTP-compatible telemetry ingestion.
+ *
+ * Mounted at root path `telemetry` (sibling of `TrialModule`,
+ * `PublicSkillsModule`) — Claude Code's OTel exporter cannot put `:orgId`
+ * in the URL, so the org is derived from the API key instead. Routes go
+ * through the global `AuthGuard`; an `Authorization: Bearer <api-key>`
+ * header is required.
+ */
+@Controller()
+export class TelemetryController {
+  constructor(
+    private readonly telemetryService: TelemetryService,
+    private readonly logger: PackmindLogger = new PackmindLogger(
+      origin,
+      LogLevel.INFO,
+    ),
+  ) {}
+
+  /**
+   * OTLP/HTTP logs endpoint. Configure Claude Code with:
+   *   OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://<host>/api/v0/telemetry/v1/logs
+   *   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <api-key>"
+   *
+   * Returns the OTLP-spec `{ partialSuccess: {} }` envelope on success.
+   */
+  @Post('v1/logs')
+  @HttpCode(HttpStatus.OK)
+  async ingestLogs(
+    @Body() body: unknown,
+    @Req() request: AuthenticatedRequest,
+  ): Promise<{ partialSuccess: Record<string, never> }> {
+    const userId = request.user.userId;
+    const organizationId = request.organization.id;
+
+    try {
+      const result = await this.telemetryService.ingest({
+        userId,
+        organizationId,
+        rawPayload: body,
+      });
+
+      this.logger.info('Ingested telemetry batch', {
+        organizationId,
+        userId: maskUserId(userId),
+        eventId: result.eventId,
+        acceptedRecords: result.acceptedRecords,
+      });
+
+      return { partialSuccess: {} };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn('Rejected telemetry batch', {
+        organizationId,
+        userId: maskUserId(userId),
+        error: message,
+      });
+      throw new BadRequestException(message);
+    }
+  }
+
+  /**
+   * Read recent telemetry batches stored for the calling org. Useful for
+   * verifying ingestion or building a future UI.
+   */
+  @Get('events')
+  async listRecent(
+    @Req() request: AuthenticatedRequest,
+    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+  ) {
+    const userId = request.user.userId;
+    const organizationId = request.organization.id;
+
+    this.logger.info('Listing recent telemetry events', {
+      organizationId,
+      userId: maskUserId(userId),
+      limit,
+    });
+
+    return this.telemetryService.listRecent({
+      userId,
+      organizationId,
+      limit,
+    });
+  }
+}

--- a/apps/api/src/app/telemetry/telemetry.module.ts
+++ b/apps/api/src/app/telemetry/telemetry.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { LogLevel, PackmindLogger } from '@packmind/logger';
+import { TelemetryController } from './telemetry.controller';
+import { TelemetryService } from './telemetry.service';
+
+@Module({
+  controllers: [TelemetryController],
+  providers: [
+    TelemetryService,
+    {
+      provide: PackmindLogger,
+      useFactory: () => new PackmindLogger('TelemetryModule', LogLevel.INFO),
+    },
+  ],
+  exports: [TelemetryService],
+})
+export class TelemetryModule {}

--- a/apps/api/src/app/telemetry/telemetry.service.ts
+++ b/apps/api/src/app/telemetry/telemetry.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import {
+  IngestTelemetryEventsCommand,
+  IngestTelemetryEventsResponse,
+  ITelemetryPort,
+  ListRecentTelemetryEventsCommand,
+  ListRecentTelemetryEventsResponse,
+} from '@packmind/types';
+import { InjectTelemetryAdapter } from '../shared/HexaInjection';
+
+@Injectable()
+export class TelemetryService {
+  constructor(
+    @InjectTelemetryAdapter()
+    private readonly telemetryAdapter: ITelemetryPort,
+  ) {}
+
+  ingest(
+    command: IngestTelemetryEventsCommand,
+  ): Promise<IngestTelemetryEventsResponse> {
+    return this.telemetryAdapter.ingestTelemetryEvents(command);
+  }
+
+  listRecent(
+    command: ListRecentTelemetryEventsCommand,
+  ): Promise<ListRecentTelemetryEventsResponse> {
+    return this.telemetryAdapter.listRecentTelemetryEvents(command);
+  }
+}

--- a/apps/api/webpack.paths.base.js
+++ b/apps/api/webpack.paths.base.js
@@ -23,6 +23,7 @@ module.exports = function getBaseWebpackPaths(__dirname) {
     '@packmind/logger': join(__dirname, '../../packages/logger/src'),
     '@packmind/llm': join(__dirname, '../../packages/llm/src'),
     '@packmind/skills': join(__dirname, '../../packages/skills/src'),
+    '@packmind/telemetry': join(__dirname, '../../packages/telemetry/src'),
     '@packmind/editions': join(__dirname, '../../packages/editions/src'),
     '@packmind/playbook-change-applier': join(
       __dirname,

--- a/apps/doc/docs.json
+++ b/apps/doc/docs.json
@@ -66,6 +66,7 @@
           "playbook-maintenance/updating-your-playbook",
           "playbook-maintenance/change-proposals",
           "playbook-maintenance/update-from-external-sources",
+          "playbook-maintenance/auto-update-artifacts",
           "concepts/spaces"
         ]
       },

--- a/apps/doc/playbook-maintenance/auto-update-artifacts.mdx
+++ b/apps/doc/playbook-maintenance/auto-update-artifacts.mdx
@@ -1,0 +1,53 @@
+---
+title: 'Auto-Update Artifacts'
+---
+
+Keep your Packmind artifacts in sync automatically by scheduling `packmind-cli install` to run in your CI/CD pipeline. When artifacts change on Packmind, the job commits the updated files to a dedicated branch and opens a merge/pull request for review — no manual intervention needed.
+
+## GitHub
+
+<Info>Automated artifact updates via GitHub Actions are coming soon.</Info>
+
+## GitLab
+
+### Prerequisites
+
+Before setting up the CI job, make sure you have:
+
+- A Packmind API key (available from your Packmind user profile settings)
+- Maintainer or Owner access to the GitLab project to create a Project Access Token
+
+### Step 1: Add the workflow file
+
+Copy the ready-to-use `.gitlab-ci.yml` file from the [Packmind repository](https://github.com/PackmindHub/packmind/auto-update/.gitlab-ci.yml) and place it at the **root of your GitLab repository**.
+
+If your repository already has a `.gitlab-ci.yml`, merge the `nightly-packmind-update` job into your existing file.
+
+### Step 2: Configure CI variables
+
+In your GitLab project, go to **Settings → CI/CD → Variables** and add the following two variables (mark both as **Masked**):
+
+| Variable              | Value                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| `PACKMIND_API_KEY_V3` | Your Packmind API key                                                                    |
+| `PACKMIND_BOT_TOKEN`  | A GitLab Project Access Token with `write_repository` and `api` scopes, role ≥ Developer |
+
+To create a Project Access Token: **Settings → Access Tokens → Add new token**, select scopes `write_repository` and `api`, and set a role of at least Developer.
+
+### Step 3: Run the job
+
+**Manually** — Go to **Build → Pipelines → Run pipeline**, select your default branch, and click **Run pipeline**. The `nightly-packmind-update` job will start automatically.
+
+**On a schedule** — Go to **Settings → CI/CD → Pipeline schedules → Add new schedule**. Use a cron expression such as `0 2 * * 1-5` (every weeknight at 02:00 UTC) and set the target branch to your default branch.
+
+### What happens next
+
+- If artifacts have changed, the job commits the updated files to a `packmind-cli-update` branch and opens a merge request targeting your default branch.
+- If no artifacts have changed, the job exits successfully without creating a commit.
+- If a merge request is already open for `packmind-cli-update`, new changes are appended to it instead of opening a duplicate.
+
+## Related Documentation
+
+- [Distribution](/governance/distribution) — Distribute artifacts to your team manually or via CLI
+- [Updating Your Playbook](/playbook-maintenance/updating-your-playbook) — Other ways to update artifacts
+- [CLI Reference](/tools/cli) — Full reference for `packmind-cli install` and other commands

--- a/apps/frontend/app/routes/org.$orgSlug._protected.space.$spaceSlug._space-protected.skills._index.tsx
+++ b/apps/frontend/app/routes/org.$orgSlug._protected.space.$spaceSlug._space-protected.skills._index.tsx
@@ -5,6 +5,7 @@ import { DownloadDefaultSkillsPopover } from '../../src/domain/skills/components
 import { useGetSkillsQuery } from '../../src/domain/skills/api/queries/SkillsQueries';
 import { useParams } from 'react-router';
 import { SkillsCreateButton } from '../../src/domain/skills/components/SkillsCreateButton';
+import { SkillsUsageTable } from '../../src/domain/telemetry/components/SkillsUsageTable';
 
 export default function SkillsIndexRouteModule() {
   const { organization } = useAuthContext();
@@ -35,6 +36,7 @@ export default function SkillsIndexRouteModule() {
     >
       <PMVStack align="stretch" gap={6}>
         <SkillsList key={spaceSlug} orgSlug={organization.slug} />
+        <SkillsUsageTable />
       </PMVStack>
     </PMPage>
   );

--- a/apps/frontend/src/domain/telemetry/api/gateways/TelemetryGatewayApi.ts
+++ b/apps/frontend/src/domain/telemetry/api/gateways/TelemetryGatewayApi.ts
@@ -1,0 +1,16 @@
+import { ListRecentTelemetryEventsResponse } from '@packmind/types';
+import { PackmindGateway } from '../../../../shared/PackmindGateway';
+
+export class TelemetryGatewayApi extends PackmindGateway {
+  constructor() {
+    super('/telemetry');
+  }
+
+  async listEvents(limit = 50): Promise<ListRecentTelemetryEventsResponse> {
+    return this._api.get<ListRecentTelemetryEventsResponse>(
+      `${this._endpoint}/events?limit=${limit}`,
+    );
+  }
+}
+
+export const telemetryGateway = new TelemetryGatewayApi();

--- a/apps/frontend/src/domain/telemetry/api/queries/TelemetryQueries.ts
+++ b/apps/frontend/src/domain/telemetry/api/queries/TelemetryQueries.ts
@@ -1,0 +1,13 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import { telemetryGateway } from '../gateways/TelemetryGatewayApi';
+
+const TELEMETRY_QUERY_SCOPE = 'telemetry';
+
+export const getTelemetryEventsOptions = (limit = 50) =>
+  queryOptions({
+    queryKey: [TELEMETRY_QUERY_SCOPE, 'events', limit] as const,
+    queryFn: () => telemetryGateway.listEvents(limit),
+  });
+
+export const useGetTelemetryEventsQuery = (limit = 50) =>
+  useQuery(getTelemetryEventsOptions(limit));

--- a/apps/frontend/src/domain/telemetry/components/SkillsUsageTable.tsx
+++ b/apps/frontend/src/domain/telemetry/components/SkillsUsageTable.tsx
@@ -1,0 +1,123 @@
+import {
+  PMBox,
+  PMHeading,
+  PMSpinner,
+  PMTable,
+  PMTableColumn,
+  PMTableRow,
+  PMText,
+  PMVStack,
+} from '@packmind/ui';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { TelemetryEvent } from '@packmind/types';
+import { useGetTelemetryEventsQuery } from '../api/queries/TelemetryQueries';
+
+type SkillActivation = {
+  id: string;
+  timestamp: string;
+  userEmail: string;
+  skillName: string;
+  trigger: string;
+};
+
+type OtlpAttribute = {
+  key: string;
+  value?: { stringValue?: string };
+};
+
+type OtlpLogRecord = {
+  observedTimeUnixNano?: string | number;
+  timeUnixNano?: string | number;
+  attributes?: OtlpAttribute[];
+};
+
+type OtlpRawPayload = {
+  resourceLogs?: Array<{
+    scopeLogs?: Array<{
+      logRecords?: OtlpLogRecord[];
+    }>;
+  }>;
+};
+
+const getAttr = (
+  attrs: OtlpAttribute[] | undefined,
+  key: string,
+): string | undefined => attrs?.find((a) => a.key === key)?.value?.stringValue;
+
+const extractSkillActivations = (
+  events: TelemetryEvent[],
+): SkillActivation[] => {
+  const out: SkillActivation[] = [];
+  for (const event of events) {
+    const payload = event.rawPayload as OtlpRawPayload | null | undefined;
+    for (const r of payload?.resourceLogs ?? []) {
+      for (const s of r.scopeLogs ?? []) {
+        for (const rec of s.logRecords ?? []) {
+          if (getAttr(rec.attributes, 'event.name') !== 'skill_activated') {
+            continue;
+          }
+          const timestamp =
+            getAttr(rec.attributes, 'event.timestamp') ??
+            (rec.observedTimeUnixNano
+              ? new Date(
+                  Number(rec.observedTimeUnixNano) / 1_000_000,
+                ).toISOString()
+              : new Date(event.receivedAt).toISOString());
+          out.push({
+            id: `${event.id}-${out.length}`,
+            timestamp,
+            userEmail: getAttr(rec.attributes, 'user.email') ?? '',
+            skillName: getAttr(rec.attributes, 'skill.name') ?? '',
+            trigger: getAttr(rec.attributes, 'invocation_trigger') ?? '',
+          });
+        }
+      }
+    }
+  }
+  out.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  return out;
+};
+
+const COLUMNS: PMTableColumn[] = [
+  { key: 'date', header: 'Date', align: 'left', width: '15%' },
+  { key: 'user', header: 'User', align: 'left', width: '30%' },
+  { key: 'skillName', header: 'Skill', align: 'left', grow: true },
+  { key: 'trigger', header: 'Trigger', align: 'left', width: '15%' },
+];
+
+const noWrap = { whiteSpace: 'nowrap' as const };
+
+export const SkillsUsageTable = () => {
+  const { data, isLoading, error } = useGetTelemetryEventsQuery();
+
+  const activations = data ? extractSkillActivations(data.events) : [];
+
+  const rows: PMTableRow[] = activations.map((a) => ({
+    key: a.id,
+    date: (
+      <span style={noWrap}>
+        {formatDistanceToNowStrict(new Date(a.timestamp), { addSuffix: true })}
+      </span>
+    ),
+    user: a.userEmail || '—',
+    skillName: <span style={noWrap}>{a.skillName || '—'}</span>,
+    trigger: <span style={noWrap}>{a.trigger || '—'}</span>,
+  }));
+
+  return (
+    <PMBox mt={4}>
+      <PMVStack align="stretch" gap={3}>
+        <PMHeading level="h3">Skills usage</PMHeading>
+        {isLoading ? (
+          <PMSpinner />
+        ) : error ? (
+          <PMText color="secondary">Failed to load telemetry events.</PMText>
+        ) : activations.length === 0 ? (
+          <PMText color="secondary">No skill activations recorded yet.</PMText>
+        ) : (
+          <PMTable columns={COLUMNS} data={rows} />
+        )}
+      </PMVStack>
+    </PMBox>
+  );
+};

--- a/auto-update/.gitlab-ci.yml
+++ b/auto-update/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+stages:
+  - update
+
+nightly-packmind-update:
+  stage: update
+  image: node:22.17.0
+  timeout: 15 minutes
+  variables:
+    GIT_DEPTH: 0
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - git config user.name "packmind-bot"
+    - git config user.email "packmind-bot@users.noreply.gitlab.com"
+    - git remote set-url origin "https://oauth2:${PACKMIND_BOT_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    - |
+      if git ls-remote --exit-code --heads origin packmind-cli-update; then
+        git fetch origin packmind-cli-update
+        git checkout packmind-cli-update
+        git merge --no-edit origin/main || true
+      else
+        git checkout -b packmind-cli-update
+      fi
+    - npm install -g @packmind/cli
+    - packmind-cli install
+    - |
+      if [ -z "$(git status --porcelain)" ]; then
+        echo "No artifact changes — skipping commit/push."
+        exit 0
+      fi
+    - git add -A
+    - 'git commit -m "chore(packmind): nightly artifacts update"'
+    - |
+      git push origin packmind-cli-update \
+        -o merge_request.create \
+        -o merge_request.target=main \
+        -o merge_request.title="chore(packmind): nightly artifacts update" \
+        -o merge_request.description="Automated nightly update of Packmind artifacts via \`packmind-cli install\`. Review the diff under \`.packmind/\` and \`packmind-lock.json\`."

--- a/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/skills/packmind-update-playbook/packmind-versions/0.23.0/apply-changes.ts
+++ b/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/skills/packmind-update-playbook/packmind-versions/0.23.0/apply-changes.ts
@@ -92,6 +92,8 @@ Ask the user: **"These changes will be submitted as: '<intent description>'. Con
 
 Run \`packmind-cli playbook submit -m "<intent description>"\` to submit all staged changes as proposals for human review.
 
+> **The \`-m\` flag is mandatory.** Without it, the CLI opens an interactive text editor (vim/nano) waiting for the message — this blocks an AI agent indefinitely. Always pass the message inline with \`-m\`.
+
 The message should be a concise summary of the intent (max 1024 characters). If this command fails, show the full error output, stop, and ask the user how to proceed — do not retry silently.
 
 ##### Step 5: Report and continue

--- a/packages/node-utils/src/cache/Cache.ts
+++ b/packages/node-utils/src/cache/Cache.ts
@@ -209,4 +209,18 @@ export class Cache {
       initialized: this.initialized,
     };
   }
+
+  /**
+   * Access the underlying ioredis client.
+   *
+   * Reserved for callers that need Redis primitives not exposed by the
+   * `set/get/invalidate` API (e.g. list/stream operations). Throws if the
+   * cache has not been initialised — callers must run after app bootstrap.
+   */
+  getRawClient(): Redis {
+    if (!this.initialized || !this.client) {
+      throw new Error('Cache not initialized. Call initialize() first.');
+    }
+    return this.client;
+  }
 }

--- a/packages/telemetry/.swcrc
+++ b/packages/telemetry/.swcrc
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/swcrc",
+  "jsc": {
+    "parser": { "syntax": "typescript", "decorators": false },
+    "target": "es2022",
+    "keepClassNames": true
+  },
+  "module": { "type": "commonjs" },
+  "sourceMaps": true
+}

--- a/packages/telemetry/jest.config.ts
+++ b/packages/telemetry/jest.config.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { compilerOptions } from '../../tsconfig.base.effective.json';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import {
+  pathsToModuleNameMapper,
+  swcTransform,
+  standardTransformIgnorePatterns,
+  standardModuleFileExtensions,
+} from '../../jest-utils';
+
+export default {
+  displayName: 'telemetry',
+  preset: '../../jest.preset.ts',
+  testEnvironment: 'node',
+  transform: swcTransform,
+  transformIgnorePatterns: standardTransformIgnorePatterns,
+  moduleFileExtensions: standardModuleFileExtensions,
+  coverageDirectory: '../../coverage/packages/telemetry',
+  moduleNameMapper: pathsToModuleNameMapper(
+    compilerOptions.paths,
+    '<rootDir>/../../',
+  ),
+};

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@packmind/telemetry",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "@packmind/logger": "0.0.1",
+    "@packmind/node-utils": "0.0.1",
+    "@packmind/test-utils": "0.0.1",
+    "@packmind/types": "0.0.1",
+    "ioredis": "^5.4.2",
+    "typeorm": "0.3.28",
+    "uuid": "^11.0.5"
+  }
+}

--- a/packages/telemetry/project.json
+++ b/packages/telemetry/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "telemetry",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/telemetry/src",
+  "projectType": "library",
+  "tags": ["env:node"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:swc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/packages/telemetry",
+        "tsConfig": "packages/telemetry/tsconfig.lib.json",
+        "packageJson": "packages/telemetry/package.json",
+        "main": "packages/telemetry/src/index.ts",
+        "assets": ["packages/telemetry/*.md"]
+      }
+    }
+  }
+}

--- a/packages/telemetry/src/TelemetryHexa.ts
+++ b/packages/telemetry/src/TelemetryHexa.ts
@@ -1,0 +1,73 @@
+import { PackmindLogger } from '@packmind/logger';
+import {
+  BaseHexa,
+  BaseHexaOpts,
+  Cache,
+  HexaRegistry,
+} from '@packmind/node-utils';
+import {
+  IAccountsPort,
+  IAccountsPortName,
+  ITelemetryPort,
+  ITelemetryPortName,
+} from '@packmind/types';
+import { DataSource } from 'typeorm';
+import { TelemetryAdapter } from './application/adapter/TelemetryAdapter';
+import { ITelemetryEventRepository } from './domain/repositories/ITelemetryEventRepository';
+import { TelemetryEventRepository } from './infra/repositories/TelemetryEventRepository';
+
+const origin = 'TelemetryHexa';
+
+export type TelemetryHexaOpts = BaseHexaOpts & {
+  repository?: ITelemetryEventRepository;
+};
+
+const baseTelemetryHexaOpts = { logger: new PackmindLogger(origin) };
+
+/**
+ * TelemetryHexa - Facade for the Telemetry domain.
+ *
+ * Stores OpenTelemetry log batches in Redis (per-org bounded ring buffer with
+ * a 14-day TTL). Has no database tables and no cross-domain dependencies
+ * beyond the Accounts port (used by `AbstractMemberUseCase` for membership
+ * validation).
+ */
+export class TelemetryHexa extends BaseHexa<TelemetryHexaOpts, ITelemetryPort> {
+  private readonly adapter: TelemetryAdapter;
+
+  constructor(dataSource: DataSource, opts?: Partial<TelemetryHexaOpts>) {
+    super(dataSource, { ...baseTelemetryHexaOpts, ...opts });
+    this.logger.info('Constructing TelemetryHexa');
+
+    const repository: ITelemetryEventRepository =
+      opts?.repository ??
+      new TelemetryEventRepository(Cache.getInstance().getRawClient());
+
+    this.adapter = new TelemetryAdapter(repository);
+    this.logger.info('TelemetryHexa construction completed');
+  }
+
+  public async initialize(registry: HexaRegistry): Promise<void> {
+    this.logger.info('Initializing TelemetryHexa (adapter retrieval phase)');
+
+    const accountsPort = registry.getAdapter<IAccountsPort>(IAccountsPortName);
+
+    await this.adapter.initialize({
+      [IAccountsPortName]: accountsPort,
+    });
+
+    this.logger.info('TelemetryHexa initialized successfully');
+  }
+
+  public getAdapter(): ITelemetryPort {
+    return this.adapter.getPort();
+  }
+
+  public getPortName(): string {
+    return ITelemetryPortName;
+  }
+
+  public destroy(): void {
+    this.logger.info('Destroying TelemetryHexa');
+  }
+}

--- a/packages/telemetry/src/TelemetryHexa.ts
+++ b/packages/telemetry/src/TelemetryHexa.ts
@@ -41,7 +41,7 @@ export class TelemetryHexa extends BaseHexa<TelemetryHexaOpts, ITelemetryPort> {
 
     const repository: ITelemetryEventRepository =
       opts?.repository ??
-      new TelemetryEventRepository(Cache.getInstance().getRawClient());
+      new TelemetryEventRepository(() => Cache.getInstance().getRawClient());
 
     this.adapter = new TelemetryAdapter(repository);
     this.logger.info('TelemetryHexa construction completed');

--- a/packages/telemetry/src/application/adapter/TelemetryAdapter.ts
+++ b/packages/telemetry/src/application/adapter/TelemetryAdapter.ts
@@ -1,0 +1,75 @@
+import { PackmindLogger } from '@packmind/logger';
+import { IBaseAdapter } from '@packmind/node-utils';
+import {
+  IAccountsPort,
+  IAccountsPortName,
+  ITelemetryPort,
+  IngestTelemetryEventsCommand,
+  IngestTelemetryEventsResponse,
+  ListRecentTelemetryEventsCommand,
+  ListRecentTelemetryEventsResponse,
+} from '@packmind/types';
+import { ITelemetryEventRepository } from '../../domain/repositories/ITelemetryEventRepository';
+import { IngestTelemetryEventsUseCase } from '../useCases/ingestTelemetryEvents/IngestTelemetryEventsUseCase';
+import { ListRecentTelemetryEventsUseCase } from '../useCases/listRecentTelemetryEvents/ListRecentTelemetryEventsUseCase';
+
+const origin = 'TelemetryAdapter';
+
+export class TelemetryAdapter
+  implements IBaseAdapter<ITelemetryPort>, ITelemetryPort
+{
+  private accountsPort: IAccountsPort | null = null;
+  private _ingestUseCase!: IngestTelemetryEventsUseCase;
+  private _listRecentUseCase!: ListRecentTelemetryEventsUseCase;
+
+  constructor(
+    private readonly repository: ITelemetryEventRepository,
+    private readonly logger: PackmindLogger = new PackmindLogger(origin),
+  ) {
+    this.logger.info(
+      'TelemetryAdapter constructed - awaiting initialization with ports',
+    );
+  }
+
+  public async initialize(ports: {
+    [IAccountsPortName]: IAccountsPort;
+  }): Promise<void> {
+    this.logger.info('Initializing TelemetryAdapter');
+    const accountsPort = ports[IAccountsPortName];
+    if (!accountsPort) {
+      throw new Error('TelemetryAdapter: required ports not provided');
+    }
+
+    this.accountsPort = accountsPort;
+    this._ingestUseCase = new IngestTelemetryEventsUseCase(
+      accountsPort,
+      this.repository,
+    );
+    this._listRecentUseCase = new ListRecentTelemetryEventsUseCase(
+      accountsPort,
+      this.repository,
+    );
+
+    this.logger.info('TelemetryAdapter initialized successfully');
+  }
+
+  public isReady(): boolean {
+    return this.accountsPort !== null;
+  }
+
+  public getPort(): ITelemetryPort {
+    return this;
+  }
+
+  async ingestTelemetryEvents(
+    command: IngestTelemetryEventsCommand,
+  ): Promise<IngestTelemetryEventsResponse> {
+    return this._ingestUseCase.execute(command);
+  }
+
+  async listRecentTelemetryEvents(
+    command: ListRecentTelemetryEventsCommand,
+  ): Promise<ListRecentTelemetryEventsResponse> {
+    return this._listRecentUseCase.execute(command);
+  }
+}

--- a/packages/telemetry/src/application/useCases/ingestTelemetryEvents/IngestTelemetryEventsUseCase.spec.ts
+++ b/packages/telemetry/src/application/useCases/ingestTelemetryEvents/IngestTelemetryEventsUseCase.spec.ts
@@ -1,0 +1,164 @@
+import { stubLogger } from '@packmind/test-utils';
+import {
+  createOrganizationId,
+  createUserId,
+  IAccountsPort,
+  Organization,
+  TelemetryEvent,
+  User,
+} from '@packmind/types';
+import { ITelemetryEventRepository } from '../../../domain/repositories/ITelemetryEventRepository';
+import {
+  describePayload,
+  IngestTelemetryEventsUseCase,
+  InvalidTelemetryPayloadError,
+  MAX_LOG_RECORDS_PER_BATCH,
+  TelemetryPayloadTooLargeError,
+} from './IngestTelemetryEventsUseCase';
+
+describe('IngestTelemetryEventsUseCase', () => {
+  const userId = createUserId('user-id');
+  const organizationId = createOrganizationId('org-id');
+
+  const buildUser = (): User =>
+    ({
+      id: userId,
+      email: 'member@test.com',
+      displayName: null,
+      passwordHash: null,
+      active: true,
+      trial: false,
+      memberships: [{ userId, organizationId, role: 'member' }],
+    }) as User;
+
+  const buildOrganization = (): Organization =>
+    ({
+      id: organizationId,
+      name: 'Org',
+      slug: 'org',
+    }) as Organization;
+
+  const buildAccountsPort = (): IAccountsPort =>
+    ({
+      getUserById: jest.fn().mockResolvedValue(buildUser()),
+      getOrganizationById: jest.fn().mockResolvedValue(buildOrganization()),
+    }) as unknown as IAccountsPort;
+
+  const buildRepository = (): jest.Mocked<ITelemetryEventRepository> => ({
+    pushBatch: jest.fn().mockResolvedValue(undefined),
+    listRecent: jest.fn().mockResolvedValue([]),
+  });
+
+  it('persists a batch and returns the accepted record count', async () => {
+    const repo = buildRepository();
+    const useCase = new IngestTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    const rawPayload = {
+      resourceLogs: [
+        {
+          scopeLogs: [
+            { logRecords: [{ body: 'a' }, { body: 'b' }] },
+            { logRecords: [{ body: 'c' }] },
+          ],
+        },
+        {
+          scopeLogs: [{ logRecords: [{ body: 'd' }] }],
+        },
+      ],
+    };
+
+    const result = await useCase.execute({
+      userId,
+      organizationId,
+      rawPayload,
+    });
+
+    expect(result.acceptedRecords).toBe(4);
+    expect(repo.pushBatch).toHaveBeenCalledTimes(1);
+
+    const persisted = repo.pushBatch.mock.calls[0][0] as TelemetryEvent;
+    expect(persisted.organizationId).toBe(organizationId);
+    expect(persisted.userId).toBe(userId);
+    expect(persisted.logRecordCount).toBe(4);
+    expect(persisted.sizeBytes).toBeGreaterThan(0);
+    expect(persisted.rawPayload).toEqual(rawPayload);
+    expect(persisted.id).toBeDefined();
+  });
+
+  it('rejects payloads that are not objects', async () => {
+    const repo = buildRepository();
+    const useCase = new IngestTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    await expect(
+      useCase.execute({ userId, organizationId, rawPayload: 'not an object' }),
+    ).rejects.toBeInstanceOf(InvalidTelemetryPayloadError);
+
+    expect(repo.pushBatch).not.toHaveBeenCalled();
+  });
+
+  it('rejects payloads exceeding the max log record count', async () => {
+    const logRecords = new Array(MAX_LOG_RECORDS_PER_BATCH + 1).fill({
+      body: 'x',
+    });
+    const rawPayload = {
+      resourceLogs: [{ scopeLogs: [{ logRecords }] }],
+    };
+
+    const repo = buildRepository();
+    const useCase = new IngestTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    await expect(
+      useCase.execute({ userId, organizationId, rawPayload }),
+    ).rejects.toBeInstanceOf(TelemetryPayloadTooLargeError);
+    expect(repo.pushBatch).not.toHaveBeenCalled();
+  });
+
+  it('accepts an OTLP body with no resourceLogs (count = 0)', async () => {
+    const repo = buildRepository();
+    const useCase = new IngestTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    const result = await useCase.execute({
+      userId,
+      organizationId,
+      rawPayload: {},
+    });
+
+    expect(result.acceptedRecords).toBe(0);
+    expect(repo.pushBatch).toHaveBeenCalledTimes(1);
+  });
+
+  describe('describePayload', () => {
+    it('counts log records across resourceLogs and scopeLogs', () => {
+      const result = describePayload({
+        resourceLogs: [
+          { scopeLogs: [{ logRecords: [{}, {}] }] },
+          { scopeLogs: [{ logRecords: [{}] }, { logRecords: [{}, {}, {}] }] },
+        ],
+      });
+      expect(result.logRecordCount).toBe(6);
+      expect(result.sizeBytes).toBeGreaterThan(0);
+    });
+
+    it('rejects malformed resourceLogs', () => {
+      expect(() => describePayload({ resourceLogs: 'oops' })).toThrow(
+        InvalidTelemetryPayloadError,
+      );
+    });
+  });
+});

--- a/packages/telemetry/src/application/useCases/ingestTelemetryEvents/IngestTelemetryEventsUseCase.ts
+++ b/packages/telemetry/src/application/useCases/ingestTelemetryEvents/IngestTelemetryEventsUseCase.ts
@@ -1,0 +1,130 @@
+import { v4 as uuidv4 } from 'uuid';
+import { PackmindLogger } from '@packmind/logger';
+import { AbstractMemberUseCase, MemberContext } from '@packmind/node-utils';
+import {
+  IAccountsPort,
+  IIngestTelemetryEventsUseCase,
+  IngestTelemetryEventsCommand,
+  IngestTelemetryEventsResponse,
+  TelemetryEvent,
+  createTelemetryEventId,
+} from '@packmind/types';
+import { ITelemetryEventRepository } from '../../../domain/repositories/ITelemetryEventRepository';
+
+const origin = 'IngestTelemetryEventsUseCase';
+
+export const MAX_LOG_RECORDS_PER_BATCH = 10_000;
+
+export class IngestTelemetryEventsUseCase
+  extends AbstractMemberUseCase<
+    IngestTelemetryEventsCommand,
+    IngestTelemetryEventsResponse
+  >
+  implements IIngestTelemetryEventsUseCase
+{
+  constructor(
+    accountsPort: IAccountsPort,
+    private readonly repository: ITelemetryEventRepository,
+    logger: PackmindLogger = new PackmindLogger(origin),
+  ) {
+    super(accountsPort, logger);
+  }
+
+  protected async executeForMembers(
+    command: IngestTelemetryEventsCommand & MemberContext,
+  ): Promise<IngestTelemetryEventsResponse> {
+    const { rawPayload, user, organization } = command;
+    const { logRecordCount, sizeBytes } = describePayload(rawPayload);
+
+    if (logRecordCount > MAX_LOG_RECORDS_PER_BATCH) {
+      throw new TelemetryPayloadTooLargeError(
+        logRecordCount,
+        MAX_LOG_RECORDS_PER_BATCH,
+      );
+    }
+
+    const event: TelemetryEvent = {
+      id: createTelemetryEventId(uuidv4()),
+      receivedAt: new Date(),
+      organizationId: organization.id,
+      userId: user.id,
+      logRecordCount,
+      sizeBytes,
+      rawPayload,
+    };
+
+    await this.repository.pushBatch(event);
+
+    return {
+      eventId: event.id,
+      acceptedRecords: logRecordCount,
+    };
+  }
+}
+
+export class TelemetryPayloadTooLargeError extends Error {
+  constructor(
+    public readonly received: number,
+    public readonly max: number,
+  ) {
+    super(
+      `Telemetry payload contains ${received} log records, exceeding the limit of ${max}`,
+    );
+    this.name = 'TelemetryPayloadTooLargeError';
+  }
+}
+
+export function describePayload(rawPayload: unknown): {
+  logRecordCount: number;
+  sizeBytes: number;
+} {
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(rawPayload ?? null);
+  } catch {
+    throw new InvalidTelemetryPayloadError('Payload is not JSON-serialisable');
+  }
+
+  const sizeBytes = Buffer.byteLength(serialized, 'utf8');
+
+  if (rawPayload === null || typeof rawPayload !== 'object') {
+    throw new InvalidTelemetryPayloadError(
+      'Payload must be an OTLP ExportLogsServiceRequest object',
+    );
+  }
+
+  const resourceLogs = (rawPayload as { resourceLogs?: unknown }).resourceLogs;
+
+  if (resourceLogs === undefined) {
+    return { logRecordCount: 0, sizeBytes };
+  }
+
+  if (!Array.isArray(resourceLogs)) {
+    throw new InvalidTelemetryPayloadError(
+      '`resourceLogs` must be an array when provided',
+    );
+  }
+
+  let logRecordCount = 0;
+  for (const resourceLog of resourceLogs) {
+    if (!resourceLog || typeof resourceLog !== 'object') continue;
+    const scopeLogs = (resourceLog as { scopeLogs?: unknown }).scopeLogs;
+    if (!Array.isArray(scopeLogs)) continue;
+    for (const scopeLog of scopeLogs) {
+      if (!scopeLog || typeof scopeLog !== 'object') continue;
+      const logRecords = (scopeLog as { logRecords?: unknown }).logRecords;
+      if (Array.isArray(logRecords)) {
+        logRecordCount += logRecords.length;
+      }
+    }
+  }
+
+  return { logRecordCount, sizeBytes };
+}
+
+export class InvalidTelemetryPayloadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidTelemetryPayloadError';
+  }
+}

--- a/packages/telemetry/src/application/useCases/listRecentTelemetryEvents/ListRecentTelemetryEventsUseCase.spec.ts
+++ b/packages/telemetry/src/application/useCases/listRecentTelemetryEvents/ListRecentTelemetryEventsUseCase.spec.ts
@@ -1,0 +1,100 @@
+import { stubLogger } from '@packmind/test-utils';
+import {
+  createOrganizationId,
+  createTelemetryEventId,
+  createUserId,
+  IAccountsPort,
+  Organization,
+  TelemetryEvent,
+  User,
+} from '@packmind/types';
+import { ITelemetryEventRepository } from '../../../domain/repositories/ITelemetryEventRepository';
+import {
+  ListRecentTelemetryEventsUseCase,
+  MAX_LIST_LIMIT,
+} from './ListRecentTelemetryEventsUseCase';
+
+describe('ListRecentTelemetryEventsUseCase', () => {
+  const userId = createUserId('user-id');
+  const organizationId = createOrganizationId('org-id');
+
+  const buildAccountsPort = (): IAccountsPort =>
+    ({
+      getUserById: jest.fn().mockResolvedValue({
+        id: userId,
+        email: 'm@t.com',
+        displayName: null,
+        passwordHash: null,
+        active: true,
+        trial: false,
+        memberships: [{ userId, organizationId, role: 'member' }],
+      } as User),
+      getOrganizationById: jest.fn().mockResolvedValue({
+        id: organizationId,
+        name: 'Org',
+        slug: 'org',
+      } as Organization),
+    }) as unknown as IAccountsPort;
+
+  const sampleEvent = (): TelemetryEvent => ({
+    id: createTelemetryEventId('evt-1'),
+    receivedAt: new Date('2026-05-06T10:00:00.000Z'),
+    organizationId,
+    userId,
+    logRecordCount: 3,
+    sizeBytes: 120,
+    rawPayload: { resourceLogs: [] },
+  });
+
+  it('returns events from the repository', async () => {
+    const repo: jest.Mocked<ITelemetryEventRepository> = {
+      pushBatch: jest.fn(),
+      listRecent: jest.fn().mockResolvedValue([sampleEvent()]),
+    };
+    const useCase = new ListRecentTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    const result = await useCase.execute({ userId, organizationId, limit: 10 });
+
+    expect(result.events).toHaveLength(1);
+    expect(repo.listRecent).toHaveBeenCalledWith(organizationId, 10);
+  });
+
+  it('caps the limit at MAX_LIST_LIMIT', async () => {
+    const repo: jest.Mocked<ITelemetryEventRepository> = {
+      pushBatch: jest.fn(),
+      listRecent: jest.fn().mockResolvedValue([]),
+    };
+    const useCase = new ListRecentTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    await useCase.execute({ userId, organizationId, limit: 999_999 });
+
+    expect(repo.listRecent).toHaveBeenCalledWith(
+      organizationId,
+      MAX_LIST_LIMIT,
+    );
+  });
+
+  it('falls back to default for non-positive limits', async () => {
+    const repo: jest.Mocked<ITelemetryEventRepository> = {
+      pushBatch: jest.fn(),
+      listRecent: jest.fn().mockResolvedValue([]),
+    };
+    const useCase = new ListRecentTelemetryEventsUseCase(
+      buildAccountsPort(),
+      repo,
+      stubLogger(),
+    );
+
+    await useCase.execute({ userId, organizationId, limit: 0 });
+
+    expect(repo.listRecent).toHaveBeenCalledWith(organizationId, 50);
+  });
+});

--- a/packages/telemetry/src/application/useCases/listRecentTelemetryEvents/ListRecentTelemetryEventsUseCase.ts
+++ b/packages/telemetry/src/application/useCases/listRecentTelemetryEvents/ListRecentTelemetryEventsUseCase.ts
@@ -1,0 +1,46 @@
+import { PackmindLogger } from '@packmind/logger';
+import { AbstractMemberUseCase, MemberContext } from '@packmind/node-utils';
+import {
+  IAccountsPort,
+  IListRecentTelemetryEventsUseCase,
+  ListRecentTelemetryEventsCommand,
+  ListRecentTelemetryEventsResponse,
+} from '@packmind/types';
+import { ITelemetryEventRepository } from '../../../domain/repositories/ITelemetryEventRepository';
+
+const origin = 'ListRecentTelemetryEventsUseCase';
+
+export const DEFAULT_LIST_LIMIT = 50;
+export const MAX_LIST_LIMIT = 500;
+
+export class ListRecentTelemetryEventsUseCase
+  extends AbstractMemberUseCase<
+    ListRecentTelemetryEventsCommand,
+    ListRecentTelemetryEventsResponse
+  >
+  implements IListRecentTelemetryEventsUseCase
+{
+  constructor(
+    accountsPort: IAccountsPort,
+    private readonly repository: ITelemetryEventRepository,
+    logger: PackmindLogger = new PackmindLogger(origin),
+  ) {
+    super(accountsPort, logger);
+  }
+
+  protected async executeForMembers(
+    command: ListRecentTelemetryEventsCommand & MemberContext,
+  ): Promise<ListRecentTelemetryEventsResponse> {
+    const limit = clampLimit(command.limit);
+    const events = await this.repository.listRecent(
+      command.organization.id,
+      limit,
+    );
+    return { events };
+  }
+}
+
+function clampLimit(input: number): number {
+  if (!Number.isFinite(input) || input <= 0) return DEFAULT_LIST_LIMIT;
+  return Math.min(Math.floor(input), MAX_LIST_LIMIT);
+}

--- a/packages/telemetry/src/domain/repositories/ITelemetryEventRepository.ts
+++ b/packages/telemetry/src/domain/repositories/ITelemetryEventRepository.ts
@@ -1,0 +1,9 @@
+import { OrganizationId, TelemetryEvent } from '@packmind/types';
+
+export interface ITelemetryEventRepository {
+  pushBatch(event: TelemetryEvent): Promise<void>;
+  listRecent(
+    organizationId: OrganizationId,
+    limit: number,
+  ): Promise<TelemetryEvent[]>;
+}

--- a/packages/telemetry/src/index.ts
+++ b/packages/telemetry/src/index.ts
@@ -1,0 +1,4 @@
+export { TelemetryHexa } from './TelemetryHexa';
+export { TelemetryAdapter } from './application/adapter/TelemetryAdapter';
+export { TelemetryEventRepository } from './infra/repositories/TelemetryEventRepository';
+export type { ITelemetryEventRepository } from './domain/repositories/ITelemetryEventRepository';

--- a/packages/telemetry/src/infra/repositories/TelemetryEventRepository.spec.ts
+++ b/packages/telemetry/src/infra/repositories/TelemetryEventRepository.spec.ts
@@ -1,0 +1,127 @@
+import {
+  createOrganizationId,
+  createTelemetryEventId,
+  createUserId,
+  TelemetryEvent,
+} from '@packmind/types';
+import { TelemetryEventRepository } from './TelemetryEventRepository';
+
+type RedisMock = {
+  multi: jest.Mock;
+  lpush: jest.Mock;
+  ltrim: jest.Mock;
+  expire: jest.Mock;
+  exec: jest.Mock;
+  lrange: jest.Mock;
+};
+
+describe('TelemetryEventRepository', () => {
+  const organizationId = createOrganizationId('org-1');
+  const userId = createUserId('user-1');
+
+  const buildEvent = (): TelemetryEvent => ({
+    id: createTelemetryEventId('evt-1'),
+    receivedAt: new Date('2026-05-06T10:00:00.000Z'),
+    organizationId,
+    userId,
+    logRecordCount: 2,
+    sizeBytes: 42,
+    rawPayload: { resourceLogs: [] },
+  });
+
+  const buildRedisMock = (): RedisMock => {
+    const mock: RedisMock = {
+      multi: jest.fn(),
+      lpush: jest.fn(),
+      ltrim: jest.fn(),
+      expire: jest.fn(),
+      exec: jest.fn().mockResolvedValue([]),
+      lrange: jest.fn().mockResolvedValue([]),
+    };
+    const chain = {
+      lpush: jest.fn().mockReturnThis(),
+      ltrim: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([]),
+    };
+    mock.multi.mockReturnValue(chain);
+    mock.lpush = chain.lpush;
+    mock.ltrim = chain.ltrim;
+    mock.expire = chain.expire;
+    mock.exec = chain.exec;
+    return mock;
+  };
+
+  it('lpushes a serialized event, trims, and sets a 14-day TTL', async () => {
+    const redis = buildRedisMock();
+    const repo = new TelemetryEventRepository(redis as unknown as never);
+
+    await repo.pushBatch(buildEvent());
+
+    expect(redis.multi).toHaveBeenCalledTimes(1);
+    expect(redis.lpush).toHaveBeenCalledTimes(1);
+
+    const [pushedKey, payload] = redis.lpush.mock.calls[0];
+    expect(pushedKey).toBe(`telemetry:events:org:${organizationId}`);
+    const parsed = JSON.parse(payload as string);
+    expect(parsed.id).toBe('evt-1');
+    expect(parsed.receivedAt).toBe('2026-05-06T10:00:00.000Z');
+
+    expect(redis.ltrim).toHaveBeenCalledWith(
+      `telemetry:events:org:${organizationId}`,
+      0,
+      999,
+    );
+    expect(redis.expire).toHaveBeenCalledWith(
+      `telemetry:events:org:${organizationId}`,
+      14 * 24 * 60 * 60,
+    );
+    expect(redis.exec).toHaveBeenCalledTimes(1);
+  });
+
+  it('listRecent returns deserialized events with Date receivedAt', async () => {
+    const redis = buildRedisMock();
+    const event = buildEvent();
+    redis.lrange = jest
+      .fn()
+      .mockResolvedValue([
+        JSON.stringify({
+          ...event,
+          receivedAt: event.receivedAt.toISOString(),
+        }),
+      ]);
+
+    const client = {
+      ...redis,
+      lrange: redis.lrange,
+    };
+
+    const repo = new TelemetryEventRepository(client as unknown as never);
+    const events = await repo.listRecent(organizationId, 50);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(event.id);
+    expect(events[0].receivedAt).toBeInstanceOf(Date);
+    expect(events[0].receivedAt.toISOString()).toBe(
+      event.receivedAt.toISOString(),
+    );
+    expect(redis.lrange).toHaveBeenCalledWith(
+      `telemetry:events:org:${organizationId}`,
+      0,
+      49,
+    );
+  });
+
+  it('listRecent clamps limit to a sane range', async () => {
+    const redis = buildRedisMock();
+    redis.lrange = jest.fn().mockResolvedValue([]);
+    const client = { ...redis, lrange: redis.lrange };
+    const repo = new TelemetryEventRepository(client as unknown as never);
+
+    await repo.listRecent(organizationId, 0);
+    expect(redis.lrange).toHaveBeenLastCalledWith(expect.any(String), 0, 0);
+
+    await repo.listRecent(organizationId, 99_999);
+    expect(redis.lrange).toHaveBeenLastCalledWith(expect.any(String), 0, 999);
+  });
+});

--- a/packages/telemetry/src/infra/repositories/TelemetryEventRepository.ts
+++ b/packages/telemetry/src/infra/repositories/TelemetryEventRepository.ts
@@ -1,0 +1,62 @@
+import type { Redis } from 'ioredis';
+import { PackmindLogger } from '@packmind/logger';
+import { OrganizationId, TelemetryEvent } from '@packmind/types';
+import { ITelemetryEventRepository } from '../../domain/repositories/ITelemetryEventRepository';
+
+const origin = 'TelemetryEventRepository';
+
+const KEY_PREFIX = 'telemetry:events:org:';
+const TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
+const MAX_BATCHES_PER_ORG = 1000;
+
+export class TelemetryEventRepository implements ITelemetryEventRepository {
+  constructor(
+    private readonly client: Redis,
+    private readonly logger: PackmindLogger = new PackmindLogger(origin),
+  ) {}
+
+  async pushBatch(event: TelemetryEvent): Promise<void> {
+    const key = this.buildKey(event.organizationId);
+    const serialized = JSON.stringify({
+      ...event,
+      receivedAt: event.receivedAt.toISOString(),
+    });
+
+    await this.client
+      .multi()
+      .lpush(key, serialized)
+      .ltrim(key, 0, MAX_BATCHES_PER_ORG - 1)
+      .expire(key, TTL_SECONDS)
+      .exec();
+
+    this.logger.info('Telemetry batch persisted', {
+      organizationId: event.organizationId,
+      eventId: event.id,
+      logRecordCount: event.logRecordCount,
+      sizeBytes: event.sizeBytes,
+    });
+  }
+
+  async listRecent(
+    organizationId: OrganizationId,
+    limit: number,
+  ): Promise<TelemetryEvent[]> {
+    const key = this.buildKey(organizationId);
+    const safeLimit = Math.max(1, Math.min(limit, MAX_BATCHES_PER_ORG));
+    const raw = await this.client.lrange(key, 0, safeLimit - 1);
+
+    return raw.map((entry) => this.deserialize(entry));
+  }
+
+  private buildKey(organizationId: OrganizationId): string {
+    return `${KEY_PREFIX}${organizationId}`;
+  }
+
+  private deserialize(entry: string): TelemetryEvent {
+    const parsed = JSON.parse(entry) as TelemetryEvent & { receivedAt: string };
+    return {
+      ...parsed,
+      receivedAt: new Date(parsed.receivedAt),
+    };
+  }
+}

--- a/packages/telemetry/src/infra/repositories/TelemetryEventRepository.ts
+++ b/packages/telemetry/src/infra/repositories/TelemetryEventRepository.ts
@@ -9,11 +9,25 @@ const KEY_PREFIX = 'telemetry:events:org:';
 const TTL_SECONDS = 14 * 24 * 60 * 60; // 14 days
 const MAX_BATCHES_PER_ORG = 1000;
 
+export type TelemetryRedisClient = Pick<
+  Redis,
+  'multi' | 'lrange' | 'lpush' | 'ltrim' | 'expire'
+>;
+
+export type TelemetryRedisProvider = () => TelemetryRedisClient;
+
 export class TelemetryEventRepository implements ITelemetryEventRepository {
+  private readonly resolveClient: TelemetryRedisProvider;
+
   constructor(
-    private readonly client: Redis,
+    clientOrProvider: TelemetryRedisClient | TelemetryRedisProvider,
     private readonly logger: PackmindLogger = new PackmindLogger(origin),
-  ) {}
+  ) {
+    this.resolveClient =
+      typeof clientOrProvider === 'function'
+        ? clientOrProvider
+        : () => clientOrProvider;
+  }
 
   async pushBatch(event: TelemetryEvent): Promise<void> {
     const key = this.buildKey(event.organizationId);
@@ -22,7 +36,7 @@ export class TelemetryEventRepository implements ITelemetryEventRepository {
       receivedAt: event.receivedAt.toISOString(),
     });
 
-    await this.client
+    await this.resolveClient()
       .multi()
       .lpush(key, serialized)
       .ltrim(key, 0, MAX_BATCHES_PER_ORG - 1)
@@ -43,7 +57,7 @@ export class TelemetryEventRepository implements ITelemetryEventRepository {
   ): Promise<TelemetryEvent[]> {
     const key = this.buildKey(organizationId);
     const safeLimit = Math.max(1, Math.min(limit, MAX_BATCHES_PER_ORG));
-    const raw = await this.client.lrange(key, 0, safeLimit - 1);
+    const raw = await this.resolveClient().lrange(key, 0, safeLimit - 1);
 
     return raw.map((entry) => this.deserialize(entry));
   }

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.effective.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/telemetry/tsconfig.lib.json
+++ b/packages/telemetry/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/telemetry/tsconfig.spec.json
+++ b/packages/telemetry/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,3 +18,4 @@ export * from './database/types';
 export * from './events';
 export * from './playbookChangeManagement';
 export * from './playbookChangeApplier';
+export * from './telemetry';

--- a/packages/types/src/telemetry/TelemetryEvent.ts
+++ b/packages/types/src/telemetry/TelemetryEvent.ts
@@ -1,0 +1,12 @@
+import { OrganizationId, UserId } from '../accounts';
+import { TelemetryEventId } from './TelemetryEventId';
+
+export type TelemetryEvent = {
+  id: TelemetryEventId;
+  receivedAt: Date;
+  organizationId: OrganizationId;
+  userId: UserId;
+  logRecordCount: number;
+  sizeBytes: number;
+  rawPayload: unknown;
+};

--- a/packages/types/src/telemetry/TelemetryEventId.ts
+++ b/packages/types/src/telemetry/TelemetryEventId.ts
@@ -1,0 +1,4 @@
+import { Branded, brandedIdFactory } from '../brandedTypes';
+
+export type TelemetryEventId = Branded<'TelemetryEventId'>;
+export const createTelemetryEventId = brandedIdFactory<TelemetryEventId>();

--- a/packages/types/src/telemetry/contracts/IIngestTelemetryEventsUseCase.ts
+++ b/packages/types/src/telemetry/contracts/IIngestTelemetryEventsUseCase.ts
@@ -1,0 +1,16 @@
+import { IUseCase, PackmindCommand, PackmindResult } from '../../UseCase';
+import { TelemetryEventId } from '../TelemetryEventId';
+
+export type IngestTelemetryEventsCommand = PackmindCommand & {
+  rawPayload: unknown;
+};
+
+export type IngestTelemetryEventsResponse = PackmindResult & {
+  eventId: TelemetryEventId;
+  acceptedRecords: number;
+};
+
+export type IIngestTelemetryEventsUseCase = IUseCase<
+  IngestTelemetryEventsCommand,
+  IngestTelemetryEventsResponse
+>;

--- a/packages/types/src/telemetry/contracts/IListRecentTelemetryEventsUseCase.ts
+++ b/packages/types/src/telemetry/contracts/IListRecentTelemetryEventsUseCase.ts
@@ -1,0 +1,15 @@
+import { IUseCase, PackmindCommand, PackmindResult } from '../../UseCase';
+import { TelemetryEvent } from '../TelemetryEvent';
+
+export type ListRecentTelemetryEventsCommand = PackmindCommand & {
+  limit: number;
+};
+
+export type ListRecentTelemetryEventsResponse = PackmindResult & {
+  events: TelemetryEvent[];
+};
+
+export type IListRecentTelemetryEventsUseCase = IUseCase<
+  ListRecentTelemetryEventsCommand,
+  ListRecentTelemetryEventsResponse
+>;

--- a/packages/types/src/telemetry/contracts/index.ts
+++ b/packages/types/src/telemetry/contracts/index.ts
@@ -1,0 +1,2 @@
+export * from './IIngestTelemetryEventsUseCase';
+export * from './IListRecentTelemetryEventsUseCase';

--- a/packages/types/src/telemetry/index.ts
+++ b/packages/types/src/telemetry/index.ts
@@ -1,0 +1,4 @@
+export * from './TelemetryEvent';
+export * from './TelemetryEventId';
+export * from './contracts';
+export * from './ports';

--- a/packages/types/src/telemetry/ports/ITelemetryPort.ts
+++ b/packages/types/src/telemetry/ports/ITelemetryPort.ts
@@ -1,0 +1,20 @@
+import {
+  IngestTelemetryEventsCommand,
+  IngestTelemetryEventsResponse,
+} from '../contracts/IIngestTelemetryEventsUseCase';
+import {
+  ListRecentTelemetryEventsCommand,
+  ListRecentTelemetryEventsResponse,
+} from '../contracts/IListRecentTelemetryEventsUseCase';
+
+export const ITelemetryPortName = 'ITelemetryPort' as const;
+
+export interface ITelemetryPort {
+  ingestTelemetryEvents(
+    command: IngestTelemetryEventsCommand,
+  ): Promise<IngestTelemetryEventsResponse>;
+
+  listRecentTelemetryEvents(
+    command: ListRecentTelemetryEventsCommand,
+  ): Promise<ListRecentTelemetryEventsResponse>;
+}

--- a/packages/types/src/telemetry/ports/index.ts
+++ b/packages/types/src/telemetry/ports/index.ts
@@ -1,0 +1,2 @@
+export { ITelemetryPortName } from './ITelemetryPort';
+export type { ITelemetryPort } from './ITelemetryPort';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -48,6 +48,7 @@
       "@packmind/spaces": ["packages/spaces/src/index.ts"],
       "@packmind/spaces/test": ["packages/spaces/test/index.ts"],
       "@packmind/standards": ["packages/standards/src/index.ts"],
+      "@packmind/telemetry": ["packages/telemetry/src/index.ts"],
       "@packmind/test-utils": ["packages/test-utils/src/index.ts"],
       "@packmind/types": ["packages/types/src/index.ts"],
       "@packmind/ui": ["packages/ui/src/index.ts"],


### PR DESCRIPTION
## Explanation

Adds a ready-to-use GitLab CI workflow template for automating Packmind artifact updates, along with end-user documentation explaining how to set it up.

- `auto-update/.gitlab-ci.yml` — GitLab CI job that runs `packmind-cli install`, commits any artifact changes to a `packmind-cli-update` branch, and opens a MR automatically via push options
- `apps/doc/playbook-maintenance/auto-update-artifacts.mdx` — new documentation page covering GitHub (coming soon) and GitLab setup steps
- `apps/doc/docs.json` — registers the new page in the Playbook Maintenance nav group

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [x] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none
- Frontend / Backend / Both: neither (CI template + docs only)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
- GitLab CI YAML validated via GitLab CI Lint
- Documentation page reviewed in context

## TODO List

- [x] CHANGELOG Updated
- [x] Documentation Updated

## Reviewer Notes

The workflow uses GitLab push options (`-o merge_request.create`) for idempotent MR creation — no `glab` CLI dependency needed. Auth is handled via a Project Access Token (`PACKMIND_BOT_TOKEN`) stored as a masked CI variable.