### PR TITLE
fix(skills): enforce 1024-char skill description limit on CLI and backend

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,8 @@
 
 ## Fixed
 
+- Skill descriptions longer than 1024 characters are now rejected with a clear 400 error on the playbook accept path instead of failing with a generic server error
+
 ## Removed
 
 # [1.14.0] - 2026-05-06

--- a/apps/api/src/app/organizations/playbook/playbook.controller.spec.ts
+++ b/apps/api/src/app/organizations/playbook/playbook.controller.spec.ts
@@ -1,0 +1,91 @@
+import {
+  BadRequestException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { AuthenticatedRequest } from '@packmind/node-utils';
+import { SkillValidationError } from '@packmind/skills';
+import { ApplyPlaybookProposalItem } from '@packmind/types';
+
+import { PlaybookController } from './playbook.controller';
+import { PlaybookService } from './playbook.service';
+
+describe('PlaybookController', () => {
+  let controller: PlaybookController;
+  let service: jest.Mocked<PlaybookService>;
+
+  const orgId = 'org-123';
+  const userId = 'user-123';
+  const request = {
+    user: { userId },
+  } as AuthenticatedRequest;
+  const proposals: ApplyPlaybookProposalItem[] = [];
+
+  beforeEach(() => {
+    service = {
+      applyPlaybook: jest.fn(),
+    } as unknown as jest.Mocked<PlaybookService>;
+    controller = new PlaybookController(service);
+  });
+
+  describe('when applyPlaybook throws SkillValidationError', () => {
+    it('translates it to a BadRequestException, passing the error message through', async () => {
+      const validationError = new SkillValidationError([
+        {
+          field: 'description',
+          message: 'description must not exceed 1024 characters',
+        },
+      ]);
+      validationError.message =
+        'A submitted skill has a description longer than 1024 characters. Edit your skill and upload it again.';
+      service.applyPlaybook.mockRejectedValue(validationError);
+
+      await expect(
+        controller.apply(request, orgId, {
+          proposals,
+          message: 'msg',
+        }),
+      ).rejects.toThrow(BadRequestException);
+
+      await expect(
+        controller.apply(request, orgId, {
+          proposals,
+          message: 'msg',
+        }),
+      ).rejects.toThrow(validationError.message);
+    });
+  });
+
+  describe('when applyPlaybook returns success: false', () => {
+    it('throws UnprocessableEntityException (existing behaviour)', async () => {
+      service.applyPlaybook.mockResolvedValue({
+        success: false,
+        error: { index: 0, type: 'createSkill' as never, message: 'boom' },
+      } as never);
+
+      await expect(
+        controller.apply(request, orgId, {
+          proposals,
+          message: 'msg',
+        }),
+      ).rejects.toThrow(UnprocessableEntityException);
+    });
+  });
+
+  describe('when applyPlaybook resolves successfully', () => {
+    it('returns the result', async () => {
+      const successResult = {
+        success: true as const,
+        created: { standards: [], commands: [], skills: [] },
+        updated: { standards: [], commands: [], skills: [] },
+      };
+      service.applyPlaybook.mockResolvedValue(successResult as never);
+
+      const result = await controller.apply(request, orgId, {
+        proposals,
+        message: 'msg',
+      });
+
+      expect(result).toBe(successResult);
+    });
+  });
+});

--- a/apps/api/src/app/organizations/playbook/playbook.controller.ts
+++ b/apps/api/src/app/organizations/playbook/playbook.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   HttpCode,
@@ -11,6 +12,7 @@ import {
 import { PackmindLogger } from '@packmind/logger';
 import { AuthenticatedRequest } from '@packmind/node-utils';
 import { ApplyPlaybookProposalItem } from '@packmind/types';
+import { SkillValidationError } from '@packmind/skills';
 import { OrganizationAccessGuard } from '../guards/organization-access.guard';
 import { PlaybookService } from './playbook.service';
 
@@ -44,13 +46,26 @@ export class PlaybookController {
       proposalCount: body.proposals.length,
     });
 
-    const result = await this.playbookService.applyPlaybook({
-      userId,
-      organizationId: orgId,
-      proposals: body.proposals,
-      message: body.message,
-      directUpdate: body.directUpdate,
-    });
+    let result;
+    try {
+      result = await this.playbookService.applyPlaybook({
+        userId,
+        organizationId: orgId,
+        proposals: body.proposals,
+        message: body.message,
+        directUpdate: body.directUpdate,
+      });
+    } catch (error) {
+      if (error instanceof SkillValidationError) {
+        this.logger.warn('Skill validation failed on playbook apply', {
+          userId: userId.substring(0, 6) + '*',
+          organizationId: orgId,
+          errors: error.errors,
+        });
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
 
     if (!result.success) {
       throw new UnprocessableEntityException(result);

--- a/apps/cli/CHANGELOG.MD
+++ b/apps/cli/CHANGELOG.MD
@@ -7,6 +7,7 @@
 ## Fixed
 
 - `install <package>` against a directory without `packmind.json` now reports `Created packmind.json with N package(s)` instead of the misleading `Nothing to install`.
+- `playbook add` and `playbook submit` now reject skills whose description exceeds 1024 characters with an actionable message, instead of failing later on the server.
 
 ## Removed
 

--- a/apps/cli/src/application/utils/parseSkillDirectory.spec.ts
+++ b/apps/cli/src/application/utils/parseSkillDirectory.spec.ts
@@ -130,6 +130,44 @@ describe('parseSkillDirectory', () => {
     });
   });
 
+  describe('when description exceeds 1024 characters', () => {
+    it('returns an error', () => {
+      const longDescription = 'a'.repeat(1025);
+      const content = [
+        '---',
+        'name: My Skill',
+        `description: "${longDescription}"`,
+        '---',
+        'Prompt body.',
+      ].join('\n');
+
+      const result = parseSkillDirectory([buildSkillMdFile(content)]);
+
+      expect(result).toEqual({
+        success: false,
+        error:
+          'Skill "My Skill" has a description of 1025 characters, which exceeds the maximum of 1024. Edit the "description" field in SKILL.md and try again.',
+      });
+    });
+  });
+
+  describe('when description is exactly 1024 characters', () => {
+    it('accepts the skill', () => {
+      const exactDescription = 'a'.repeat(1024);
+      const content = [
+        '---',
+        'name: My Skill',
+        `description: "${exactDescription}"`,
+        '---',
+        'Prompt body.',
+      ].join('\n');
+
+      const result = parseSkillDirectory([buildSkillMdFile(content)]);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
   describe('when body is empty', () => {
     it('returns an error', () => {
       const content = [

--- a/apps/cli/src/application/utils/parseSkillDirectory.ts
+++ b/apps/cli/src/application/utils/parseSkillDirectory.ts
@@ -3,6 +3,7 @@ import {
   parseSkillMdContent,
   CLAUDE_CODE_ADDITIONAL_FIELDS,
 } from '@packmind/node-utils';
+import { DESCRIPTION_MAX_LENGTH } from '@packmind/skills';
 
 const SKILL_MD_FILENAME = 'SKILL.md';
 
@@ -73,6 +74,14 @@ export function parseSkillDirectory(
     };
   }
 
+  const trimmedDescription = description.trim();
+  if (trimmedDescription.length > DESCRIPTION_MAX_LENGTH) {
+    return {
+      success: false,
+      error: `Skill "${name.trim()}" has a description of ${trimmedDescription.length} characters, which exceeds the maximum of ${DESCRIPTION_MAX_LENGTH}. Edit the "description" field in SKILL.md and try again.`,
+    };
+  }
+
   if (body.trim().length === 0) {
     return {
       success: false,
@@ -82,7 +91,7 @@ export function parseSkillDirectory(
 
   const payload: NewSkillPayload = {
     name: name.trim(),
-    description: description.trim(),
+    description: trimmedDescription,
     prompt: body,
     skillMdPermissions: skillMdFile.permissions,
   };

--- a/apps/cli/src/infra/commands/playbook/submit/skillDescriptionValidator.spec.ts
+++ b/apps/cli/src/infra/commands/playbook/submit/skillDescriptionValidator.spec.ts
@@ -1,0 +1,126 @@
+import { ChangeProposalType } from '@packmind/types';
+
+import { ProposalItem } from './proposalBuilder';
+import { validateProposalSkillDescriptions } from './skillDescriptionValidator';
+
+function makeCreateSkillProposal(
+  name: string,
+  description: string,
+): ProposalItem {
+  return {
+    type: ChangeProposalType.createSkill,
+    artefactId: null,
+    payload: {
+      name,
+      description,
+      prompt: 'body',
+      skillMdPermissions: 'rw-r--r--',
+    },
+    targetId: undefined,
+    spaceId: 'space-1',
+  };
+}
+
+function makeUpdateDescriptionProposal(
+  artefactId: string,
+  oldValue: string,
+  newValue: string,
+): ProposalItem {
+  return {
+    type: ChangeProposalType.updateSkillDescription,
+    artefactId,
+    payload: { oldValue, newValue },
+    targetId: undefined,
+    spaceId: 'space-1',
+  };
+}
+
+describe('validateProposalSkillDescriptions', () => {
+  describe('when all skill descriptions are within the limit', () => {
+    it('returns no errors', () => {
+      const proposals: ProposalItem[] = [
+        makeCreateSkillProposal('skill-a', 'short description'),
+        makeUpdateDescriptionProposal('skill-b-id', 'old', 'new'),
+      ];
+
+      expect(validateProposalSkillDescriptions(proposals)).toEqual([]);
+    });
+  });
+
+  describe('when a createSkill payload exceeds 1024 chars', () => {
+    it('returns an actionable error mentioning the skill name', () => {
+      const longDescription = 'a'.repeat(1025);
+      const proposals: ProposalItem[] = [
+        makeCreateSkillProposal('my-skill', longDescription),
+      ];
+
+      const errors = validateProposalSkillDescriptions(proposals);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Skill "my-skill"');
+      expect(errors[0]).toContain('1025 characters');
+      expect(errors[0]).toContain('maximum of 1024');
+    });
+  });
+
+  describe('when an updateSkillDescription payload exceeds 1024 chars', () => {
+    it('returns an actionable error mentioning the artefactId', () => {
+      const longValue = 'b'.repeat(1500);
+      const proposals: ProposalItem[] = [
+        makeUpdateDescriptionProposal('skill-uuid-123', 'old', longValue),
+      ];
+
+      const errors = validateProposalSkillDescriptions(proposals);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('skill-uuid-123');
+      expect(errors[0]).toContain('1500 characters');
+      expect(errors[0]).toContain('maximum of 1024');
+    });
+  });
+
+  describe('when a description is exactly 1024 chars', () => {
+    it('accepts it', () => {
+      const exact = 'a'.repeat(1024);
+      const proposals: ProposalItem[] = [
+        makeCreateSkillProposal('edge', exact),
+      ];
+
+      expect(validateProposalSkillDescriptions(proposals)).toEqual([]);
+    });
+  });
+
+  describe('when multiple proposals are oversized', () => {
+    it('returns one error per offending proposal', () => {
+      const proposals: ProposalItem[] = [
+        makeCreateSkillProposal('skill-a', 'a'.repeat(2000)),
+        makeUpdateDescriptionProposal('skill-b', 'old', 'b'.repeat(2000)),
+        makeCreateSkillProposal('skill-c', 'ok'),
+      ];
+
+      const errors = validateProposalSkillDescriptions(proposals);
+      expect(errors).toHaveLength(2);
+    });
+  });
+
+  describe('when proposals are unrelated to skill descriptions', () => {
+    it('ignores them', () => {
+      const proposals: ProposalItem[] = [
+        {
+          type: ChangeProposalType.updateSkillName,
+          artefactId: 'skill-id',
+          payload: { oldValue: 'a', newValue: 'b' },
+          targetId: undefined,
+          spaceId: 'space-1',
+        },
+        {
+          type: ChangeProposalType.createCommand,
+          artefactId: null,
+          payload: { name: 'foo', content: 'bar' },
+          targetId: undefined,
+          spaceId: 'space-1',
+        },
+      ];
+
+      expect(validateProposalSkillDescriptions(proposals)).toEqual([]);
+    });
+  });
+});

--- a/apps/cli/src/infra/commands/playbook/submit/skillDescriptionValidator.ts
+++ b/apps/cli/src/infra/commands/playbook/submit/skillDescriptionValidator.ts
@@ -1,0 +1,43 @@
+import {
+  ChangeProposalType,
+  NewSkillPayload,
+  ScalarUpdatePayload,
+} from '@packmind/types';
+import { DESCRIPTION_MAX_LENGTH } from '@packmind/skills';
+
+import { ProposalItem } from './proposalBuilder';
+
+/**
+ * Checks that no submitted proposal carries a skill description longer than
+ * the backend-enforced limit. Mirrors `SkillValidator.validateDescriptionFormat`
+ * to fail fast on the CLI with an actionable error message, instead of
+ * surfacing a generic API error later.
+ */
+export function validateProposalSkillDescriptions(
+  proposals: ProposalItem[],
+): string[] {
+  const errors: string[] = [];
+
+  for (const proposal of proposals) {
+    if (proposal.type === ChangeProposalType.createSkill) {
+      const payload = proposal.payload as NewSkillPayload;
+      const description = payload?.description ?? '';
+      if (description.length > DESCRIPTION_MAX_LENGTH) {
+        errors.push(
+          `Skill "${payload.name ?? 'unknown'}" has a description of ${description.length} characters, which exceeds the maximum of ${DESCRIPTION_MAX_LENGTH}. Edit the "description" field in SKILL.md and try again.`,
+        );
+      }
+    } else if (proposal.type === ChangeProposalType.updateSkillDescription) {
+      const payload = proposal.payload as ScalarUpdatePayload;
+      const newValue = payload?.newValue ?? '';
+      if (newValue.length > DESCRIPTION_MAX_LENGTH) {
+        const label = proposal.artefactId ?? 'unknown';
+        errors.push(
+          `Skill (id: ${label}) has a description of ${newValue.length} characters, which exceeds the maximum of ${DESCRIPTION_MAX_LENGTH}. Edit the "description" field in SKILL.md and try again.`,
+        );
+      }
+    }
+  }
+
+  return errors;
+}

--- a/apps/cli/src/infra/commands/playbook/submitHandler.ts
+++ b/apps/cli/src/infra/commands/playbook/submitHandler.ts
@@ -16,6 +16,7 @@ import {
 import { checkForDuplicateNames } from './submit/duplicateNameChecker';
 import { createTargetContextResolver } from './submit/targetContextResolver';
 import { buildProposals, ProposalItem } from './submit/proposalBuilder';
+import { validateProposalSkillDescriptions } from './submit/skillDescriptionValidator';
 import {
   fetchAvailablePackageSlugs,
   logPackageAddGuidance,
@@ -144,6 +145,18 @@ export async function playbookSubmitHandler(
     changes,
     resolver.getTargetContext,
   );
+
+  // Pre-flight: reject skill proposals whose description exceeds the limit.
+  // The backend enforces the same cap; failing fast here keeps the error tied
+  // to the local file so users can fix it before sending anything.
+  const descriptionErrors = validateProposalSkillDescriptions(allProposals);
+  if (descriptionErrors.length > 0) {
+    for (const error of descriptionErrors) {
+      logErrorConsole(error);
+    }
+    exit(1);
+    return;
+  }
 
   // Pre-flight: reject when the same artifact is updated from multiple agents
   if (conflicts.length > 0) {

--- a/packages/playbook-change-applier/package.json
+++ b/packages/playbook-change-applier/package.json
@@ -9,6 +9,7 @@
     "@packmind/types": "*",
     "@packmind/logger": "*",
     "@packmind/node-utils": "*",
+    "@packmind/skills": "*",
     "@packmind/test-utils": "*",
     "typeorm": "0.3.28",
     "uuid": "^11.1.0",

--- a/packages/playbook-change-applier/src/ApplyPlaybookUseCase.spec.ts
+++ b/packages/playbook-change-applier/src/ApplyPlaybookUseCase.spec.ts
@@ -1090,6 +1090,53 @@ describe('ApplyPlaybookUseCase', () => {
       });
     });
 
+    describe('when an updateSkillDescription proposal exceeds 1024 chars', () => {
+      const skillId = createSkillId('existing-skill');
+      const skillVersionId = createSkillVersionId('skill-ver-1');
+
+      const skillVersion: SkillVersion = {
+        id: skillVersionId,
+        skillId,
+        name: 'My Skill',
+        slug: 'my-skill',
+        description: 'A short description',
+        prompt: 'Do things',
+        version: 1,
+        userId,
+      };
+
+      beforeEach(() => {
+        skillsPort.getLatestSkillVersion.mockResolvedValue(skillVersion);
+        skillsPort.getSkillFiles.mockResolvedValue([]);
+      });
+
+      it('throws an error with an actionable message before saving the new version', async () => {
+        const longDescription = 'a'.repeat(1025);
+
+        await expect(
+          useCase.execute(
+            buildCommand({
+              proposals: [
+                {
+                  spaceId,
+                  type: ChangeProposalType.updateSkillDescription,
+                  artefactId: skillId,
+                  payload: {
+                    oldValue: 'A short description',
+                    newValue: longDescription,
+                  },
+                },
+              ],
+            }),
+          ),
+        ).rejects.toThrow(
+          /description longer than 1024 characters\. Edit your skill and upload it again\./,
+        );
+
+        expect(skillsPort.saveSkillVersion).not.toHaveBeenCalled();
+      });
+    });
+
     describe('when submitting a deleteRule proposal', () => {
       const ruleToDelete = createRuleId('rule-to-delete');
       const stdVersionWithTwoRules: StandardVersion = {

--- a/packages/playbook-change-applier/src/ApplyPlaybookUseCase.spec.ts
+++ b/packages/playbook-change-applier/src/ApplyPlaybookUseCase.spec.ts
@@ -1137,6 +1137,55 @@ describe('ApplyPlaybookUseCase', () => {
       });
     });
 
+    describe('when updating a non-description field on a legacy skill whose existing description exceeds 1024 chars', () => {
+      const skillId = createSkillId('legacy-skill');
+      const skillVersionId = createSkillVersionId('legacy-ver-1');
+      const newSkillVersionId = createSkillVersionId('legacy-ver-2');
+
+      const legacyOversizedDescription = 'l'.repeat(1500);
+
+      const skillVersion: SkillVersion = {
+        id: skillVersionId,
+        skillId,
+        name: 'Legacy Skill',
+        slug: 'legacy-skill',
+        description: legacyOversizedDescription,
+        prompt: 'Do things',
+        version: 1,
+        userId,
+      };
+
+      it('allows the update without flagging the legacy description', async () => {
+        skillsPort.getLatestSkillVersion.mockResolvedValue(skillVersion);
+        skillsPort.getSkillFiles.mockResolvedValue([]);
+        skillsPort.saveSkillVersion.mockResolvedValue({
+          ...skillVersion,
+          id: newSkillVersionId,
+          name: 'Renamed Skill',
+          version: 2,
+        });
+
+        const result = await useCase.execute(
+          buildCommand({
+            proposals: [
+              {
+                spaceId,
+                type: ChangeProposalType.updateSkillName,
+                artefactId: skillId,
+                payload: {
+                  oldValue: 'Legacy Skill',
+                  newValue: 'Renamed Skill',
+                },
+              },
+            ],
+          }),
+        );
+
+        expect(result.success).toBe(true);
+        expect(skillsPort.saveSkillVersion).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('when submitting a deleteRule proposal', () => {
       const ruleToDelete = createRuleId('rule-to-delete');
       const stdVersionWithTwoRules: StandardVersion = {

--- a/packages/playbook-change-applier/src/ApplyPlaybookUseCase.ts
+++ b/packages/playbook-change-applier/src/ApplyPlaybookUseCase.ts
@@ -41,6 +41,7 @@ import {
   camelToKebab,
   sortAdditionalPropertiesKeys,
 } from '@packmind/types';
+import { DESCRIPTION_MAX_LENGTH, SkillValidationError } from '@packmind/skills';
 import { IChangesProposalApplier } from './appliers/IChangesProposalApplier';
 import { StandardChangesApplier } from './appliers/StandardChangesApplier';
 import { CommandChangesApplier } from './appliers/CommandChangesApplier';
@@ -175,6 +176,17 @@ export class ApplyPlaybookUseCase extends AbstractMemberUseCase<
         const errorType =
           step.kind === 'create' ? step.proposal.type : step.proposals[0].type;
         await this.rollback(rollbackEntries);
+        if (error instanceof SkillValidationError) {
+          const descriptionError = error.errors.find(
+            (e) => e.field === 'description',
+          );
+          error.message = descriptionError
+            ? `A submitted skill has a description longer than ${DESCRIPTION_MAX_LENGTH} characters. Edit your skill and upload it again.`
+            : `A submitted skill is invalid: ${error.errors
+                .map((e) => e.message)
+                .join('; ')}. Edit your skill and upload it again.`;
+          throw error;
+        }
         return {
           success: false,
           error: {
@@ -280,6 +292,18 @@ export class ApplyPlaybookUseCase extends AbstractMemberUseCase<
       currentVersion,
       changeProposals,
     );
+
+    if (step.itemType === 'skill') {
+      const newSkillVersion = result.version as SkillVersionWithFiles;
+      if (newSkillVersion.description.length > DESCRIPTION_MAX_LENGTH) {
+        throw new SkillValidationError([
+          {
+            field: 'description',
+            message: `description must not exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+          },
+        ]);
+      }
+    }
 
     const spaceId = step.proposals[0].spaceId;
     const brandedUserId = createUserId(userId);

--- a/packages/playbook-change-applier/src/ApplyPlaybookUseCase.ts
+++ b/packages/playbook-change-applier/src/ApplyPlaybookUseCase.ts
@@ -19,6 +19,7 @@ import {
   NewCommandPayload,
   NewSkillPayload,
   NewStandardPayload,
+  ScalarUpdatePayload,
   RecipeId,
   RecipeVersion,
   SkillId,
@@ -284,6 +285,26 @@ export class ApplyPlaybookUseCase extends AbstractMemberUseCase<
     const applier = this.getApplierForType(step.itemType);
     const currentVersion = await applier.getVersion(step.artefactId);
 
+    if (step.itemType === 'skill') {
+      for (const proposal of step.proposals) {
+        if (proposal.type !== ChangeProposalType.updateSkillDescription) {
+          continue;
+        }
+        const payload = proposal.payload as ScalarUpdatePayload;
+        if (
+          typeof payload.newValue === 'string' &&
+          payload.newValue.length > DESCRIPTION_MAX_LENGTH
+        ) {
+          throw new SkillValidationError([
+            {
+              field: 'description',
+              message: `description must not exceed ${DESCRIPTION_MAX_LENGTH} characters`,
+            },
+          ]);
+        }
+      }
+    }
+
     const changeProposals = step.proposals.map((item) =>
       this.buildChangeProposal(item, userId),
     );
@@ -292,18 +313,6 @@ export class ApplyPlaybookUseCase extends AbstractMemberUseCase<
       currentVersion,
       changeProposals,
     );
-
-    if (step.itemType === 'skill') {
-      const newSkillVersion = result.version as SkillVersionWithFiles;
-      if (newSkillVersion.description.length > DESCRIPTION_MAX_LENGTH) {
-        throw new SkillValidationError([
-          {
-            field: 'description',
-            message: `description must not exceed ${DESCRIPTION_MAX_LENGTH} characters`,
-          },
-        ]);
-      }
-    }
 
     const spaceId = step.proposals[0].spaceId;
     const brandedUserId = createUserId(userId);

--- a/packages/skills/src/application/validator/SkillValidator.ts
+++ b/packages/skills/src/application/validator/SkillValidator.ts
@@ -7,9 +7,9 @@ import {
   SkillProperties,
 } from '../../domain/SkillProperties';
 
-const NAME_MAX_LENGTH = 64;
-const DESCRIPTION_MAX_LENGTH = 1024;
-const COMPATIBILITY_MAX_LENGTH = 500;
+export const NAME_MAX_LENGTH = 64;
+export const DESCRIPTION_MAX_LENGTH = 1024;
+export const COMPATIBILITY_MAX_LENGTH = 500;
 const ALLOWED_SHELL_VALUES = ['bash', 'powershell'] as const;
 
 /**


### PR DESCRIPTION
## Explanation

Skills uploaded through the playbook flow could carry a description larger than the backend-enforced 1024-character cap. When such a description reached the change-proposal accept / apply path, the API returned a generic error instead of an actionable response, and outdated CLIs had no way to fail fast on the local file.

This PR enforces the cap end-to-end:

- **CLI (`playbook add`)**: rejects SKILL.md whose frontmatter `description` exceeds 1024 chars with a file-level error before anything is staged.
- **CLI (`playbook submit`)**: pre-flights every staged `createSkill` / `updateSkillDescription` proposal against the cap and aborts before the network call, so outdated `add` invocations can't slip through.
- **Backend (`ApplyPlaybookUseCase`)**: guards the `updateSkillDescription` path (previously unchecked), rewrites `SkillValidationError.message` to a user-facing string, and rethrows it after rollback so HTTP handlers can map cleanly to a 4xx.
- **Backend (`PlaybookController.apply`)**: catches `SkillValidationError` and rethrows as `BadRequestException`, passing the use-case-supplied message through unchanged. Existing-user upgrade safety net for any CLI that hasn't picked up the new validation yet.
- Shared cap exposed as `DESCRIPTION_MAX_LENGTH` from `@packmind/skills` so the CLI and backend agree on the same number.

Relates to #508

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: `@packmind/skills`, `@packmind/playbook-change-applier`
- Frontend / Backend / Both: CLI + Backend (API)
- Breaking changes (if any): None

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**

- `parseSkillDirectory.spec.ts`: rejects description > 1024, accepts exactly 1024.
- `skillDescriptionValidator.spec.ts` (new): unit tests covering `createSkill` and `updateSkillDescription` proposals at the boundary, and ignoring unrelated proposal types.
- `ApplyPlaybookUseCase.spec.ts`: new case verifying `updateSkillDescription > 1024` throws before persisting the new version.
- `playbook.controller.spec.ts` (new): verifies `SkillValidationError` is mapped to `BadRequestException` and the message is passed through.
- Lint + unit tests pass on `skills`, `playbook-change-applier`, `packmind-cli`, `api`. Typecheck and build pass for `api` and `playbook-change-applier`.

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

- Per-commit split follows the project's task-splitting rule; each commit is independently buildable.
- The use case is now the single source of truth for the user-facing message; the controller is a thin HTTP mapper. If we want to further centralize this (e.g., a Nest exception filter for `SkillValidationError`), happy to follow up.
- Adds `@packmind/skills` as a dependency of `@packmind/playbook-change-applier` so we can throw the real `SkillValidationError` class (no fragile name-based duck typing).