### PR TITLE
📝 docs: fix audit-flagged drift in apps/doc

### DIFF
--- a/apps/doc/administration/manage-ai-agents.mdx
+++ b/apps/doc/administration/manage-ai-agents.mdx
@@ -31,7 +31,7 @@ When you distribute standards or commands, only the enabled agents will have the
 | **Cursor**         | `.cursor/` directory        | Yes              |
 | **Claude Code**    | `.claude/` directory        | Yes              |
 | **Junie**          | `.junie/guidelines.md`      | Yes              |
-| **Gitlab Duo**     | `.gitlab/duo/chat-rules.md` | Yes              |
+| **GitLab Duo**     | `.gitlab/duo/chat-rules.md` | Yes              |
 | **Continue**       | `.continue/rules/packmind/` | Yes              |
 | **OpenCode**       | `AGENTS.md`, `.opencode/`   | Yes              |
 | **Codex**          | `AGENTS.md`, `.agents/`     | Yes              |

--- a/apps/doc/concepts/skills-management.mdx
+++ b/apps/doc/concepts/skills-management.mdx
@@ -204,7 +204,7 @@ For complete details on where artifacts appear, see [Understanding Where Your Ar
 | -------------- | ------------------- | ------------------------- | -------------------- |
 | **Activation** | Automatic           | User-invoked              | Agent-discovered     |
 | **Purpose**    | Enforce guidelines  | Execute tasks             | Provide capabilities |
-| **Creation**   | CLI or Web UI       | CLI or Web UI             | CLI only             |
+| **Creation**   | CLI or Web UI       | CLI or Web UI             | CLI                  |
 | **Format**     | Rules with examples | Step-by-step instructions | SKILL.md + resources |
 
 - **Standards** are coding guidelines that AI assistants follow automatically

--- a/apps/doc/home.mdx
+++ b/apps/doc/home.mdx
@@ -13,7 +13,6 @@ Every tool expects its own inputs:
 - **Copilot** → `.github/copilot-instructions.md`, chat modes, reusable prompts
 - **Claude** → `CLAUDE.md`, commands, skills
 - **Cursor** → `.cursor/rules/*.mdc`
-- **Kiro** → `.kiro/steering/*.md`
 - _(with more formats appearing every month…)_
 
 But your team’s **actual standards aren’t stored anywhere**:

--- a/apps/doc/index.mdx
+++ b/apps/doc/index.mdx
@@ -13,7 +13,6 @@ Every tool expects its own inputs:
 - **Copilot** → `.github/copilot-instructions.md`, chat modes, reusable prompts
 - **Claude** → `CLAUDE.md`, commands, skills
 - **Cursor** → `.cursor/rules/*.mdc`
-- **Kiro** → `.kiro/steering/*.md`
 - _(with more formats appearing every month…)_
 
 But your team’s **actual standards aren’t stored anywhere**:

--- a/apps/doc/playbook-maintenance/change-proposals.mdx
+++ b/apps/doc/playbook-maintenance/change-proposals.mdx
@@ -121,7 +121,7 @@ The file must be located in a recognized artifact directory:
 | ------------- | --------------------------------------------------------------------------------------------------------- |
 | **Commands**  | `.claude/commands/`, `.cursor/commands/`, `.github/prompts/`, `.continue/prompts/`, `.packmind/commands/` |
 | **Standards** | `.claude/rules/`, `.cursor/rules/`, `.github/instructions/`, `.continue/rules/`, `.packmind/standards/`   |
-| **Skills**    | `.claude/skills/`, `.cursor/skills/`, `.github/skills/`                                                   |
+| **Skills**    | `.claude/skills/`, `.cursor/skills/`, `.github/skills/`, `.gitlab/duo/skills/`, `.opencode/skills/`, `.agents/skills/` |
 
 #### File format requirements
 


### PR DESCRIPTION
## Explanation

Fixes five drift issues flagged by a `doc-audit` of `apps/doc/` against the current Packmind codebase:

- **[Error]** `index.mdx` and `home.mdx` advertised **Kiro** (`.kiro/steering/*.md`) as a supported tool. No Kiro deployer exists. `CodingAgentDeployerRegistry` registers exactly 10 agents (`packmind, junie, claude, cursor, copilot, agents_md, gitlab_duo, continue, opencode, codex`). Kiro line dropped; the existing "more formats appearing every month…" hedge already covers breadth.
- **[Warning]** `concepts/skills-management.mdx` comparison table said Skills are created **"CLI only"**, but the same page's "Creating Skills" section calls `/packmind-update-playbook` (an AI-agent-driven skill) "the easiest way". Dropped the "only" qualifier; the row now reads `CLI`, consistent with the AI-agent path described elsewhere on the page.
- **[Warning]** `playbook-maintenance/change-proposals.mdx` skills directory table only listed `.claude/skills/`, `.cursor/skills/`, `.github/skills/`. Per `CODING_AGENT_ARTEFACT_PATHS` (`packages/types/src/coding-agent/CodingAgentArtefactPaths.ts`), three more skill directories exist: `.gitlab/duo/skills/`, `.opencode/skills/`, `.agents/skills/` — all three appended.
- **[Warning]** `administration/manage-ai-agents.mdx` used **"Gitlab Duo"** (lowercase 'L'), inconsistent with every other doc page (`tools/cli.mdx`, `concepts/commands-management.mdx`, `concepts/artifact-rendering.mdx`, `concepts/skills-management.mdx`), which all use **"GitLab Duo"**. Fixed.

<!-- Reference any existing issue, drop the section otherwise -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [x] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none (docs only)
- Frontend / Backend / Both: docs (`apps/doc/`, Mintlify)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**

Verified post-edit with grep:
- `grep -rni "kiro" apps/doc/` → no results
- `grep -rn "Gitlab Duo" apps/doc/` → no results (wrong-casing eliminated)
- `grep -n "CLI only" apps/doc/concepts/skills-management.mdx` → no results
- `grep -n "gitlab/duo/skills" apps/doc/playbook-maintenance/change-proposals.mdx` → row updated as expected

`apps/doc` is Mintlify content with no Nx test target; no lint/test job runs against these files.

## TODO List

- [ ] CHANGELOG Updated
- [x] Documentation Updated

## Reviewer Notes

- All edits cross-checked against the actual codebase sources of truth: `CodingAgentDeployerRegistry`, the `CodingAgent` type union, and `CODING_AGENT_ARTEFACT_PATHS`.
- The "Kiro" removal is preferred over swap-with-another-agent because the surrounding list is illustrative and already has the "more formats appearing every month…" line covering breadth.
- For the skills comparison row, `CLI` (without "only") is technically still accurate — Skills creation has no Web UI path — but no longer contradicts the "Creating Skills" section above it that recommends `/packmind-update-playbook`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)