### PR TITLE
🐛 fix(ci): include CHANGELOG.MD in app GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,36 @@ jobs:
             echo "version_suffix=-${{ vars.PACKMIND_EDITION }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Create GitHub Release
-        uses: actions/create-release@v1
+      - name: Extract changelog for version
+        id: extract-changelog
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get-version.outputs.version }}
+        run: |
+          CHANGELOG_FILE="CHANGELOG.MD"
+
+          # Extract section for this version
+          CHANGELOG_SECTION=$(awk -v ver="$VERSION" '
+            /^# \[/ {
+              if (found) exit;
+              if ($0 ~ "\\[" ver "\\]") found=1;
+              next;
+            }
+            found { print }
+          ' "$CHANGELOG_FILE")
+
+          # Save to output with proper escaping
+          echo "changelog<<EOF" >> $GITHUB_OUTPUT
+          echo "$CHANGELOG_SECTION" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          release_name: Release v${{ steps.get-version.outputs.version }}
+          name: Release v${{ steps.get-version.outputs.version }}
           body: |
-            ## Release Notes
-
-            Upgrade to ${{ steps.get-version.outputs.version }}
+            ## Changes
+            ${{ steps.extract-changelog.outputs.changelog }}
 
             ## Docker Images
 


### PR DESCRIPTION
## Explanation

The app release workflow (`.github/workflows/release.yml`) was creating GitHub releases on `release/X.Y.Z` tags with a hardcoded, generic body ("Upgrade to X.Y.Z") and **no actual release notes**. Meanwhile, the CLI release workflow (`.github/workflows/publish-cli-release.yml`) already extracts the per-version section from `apps/cli/CHANGELOG.MD` and injects it into the release body.

This PR brings the app release to parity: it extracts the matching section from the **root `CHANGELOG.MD`** (using the same awk pattern as the CLI workflow) and injects it under a `## Changes` block in the release body.

It also migrates the deprecated/archived `actions/create-release@v1` to `softprops/action-gh-release@v2`, matching the CLI workflow.

Relates to #

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none (CI workflow only)
- Frontend / Backend / Both: neither (CI)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**

The release workflow only runs on `release/*` tag pushes, so true end-to-end verification happens at the next app release. Pre-merge checks performed locally:

- Dry-run the awk extraction against the current `CHANGELOG.MD` for version `1.14.0` — returns the expected `## Added / ## Changed / ## Fixed` block, terminating cleanly before the next `# [1.13.1]` heading.
- Sanity-check with a non-existent version (`9.99.99`) — extraction returns empty; the release body still renders the `## Docker Images` section.
- Format contract verified against `.claude/rules/packmind/standard-changelog.md` (`# [X.Y.Z] - YYYY-MM-DD` heading shape — identical between the root and CLI changelogs).

## TODO List

- [ ] CHANGELOG Updated (N/A — CI-only change)
- [ ] Documentation Updated (N/A — internal workflow)

## Reviewer Notes

- The new step is a near-copy of `publish-cli-release.yml:197-217`; only the changelog path differs (`CHANGELOG.MD` vs `apps/cli/CHANGELOG.MD`).
- `softprops/action-gh-release@v2` reads `GITHUB_TOKEN` from `github.token` by default, so the explicit `env: GITHUB_TOKEN` block from the v1 action was dropped.
- Body layout was restructured to put `## Changes` first and `## Docker Images` second (the previous "Upgrade to X.Y.Z" line carried no information and was removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)