### PR TITLE
Unify CI/CD deployment workflow for OSS and Enterprise editions

### DIFF
--- a/.github/workflows/deploy-staging-and-release.yml
+++ b/.github/workflows/deploy-staging-and-release.yml
@@ -42,14 +42,17 @@ jobs:
         uses: mikefarah/yq@v4.47.2
 
       # ========================================================================
-      # PROPRIETARY EDITION - Cloud deployments (main branch only)
+      # UNIFIED (OSS + Enterprise) - Cloud + on-prem staging (main branch only)
+      # A single CI run publishes both image variants, so every commit updates
+      # the cloud (staging + prod) and on-prem staging values together.
       # ========================================================================
-      - name: Update cloud values (main branch - proprietary)
-        if: github.ref == 'refs/heads/main' && vars.PACKMIND_EDITION == 'proprietary'
+      - name: Update staging + prod values (main branch)
+        if: github.ref == 'refs/heads/main'
         working-directory: helm-charts
         env:
           PROD_CLOUD_VALUES: "packmind-internal-values/values-prod-cloud.yaml"
           STAGING_CLOUD_VALUES: "packmind-internal-values/values-staging-cloud.yaml"
+          STAGING_ONPREM_VALUES: "packmind-internal-values/values-staging-onprem-oss.yaml"
           IMAGE_TAG: "${{ github.sha }}"
         run: |
           # Update prod cloud values
@@ -62,94 +65,54 @@ jobs:
           yq eval '.frontend.image.tag = env(IMAGE_TAG)' -i $STAGING_CLOUD_VALUES
           yq eval '.mcpServer.image.tag = env(IMAGE_TAG)' -i $STAGING_CLOUD_VALUES
 
-      - name: Commit and Push Changes (main branch - proprietary)
-        if: github.ref == 'refs/heads/main' && vars.PACKMIND_EDITION == 'proprietary'
-        working-directory: helm-charts
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packmind-internal-values/values-prod-cloud.yaml packmind-internal-values/values-staging-cloud.yaml
-          git commit -m "[k8s-values] - update cloud values with commit ${{ github.sha }}"
-          git push
-
-      # ========================================================================
-      # OSS EDITION - On-premise deployments
-      # ========================================================================
-      - name: Update staging on-prem values (main branch - oss)
-        if: github.ref == 'refs/heads/main' && vars.PACKMIND_EDITION == 'oss'
-        working-directory: helm-charts
-        env:
-          STAGING_ONPREM_VALUES: "packmind-internal-values/values-staging-onprem-oss.yaml"
-          IMAGE_TAG: "${{ github.sha }}"
-        run: |
           # Update staging on-premise values
           yq eval '.api.image.tag = env(IMAGE_TAG)' -i $STAGING_ONPREM_VALUES
           yq eval '.frontend.image.tag = env(IMAGE_TAG)' -i $STAGING_ONPREM_VALUES
           yq eval '.mcpServer.image.tag = env(IMAGE_TAG)' -i $STAGING_ONPREM_VALUES
 
-      - name: Commit and Push Changes (main branch - oss)
-        if: github.ref == 'refs/heads/main' && vars.PACKMIND_EDITION == 'oss'
+      - name: Commit and Push Changes (main branch)
+        if: github.ref == 'refs/heads/main'
         working-directory: helm-charts
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packmind-internal-values/values-staging-onprem-oss.yaml
-          git commit -m "[k8s-values] - update staging on-prem values with commit ${{ github.sha }}"
+          git add packmind-internal-values/values-prod-cloud.yaml packmind-internal-values/values-staging-cloud.yaml packmind-internal-values/values-staging-onprem-oss.yaml
+          git commit -m "[k8s-values] - update staging + prod cloud values with commit ${{ github.sha }}"
           git push
 
-      - name: Get package version (release tags - oss)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'oss'
+      # ========================================================================
+      # UNIFIED (OSS + Enterprise) - On-premise release deployments
+      # Each release tag updates both the OSS and enterprise on-prem values.
+      # ========================================================================
+      - name: Get package version (release tags)
+        if: startsWith(github.ref, 'refs/tags/release/')
         id: get-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      - name: Update release on-prem values (release tags - oss)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'oss'
+      - name: Update release on-prem values (release tags)
+        if: startsWith(github.ref, 'refs/tags/release/')
         working-directory: helm-charts
         env:
           RELEASE_ONPREM_VALUES: "packmind-internal-values/values-release-onprem-oss.yaml"
+          RELEASE_ONPREM_ENTERPRISE_VALUES: "packmind-internal-values/values-release-onprem-enterprise.yaml"
           IMAGE_TAG: "${{ steps.get-version.outputs.version }}"
         run: |
-          # Update release on-premise values
+          # Update OSS release on-premise values
           yq eval '.api.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_VALUES
           yq eval '.frontend.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_VALUES
           yq eval '.mcpServer.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_VALUES
 
-      - name: Commit and Push Changes (release tags - oss)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'oss'
-        working-directory: helm-charts
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packmind-internal-values/values-release-onprem-oss.yaml
-          git commit -m "[k8s-values] - update release on-prem values with version v${{ steps.get-version.outputs.version }}"
-          git push
-
-      # ========================================================================
-      # PROPRIETARY EDITION - On-premise release deployments
-      # ========================================================================
-      - name: Get package version (release tags - proprietary)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'proprietary'
-        id: get-version-proprietary
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      - name: Update release on-prem enterprise values (release tags - proprietary)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'proprietary'
-        working-directory: helm-charts
-        env:
-          RELEASE_ONPREM_ENTERPRISE_VALUES: "packmind-internal-values/values-release-onprem-enterprise.yaml"
-          IMAGE_TAG: "${{ steps.get-version-proprietary.outputs.version }}"
-        run: |
-          # Update release on-premise enterprise values
+          # Update enterprise release on-premise values
           yq eval '.api.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_ENTERPRISE_VALUES
           yq eval '.frontend.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_ENTERPRISE_VALUES
           yq eval '.mcpServer.image.tag = env(IMAGE_TAG)' -i $RELEASE_ONPREM_ENTERPRISE_VALUES
 
-      - name: Commit and Push Changes (release tags - proprietary)
-        if: startsWith(github.ref, 'refs/tags/release/') && vars.PACKMIND_EDITION == 'proprietary'
+      - name: Commit and Push Changes (release tags)
+        if: startsWith(github.ref, 'refs/tags/release/')
         working-directory: helm-charts
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add packmind-internal-values/values-release-onprem-enterprise.yaml
-          git commit -m "[k8s-values] - update release on-prem enterprise values with version v${{ steps.get-version-proprietary.outputs.version }}"
+          git add packmind-internal-values/values-release-onprem-oss.yaml packmind-internal-values/values-release-onprem-enterprise.yaml
+          git commit -m "[k8s-values] - update release on-prem values with version v${{ steps.get-version.outputs.version }}"
           git push


### PR DESCRIPTION
## Explanation

This PR consolidates the deployment workflow to eliminate edition-specific branching logic. Previously, the CI/CD pipeline had separate jobs for OSS and proprietary editions, requiring different conditions and commits. Now, a single unified workflow:

- **On main branch**: Updates both cloud (staging + prod) and on-prem staging values in one job
- **On release tags**: Updates both OSS and enterprise on-prem release values in one job

This simplifies the workflow, reduces duplication, and ensures both image variants are published together with every commit/release.

## Type of Change

- [ ] Bug fix
- [x] Improvement/Enhancement
- [x] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- **CI/CD**: GitHub Actions workflow for staging and release deployments
- **No code changes**: This is a workflow configuration update only

## Testing

N/A - This is a CI/CD configuration change. The workflow will be validated by the next main branch commit and release tag.

## Reviewer Notes

The key changes:
1. Removed `vars.PACKMIND_EDITION` conditions from all deployment steps
2. Consolidated separate "proprietary" and "oss" jobs into unified jobs
3. Combined file updates so both value files are updated and committed together
4. Simplified step naming and commit messages to reflect the unified approach

This ensures that every commit to main updates all deployment targets consistently, preventing drift between editions.

https://claude.ai/code/session_01GnFUbyMuQHkpiRmYXHTN2H