### PR TITLE
Isolate Nx cache in Docker with dedicated volume

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The app should be available at [http://localhost:4200](http://localhost:4200)
 > reset only the containers' Nx state, run:
 >
 > ```shell
-> docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f
+> docker volume ls -q --filter name='dev-nx$' | xargs docker volume rm -f
 > ```
 >
 > For a full reset (including the database), use `docker compose down -v`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,18 @@ docker compose --profile=dev up
 
 The app should be available at [http://localhost:4200](http://localhost:4200)
 
+> **Nx state in Docker:** the containers keep their Nx cache and project
+> graph in a dedicated `dev-nx` Docker volume, isolated from the host's
+> `.nx/` directory. This prevents the Linux/Alpine containers and your
+> host (e.g. macOS) from sharing — and corrupting — the same Nx store. To
+> reset only the containers' Nx state, run:
+>
+> ```shell
+> docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f
+> ```
+>
+> For a full reset (including the database), use `docker compose down -v`.
+
 ## Migrating an existing checkout from npm to pnpm
 
 If you previously worked with npm, run the one-shot migration script from the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-nx-sock:/nx-sock
     environment:
       <<: *nx-env
@@ -114,6 +115,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-corepack-cache:/root/.cache/node/corepack
       - dev-pnpm-store:/root/.local/share/pnpm
 
@@ -137,6 +139,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-corepack-cache:/root/.cache/node/corepack
       - dev-pnpm-store:/root/.local/share/pnpm
     depends_on:
@@ -177,6 +180,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-dist:/packmind/dist
       - dev-tmp:/packmind/tmp
       - dev-nx-sock:/nx-sock
@@ -231,6 +235,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-dist:/packmind/dist
       - dev-tmp:/packmind/tmp
       - dev-nx-sock:/nx-sock
@@ -276,6 +281,7 @@ services:
     volumes:
       - .:/packmind
       - dev-node_modules:/packmind/node_modules
+      - dev-nx:/packmind/.nx
       - dev-dist:/packmind/dist
       - dev-tmp:/packmind/tmp
       - dev-nx-sock:/nx-sock
@@ -297,6 +303,7 @@ services:
 
 volumes:
   dev-nx-sock:
+  dev-nx:
   dev-postgres-data:
   dev-redis-data:
   dev-pgadmin:

--- a/downgrade_node22.sh
+++ b/downgrade_node22.sh
@@ -11,7 +11,8 @@ docker compose down
 echo "🗑️  Suppression des volumes Docker dev-nx-sock et dev-node_modules..."
 docker volume rm dev-nx-sock dev-node_modules 2>/dev/null || true
 echo "🗑️  Suppression du volume Nx des containers (dev-nx)..."
-docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f 2>/dev/null || true
+nx_volumes="$(docker volume ls -q --filter name='dev-nx$')"
+[ -n "$nx_volumes" ] && docker volume rm -f $nx_volumes 2>/dev/null || true
 
 # 2. Reset Nx (tant que node_modules et .nx existent encore)
 echo ""

--- a/downgrade_node22.sh
+++ b/downgrade_node22.sh
@@ -10,6 +10,8 @@ echo "⏹️  Arrêt des containers Docker..."
 docker compose down
 echo "🗑️  Suppression des volumes Docker dev-nx-sock et dev-node_modules..."
 docker volume rm dev-nx-sock dev-node_modules 2>/dev/null || true
+echo "🗑️  Suppression du volume Nx des containers (dev-nx)..."
+docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f 2>/dev/null || true
 
 # 2. Reset Nx (tant que node_modules et .nx existent encore)
 echo ""

--- a/migrate_node24.sh
+++ b/migrate_node24.sh
@@ -11,7 +11,8 @@ docker compose down
 echo "🗑️  Suppression des volumes Docker dev-nx-sock et dev-node_modules..."
 docker volume rm dev-nx-sock dev-node_modules 2>/dev/null || true
 echo "🗑️  Suppression du volume Nx des containers (dev-nx)..."
-docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f 2>/dev/null || true
+nx_volumes="$(docker volume ls -q --filter name='dev-nx$')"
+[ -n "$nx_volumes" ] && docker volume rm -f $nx_volumes 2>/dev/null || true
 
 # 2. Reset Nx (tant que node_modules et .nx existent encore)
 echo ""

--- a/migrate_node24.sh
+++ b/migrate_node24.sh
@@ -10,6 +10,8 @@ echo "⏹️  Arrêt des containers Docker..."
 docker compose down
 echo "🗑️  Suppression des volumes Docker dev-nx-sock et dev-node_modules..."
 docker volume rm dev-nx-sock dev-node_modules 2>/dev/null || true
+echo "🗑️  Suppression du volume Nx des containers (dev-nx)..."
+docker volume ls -q --filter name=dev-nx | xargs -r docker volume rm -f 2>/dev/null || true
 
 # 2. Reset Nx (tant que node_modules et .nx existent encore)
 echo ""


### PR DESCRIPTION
## Explanation

This change isolates the Nx cache and project graph in Docker containers by introducing a dedicated `dev-nx` Docker volume. This prevents Linux/Alpine containers and the host machine (e.g., macOS) from sharing and corrupting the same Nx store, which can occur due to platform differences.

The changes include:
- Adding `dev-nx` volume to all relevant services in `docker-compose.yml`
- Declaring the `dev-nx` volume in the volumes section
- Updating migration scripts to clean up the new volume during Node.js version upgrades
- Documenting the new behavior and reset procedures in `CONTRIBUTING.md`

## Type of Change

- [x] Improvement/Enhancement
- [x] Documentation

## Affected Components

- **Infrastructure**: Docker Compose configuration
- **Documentation**: Contributing guide
- **Scripts**: Node.js migration scripts

## Testing

No testing needed. This is a Docker configuration enhancement that:
- Adds volume mounts to existing services (non-breaking)
- Updates cleanup scripts to handle the new volume
- Provides documentation for developers

The change is straightforward configuration and documentation updates with no code logic changes.

## TODO List

- [x] Documentation Updated (CONTRIBUTING.md)

## Reviewer Notes

The implementation adds the `dev-nx:/packmind/.nx` volume mount to 6 services:
- `nx-cloud`
- `api`
- `cli`
- `api-build`
- `api-build-prod`
- `api-build-prod-arm64`

Both migration scripts (`downgrade_node22.sh` and `migrate_node24.sh`) have been updated to clean up this volume during version transitions, ensuring a fresh Nx state after Node.js upgrades.

https://claude.ai/code/session_01559xduNDjnWKxCfXXY4Qmf