### PR TITLE
♻️ chore(cli): drop PACKMIND_API_KEY_V3 in favor of PACKMIND_API_KEY

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
     secrets:
       GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PACKMIND_API_KEY_V3: ${{ secrets.PACKMIND_API_KEY_V3 }}
+      PACKMIND_API_KEY: ${{ secrets.PACKMIND_API_KEY }}
 
   # Stage 3: Docker Images (on main branch, and release tags)
   # Note: The docker workflow handles branch conditions internally based on edition

--- a/.github/workflows/nightly-packmind-update.yml
+++ b/.github/workflows/nightly-packmind-update.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Update Packmind artifacts
         uses: PackmindHub/update-packmind-artifacts@v1
         with:
-          packmind-api-key: ${{ secrets.PACKMIND_API_KEY_V3 }}
+          packmind-api-key: ${{ secrets.PACKMIND_API_KEY }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -23,7 +23,7 @@ on:
       SONAR_TOKEN:
         required: true
         description: 'Token for SonarCloud code quality analysis'
-      PACKMIND_API_KEY_V3:
+      PACKMIND_API_KEY:
         required: false
         description: 'API key to run new packmind-cli'
 
@@ -138,10 +138,10 @@ jobs:
       - name: Make binary executable
         run: chmod +x ./cli-binary/packmind-cli-linux-x64
 
-      - name: Run Packmind CLI V3
+      - name: Run Packmind CLI
         run: ./cli-binary/packmind-cli-linux-x64 lint .
         env:
-          PACKMIND_API_KEY_V3: ${{ secrets.PACKMIND_API_KEY_V3 }}
+          PACKMIND_API_KEY: ${{ secrets.PACKMIND_API_KEY }}
 
   check-cli-sync:
     if: vars.PACKMIND_EDITION == 'proprietary'

--- a/.github/workflows/tmp-cli-lint-windows.yml
+++ b/.github/workflows/tmp-cli-lint-windows.yml
@@ -39,4 +39,4 @@ jobs:
       - name: Run CLI lint
         run: node dist/apps/cli/main.cjs lint .
         env:
-          PACKMIND_API_KEY_V3: ${{ secrets.PACKMIND_API_KEY_V3 }}
+          PACKMIND_API_KEY: ${{ secrets.PACKMIND_API_KEY }}

--- a/apps/cli-e2e-tests/README.md
+++ b/apps/cli-e2e-tests/README.md
@@ -12,7 +12,7 @@ Before running these tests, you need:
    nx build packmind-cli
    ```
 
-2. **Clean Environment**: Ensure `PACKMIND_API_KEY_V3` is not set in your `.env` file or shell environment, as tests need to control authentication state
+2. **Clean Environment**: Ensure `PACKMIND_API_KEY` is not set in your `.env` file or shell environment, as tests need to control authentication state
 
 3. **Running API** (for authenticated tests only): The API server must be running. By default, tests expect it at `http://localhost:4200`, but you can override this with the `PACKMIND_INSTANCE_URL` environment variable:
 

--- a/apps/cli-e2e-tests/src/helpers/runCli.ts
+++ b/apps/cli-e2e-tests/src/helpers/runCli.ts
@@ -74,10 +74,10 @@ export async function runCli(
   const tempHome =
     opts?.home ?? fs.mkdtempSync(path.join(os.tmpdir(), 'cli-e2e-test-'));
 
-  // Build clean environment by filtering out PACKMIND_API_KEY(_V3)
+  // Build clean environment by filtering out PACKMIND_API_KEY
   const cleanEnv: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (key !== 'PACKMIND_API_KEY_V3' && key !== 'PACKMIND_API_KEY') {
+    if (key !== 'PACKMIND_API_KEY') {
       cleanEnv[key] = value;
     }
   }
@@ -88,7 +88,6 @@ export async function runCli(
     HOME: tempHome, // Override HOME to prevent loading ~/.packmind/credentials.json
     ...(opts?.apiKey && {
       PACKMIND_API_KEY: opts.apiKey,
-      PACKMIND_API_KEY_V3: opts.apiKey,
     }),
   };
 

--- a/apps/cli/CHANGELOG.MD
+++ b/apps/cli/CHANGELOG.MD
@@ -8,6 +8,8 @@
 
 ## Removed
 
+- Dropped support for the `PACKMIND_API_KEY_V3` environment variable. Use `PACKMIND_API_KEY` instead.
+
 # [0.31.0] - 2026-07-10
 
 ## Added

--- a/apps/cli/src/domain/errors/NotLoggedInError.ts
+++ b/apps/cli/src/domain/errors/NotLoggedInError.ts
@@ -5,7 +5,7 @@
 export class NotLoggedInError extends Error {
   constructor() {
     super(
-      "You're not logged in to Packmind. Please either use the login command or set the PACKMIND_API_KEY_V3 environment variable (from the Settings menu in Packmind).",
+      "You're not logged in to Packmind. Please either use the login command or set the PACKMIND_API_KEY environment variable (from the Settings menu in Packmind).",
     );
     this.name = 'NotLoggedInError';
   }

--- a/apps/cli/src/infra/commands/LinterCommand.ts
+++ b/apps/cli/src/infra/commands/LinterCommand.ts
@@ -58,7 +58,7 @@ export const lintCommand = command({
     continueOnMissingKey: flag({
       long: 'continue-on-missing-key',
       description:
-        'Skip linting and exit with status code 0 if PACKMIND_API_KEY_V3 is not set',
+        'Skip linting and exit with status code 0 if PACKMIND_API_KEY is not set',
     }),
     changedFiles: flag({
       long: 'changed-files',

--- a/apps/cli/src/infra/commands/LogoutCommand.ts
+++ b/apps/cli/src/infra/commands/LogoutCommand.ts
@@ -34,9 +34,9 @@ export const logoutCommand = command({
           logInfoConsole('No stored credentials file found.');
         }
         logConsole(
-          '\nNote: PACKMIND_API_KEY_V3 environment variable is still set.',
+          '\nNote: PACKMIND_API_KEY environment variable is still set.',
         );
-        logConsole('To fully log out, run: unset PACKMIND_API_KEY_V3');
+        logConsole('To fully log out, run: unset PACKMIND_API_KEY');
       }
     } catch (error) {
       logErrorConsole('Failed to remove credentials file.');

--- a/apps/cli/src/infra/commands/WhoamiCommand.ts
+++ b/apps/cli/src/infra/commands/WhoamiCommand.ts
@@ -75,7 +75,7 @@ export const whoamiCommand = command({
         `\nNo credentials found. Run \`packmind-cli login\` to authenticate.`,
       );
       logConsole(`\nCredentials are loaded from (in order of priority):`);
-      logConsole(`  1. PACKMIND_API_KEY_V3 environment variable`);
+      logConsole(`  1. PACKMIND_API_KEY environment variable`);
       logConsole(`  2. ${result.credentialsPath}`);
       process.exit(1);
     }

--- a/apps/cli/src/infra/utils/credentials/CredentialsService.ts
+++ b/apps/cli/src/infra/utils/credentials/CredentialsService.ts
@@ -72,8 +72,7 @@ const defaultCredentialsService = new CredentialsService();
  * Loads the API key from environment variable or credentials file.
  * Priority:
  * 1. PACKMIND_API_KEY environment variable
- * 2. PACKMIND_API_KEY_V3 environment variable
- * 3. ~/.packmind/credentials.json file
+ * 2. ~/.packmind/credentials.json file
  *
  * @returns The API key or empty string if not found
  */

--- a/apps/cli/src/infra/utils/credentials/EnvCredentialsProvider.spec.ts
+++ b/apps/cli/src/infra/utils/credentials/EnvCredentialsProvider.spec.ts
@@ -31,7 +31,6 @@ describe('EnvCredentialsProvider', () => {
   beforeEach(() => {
     process.env = { ...originalEnv };
     delete process.env.PACKMIND_API_KEY;
-    delete process.env.PACKMIND_API_KEY_V3;
   });
 
   afterAll(() => {
@@ -49,32 +48,9 @@ describe('EnvCredentialsProvider', () => {
       });
     });
 
-    describe('when only PACKMIND_API_KEY_V3 is set', () => {
-      it('returns the PACKMIND_API_KEY_V3 source name', () => {
-        process.env.PACKMIND_API_KEY_V3 = createTestApiKey({});
-        const provider = new EnvCredentialsProvider();
-
-        expect(provider.getSourceName()).toBe(
-          'PACKMIND_API_KEY_V3 environment variable',
-        );
-      });
-    });
-
     describe('when PACKMIND_API_KEY is set', () => {
       it('returns the PACKMIND_API_KEY source name', () => {
         process.env.PACKMIND_API_KEY = createTestApiKey({});
-        const provider = new EnvCredentialsProvider();
-
-        expect(provider.getSourceName()).toBe(
-          'PACKMIND_API_KEY environment variable',
-        );
-      });
-    });
-
-    describe('when both env variables are set', () => {
-      it('prefers PACKMIND_API_KEY', () => {
-        process.env.PACKMIND_API_KEY = createTestApiKey({});
-        process.env.PACKMIND_API_KEY_V3 = createTestApiKey({});
         const provider = new EnvCredentialsProvider();
 
         expect(provider.getSourceName()).toBe(
@@ -93,32 +69,21 @@ describe('EnvCredentialsProvider', () => {
       });
     });
 
-    describe('when env variables are empty', () => {
+    describe('when env variable is empty', () => {
       it('returns false', () => {
         process.env.PACKMIND_API_KEY = '';
-        process.env.PACKMIND_API_KEY_V3 = '';
         const provider = new EnvCredentialsProvider();
 
         expect(provider.hasCredentials()).toBe(false);
       });
     });
 
-    describe('when env variables are whitespace only', () => {
+    describe('when env variable is whitespace only', () => {
       it('returns false', () => {
         process.env.PACKMIND_API_KEY = '   ';
-        process.env.PACKMIND_API_KEY_V3 = '   ';
         const provider = new EnvCredentialsProvider();
 
         expect(provider.hasCredentials()).toBe(false);
-      });
-    });
-
-    describe('when PACKMIND_API_KEY_V3 is set', () => {
-      it('returns true', () => {
-        process.env.PACKMIND_API_KEY_V3 = createTestApiKey({});
-        const provider = new EnvCredentialsProvider();
-
-        expect(provider.hasCredentials()).toBe(true);
       });
     });
 
@@ -151,7 +116,7 @@ describe('EnvCredentialsProvider', () => {
     });
 
     it('returns credentials with host from API key', () => {
-      process.env.PACKMIND_API_KEY_V3 = createTestApiKey({
+      process.env.PACKMIND_API_KEY = createTestApiKey({
         host: 'https://custom.host.com',
       });
       const provider = new EnvCredentialsProvider();
@@ -162,7 +127,7 @@ describe('EnvCredentialsProvider', () => {
     });
 
     it('returns credentials with user name from JWT', () => {
-      process.env.PACKMIND_API_KEY_V3 = createTestApiKey({
+      process.env.PACKMIND_API_KEY = createTestApiKey({
         user: { name: 'John Doe', userId: 'user-123' },
       });
       const provider = new EnvCredentialsProvider();
@@ -173,7 +138,7 @@ describe('EnvCredentialsProvider', () => {
     });
 
     it('returns credentials with organization name from JWT', () => {
-      process.env.PACKMIND_API_KEY_V3 = createTestApiKey({
+      process.env.PACKMIND_API_KEY = createTestApiKey({
         organization: {
           id: 'org-123',
           name: 'My Organization',
@@ -190,7 +155,7 @@ describe('EnvCredentialsProvider', () => {
 
     it('returns credentials with expiration date from JWT', () => {
       const expTimestamp = Math.floor(Date.now() / 1000) + 3600;
-      process.env.PACKMIND_API_KEY_V3 = createTestApiKey({ exp: expTimestamp });
+      process.env.PACKMIND_API_KEY = createTestApiKey({ exp: expTimestamp });
       const provider = new EnvCredentialsProvider();
 
       const credentials = provider.loadCredentials();
@@ -200,7 +165,7 @@ describe('EnvCredentialsProvider', () => {
 
     it('returns credentials with the original API key', () => {
       const apiKey = createTestApiKey({});
-      process.env.PACKMIND_API_KEY_V3 = apiKey;
+      process.env.PACKMIND_API_KEY = apiKey;
       const provider = new EnvCredentialsProvider();
 
       const credentials = provider.loadCredentials();
@@ -210,58 +175,12 @@ describe('EnvCredentialsProvider', () => {
 
     describe('when JWT has no exp claim', () => {
       it('returns undefined expiresAt', () => {
-        process.env.PACKMIND_API_KEY_V3 = createTestApiKey({});
+        process.env.PACKMIND_API_KEY = createTestApiKey({});
         const provider = new EnvCredentialsProvider();
 
         const credentials = provider.loadCredentials();
 
         expect(credentials?.expiresAt).toBeUndefined();
-      });
-    });
-
-    describe('when both env variables are set', () => {
-      let credentials: ReturnType<EnvCredentialsProvider['loadCredentials']>;
-      const preferredKey = createTestApiKey({
-        host: 'https://preferred.host.com',
-      });
-
-      beforeEach(() => {
-        const fallbackKey = createTestApiKey({
-          host: 'https://fallback.host.com',
-        });
-        process.env.PACKMIND_API_KEY = preferredKey;
-        process.env.PACKMIND_API_KEY_V3 = fallbackKey;
-        const provider = new EnvCredentialsProvider();
-        credentials = provider.loadCredentials();
-      });
-
-      it('returns the API key from PACKMIND_API_KEY', () => {
-        expect(credentials?.apiKey).toBe(preferredKey);
-      });
-
-      it('returns the host from PACKMIND_API_KEY', () => {
-        expect(credentials?.host).toBe('https://preferred.host.com');
-      });
-    });
-
-    describe('when only PACKMIND_API_KEY_V3 is set', () => {
-      let credentials: ReturnType<EnvCredentialsProvider['loadCredentials']>;
-      const fallbackKey = createTestApiKey({
-        host: 'https://fallback.host.com',
-      });
-
-      beforeEach(() => {
-        process.env.PACKMIND_API_KEY_V3 = fallbackKey;
-        const provider = new EnvCredentialsProvider();
-        credentials = provider.loadCredentials();
-      });
-
-      it('falls back to PACKMIND_API_KEY_V3 for the API key', () => {
-        expect(credentials?.apiKey).toBe(fallbackKey);
-      });
-
-      it('falls back to PACKMIND_API_KEY_V3 for the host', () => {
-        expect(credentials?.host).toBe('https://fallback.host.com');
       });
     });
   });

--- a/apps/cli/src/infra/utils/credentials/EnvCredentialsProvider.ts
+++ b/apps/cli/src/infra/utils/credentials/EnvCredentialsProvider.ts
@@ -4,10 +4,7 @@ import {
 } from './ICredentialsProvider';
 import { decodeApiKey } from './decodeApiKey';
 
-export const ENV_VAR_NAMES = [
-  'PACKMIND_API_KEY',
-  'PACKMIND_API_KEY_V3',
-] as const;
+export const ENV_VAR_NAMES = ['PACKMIND_API_KEY'] as const;
 
 export class EnvCredentialsProvider implements ICredentialsProvider {
   getSourceName(): string {

--- a/apps/doc/getting-started/gs-cli-setup.mdx
+++ b/apps/doc/getting-started/gs-cli-setup.mdx
@@ -147,7 +147,7 @@ This displays:
 
 ### API Key Authentication (Alternative)
 
-You can authenticate using the `PACKMIND_API_KEY_V3` environment variable instead of the interactive login flow. This is the recommended approach for:
+You can authenticate using the `PACKMIND_API_KEY` environment variable instead of the interactive login flow. This is the recommended approach for:
 
 - **CI/CD pipelines** — Automated environments where interactive login isn't possible
 - **Docker containers** — Pass the API key as an environment variable
@@ -164,10 +164,10 @@ You can authenticate using the `PACKMIND_API_KEY_V3` environment variable instea
 
 #### Setting the Environment Variable
 
-Set the `PACKMIND_API_KEY_V3` environment variable with your API key:
+Set the `PACKMIND_API_KEY` environment variable with your API key:
 
 ```bash
-export PACKMIND_API_KEY_V3="your-api-key-here"
+export PACKMIND_API_KEY="your-api-key-here"
 ```
 
 To make this permanent, add it to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.).

--- a/apps/doc/playbook-maintenance/auto-update-artifacts.mdx
+++ b/apps/doc/playbook-maintenance/auto-update-artifacts.mdx
@@ -64,18 +64,16 @@ When standards, commands, or skills evolve on Packmind, your repositories don't 
               fetch-depth: 0 # required so the action can diff and commit
           - uses: PackmindHub/update-packmind-artifacts@v1
             with:
-              packmind-api-key: ${{ secrets.PACKMIND_API_KEY_V3 }}
+              packmind-api-key: ${{ secrets.PACKMIND_API_KEY }}
     ```
 
     ### Configure the API key secret
 
     In your repository: **Settings → Secrets and variables → Actions → New repository secret**.
 
-    | Secret name           | Value                                         |
-    | --------------------- | --------------------------------------------- |
-    | `PACKMIND_API_KEY_V3` | The API key from your Packmind user profile   |
-
-    <Note>The `_V3` suffix is the current API key format used by Packmind — keep the name as-is.</Note>
+    | Secret name        | Value                                       |
+    | ------------------ | ------------------------------------------- |
+    | `PACKMIND_API_KEY` | The API key from your Packmind user profile |
 
     Common action inputs (branch name, PR title, target branch, Node version) are documented on the [Marketplace listing](https://github.com/marketplace/actions/update-packmind-artifacts).
 
@@ -142,14 +140,12 @@ When standards, commands, or skills evolve on Packmind, your repositories don't 
 
     In **Settings → CI/CD → Variables**, add both variables and mark them as **Masked**:
 
-    | Variable              | Value                                                                                    |
-    | --------------------- | ---------------------------------------------------------------------------------------- |
-    | `PACKMIND_API_KEY_V3` | The API key from your Packmind user profile                                              |
-    | `PACKMIND_BOT_TOKEN`  | A Project Access Token with `write_repository` and `api` scopes, role ≥ Developer       |
+    | Variable             | Value                                                                              |
+    | -------------------- | ---------------------------------------------------------------------------------- |
+    | `PACKMIND_API_KEY`   | The API key from your Packmind user profile                                        |
+    | `PACKMIND_BOT_TOKEN` | A Project Access Token with `write_repository` and `api` scopes, role ≥ Developer  |
 
     To create the token: **Settings → Access Tokens → Add new token** with scopes `write_repository` and `api`.
-
-    <Note>The `_V3` suffix is the current API key format used by Packmind — keep the name as-is.</Note>
 
     ### Schedule the job
 
@@ -191,8 +187,8 @@ The example uses `0 2 * * 1-5` — every weeknight at 02:00 UTC (03:00 Paris in 
 
 <Accordion title="Authentication error from packmind-cli">
   The API key is missing, mistyped, or revoked. Regenerate it from your Packmind
-  profile and update the `PACKMIND_API_KEY_V3` secret. Make sure the variable
-  name matches exactly — including the `_V3` suffix.
+  profile and update the `PACKMIND_API_KEY` secret. Make sure the variable name
+  matches exactly.
 </Accordion>
 
 <Accordion title="The PR/MR exists but doesn't reflect the latest changes">

--- a/apps/doc/tools/cli.mdx
+++ b/apps/doc/tools/cli.mdx
@@ -162,10 +162,10 @@ To clear stored credentials:
 packmind-cli logout
 ```
 
-This removes the credentials file. If you also have `PACKMIND_API_KEY_V3` set as an environment variable, you'll need to unset it separately:
+This removes the credentials file. If you also have `PACKMIND_API_KEY` set as an environment variable, you'll need to unset it separately:
 
 ```bash
-unset PACKMIND_API_KEY_V3
+unset PACKMIND_API_KEY
 ```
 
 ### Whoami Command
@@ -184,9 +184,9 @@ This displays:
 - User name
 - Credential expiration status
 
-### API Key Authentication (PACKMIND_API_KEY_V3)
+### API Key Authentication (PACKMIND_API_KEY)
 
-You can authenticate using the `PACKMIND_API_KEY_V3` environment variable instead of the interactive login flow. This is the recommended approach for:
+You can authenticate using the `PACKMIND_API_KEY` environment variable instead of the interactive login flow. This is the recommended approach for:
 
 - **CI/CD pipelines** — Automated environments where interactive login isn't possible
 - **Docker containers** — Pass the API key as an environment variable
@@ -203,16 +203,16 @@ You can authenticate using the `PACKMIND_API_KEY_V3` environment variable instea
 
 #### Setting the Environment Variable
 
-Set the `PACKMIND_API_KEY_V3` environment variable with your API key:
+Set the `PACKMIND_API_KEY` environment variable with your API key:
 
 ```bash
-export PACKMIND_API_KEY_V3="your-api-key-here"
+export PACKMIND_API_KEY="your-api-key-here"
 ```
 
 To make this permanent, add it to your shell configuration file (`~/.bashrc`, `~/.zshrc`, etc.):
 
 ```bash
-echo 'export PACKMIND_API_KEY_V3="your-api-key-here"' >> ~/.zshrc
+echo 'export PACKMIND_API_KEY="your-api-key-here"' >> ~/.zshrc
 source ~/.zshrc
 ```
 
@@ -221,14 +221,14 @@ source ~/.zshrc
 ```yaml
 - name: Install Packmind packages
   env:
-    PACKMIND_API_KEY_V3: ${{ secrets.PACKMIND_API_KEY_V3 }}
+    PACKMIND_API_KEY: ${{ secrets.PACKMIND_API_KEY }}
   run: packmind-cli install
 ```
 
 <Tip>
   **Credential Priority** — When both a credentials file and the
-  `PACKMIND_API_KEY_V3` environment variable exist, the environment variable
-  takes precedence.
+  `PACKMIND_API_KEY` environment variable exist, the environment variable takes
+  precedence.
 </Tip>
 
 ## Init Command

--- a/apps/frontend/src/domain/accounts/components/LocalEnvironmentSetup/components/ApiKeyGenerator.tsx
+++ b/apps/frontend/src/domain/accounts/components/LocalEnvironmentSetup/components/ApiKeyGenerator.tsx
@@ -101,8 +101,8 @@ export const ApiKeyGenerator: React.FC<IApiKeyGeneratorProps> = ({
               <PMAlert.Title>API Key Generated Successfully!</PMAlert.Title>
               <PMAlert.Description>
                 Copy this key now - it won't be shown again. Set it as the{' '}
-                <code>PACKMIND_API_KEY_V3</code> environment variable. Expires
-                on {formatExpirationDate(generatedKeyExpiresAt)}
+                <code>PACKMIND_API_KEY</code> environment variable. Expires on{' '}
+                {formatExpirationDate(generatedKeyExpiresAt)}
               </PMAlert.Description>
             </PMAlert.Content>
           </PMAlert.Root>

--- a/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/AutomateUpdatesStep.spec.tsx
+++ b/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/AutomateUpdatesStep.spec.tsx
@@ -140,7 +140,7 @@ describe('AutomateUpdatesStep', () => {
     const panel = getActivePanel();
     expect(
       within(panel).getByText(
-        /set PACKMIND_API_KEY_V3 and PACKMIND_BOT_TOKEN in Settings → CI\/CD → Variables/i,
+        /set PACKMIND_API_KEY and PACKMIND_BOT_TOKEN in Settings → CI\/CD → Variables/i,
       ),
     ).toBeInTheDocument();
     expect(
@@ -157,7 +157,7 @@ describe('AutomateUpdatesStep', () => {
     const panel = getActivePanel();
     expect(
       within(panel).getByText(
-        /set PACKMIND_API_KEY_V3 in Settings → Secrets and variables → Actions/i,
+        /set PACKMIND_API_KEY in Settings → Secrets and variables → Actions/i,
       ),
     ).toBeInTheDocument();
   });

--- a/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/constants.ts
+++ b/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/constants.ts
@@ -28,7 +28,7 @@ export const PROVIDER_METADATA: Record<AutoUpdateProvider, IProviderMetadata> =
       label: 'GitHub Actions',
       workflowFilePath: '.github/workflows/nightly-packmind-update.yml',
       cronInYaml: true,
-      secretNames: ['PACKMIND_API_KEY_V3'],
+      secretNames: ['PACKMIND_API_KEY'],
       scheduleLocationHint:
         'The schedule is set directly in the workflow file below.',
       secretsLocationPath: 'Settings → Secrets and variables → Actions',
@@ -37,7 +37,7 @@ export const PROVIDER_METADATA: Record<AutoUpdateProvider, IProviderMetadata> =
       label: 'GitLab CI',
       workflowFilePath: '.gitlab-ci.yml',
       cronInYaml: false,
-      secretNames: ['PACKMIND_API_KEY_V3', 'PACKMIND_BOT_TOKEN'],
+      secretNames: ['PACKMIND_API_KEY', 'PACKMIND_BOT_TOKEN'],
       scheduleLocationHint:
         'In GitLab: Build → Pipeline schedules → New schedule, then paste the cron expression below.',
       secretsLocationPath: 'Settings → CI/CD → Variables',

--- a/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/yaml.test.ts
+++ b/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/yaml.test.ts
@@ -26,9 +26,9 @@ describe('buildWorkflowYaml', () => {
       );
     });
 
-    it('references the PACKMIND_API_KEY_V3 secret', () => {
+    it('references the PACKMIND_API_KEY secret', () => {
       expect(buildWorkflowYaml('github', '0 2 * * 1-5')).toContain(
-        'secrets.PACKMIND_API_KEY_V3',
+        'secrets.PACKMIND_API_KEY',
       );
     });
 
@@ -55,7 +55,7 @@ describe('buildWorkflowYaml', () => {
     });
 
     it('references PACKMIND_BOT_TOKEN for git push authentication', () => {
-      // PACKMIND_API_KEY_V3 is consumed by the CLI from the GitLab CI env
+      // PACKMIND_API_KEY is consumed by the CLI from the GitLab CI env
       // automatically, so it is not referenced literally in the YAML.
       const yaml = buildWorkflowYaml('gitlab', '0 2 * * 1-5');
       expect(yaml).toContain('PACKMIND_BOT_TOKEN');

--- a/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/yaml.ts
+++ b/apps/frontend/src/domain/setup/components/AutomateUpdatesStep/yaml.ts
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
       - uses: packmind/update-packmind-artifacts@v1
         with:
-          api-key: \${{ secrets.PACKMIND_API_KEY_V3 }}
+          api-key: \${{ secrets.PACKMIND_API_KEY }}
 `;
 
 const GITLAB_TEMPLATE = `stages:

--- a/apps/frontend/src/domain/setup/components/SetupCliPage.tsx
+++ b/apps/frontend/src/domain/setup/components/SetupCliPage.tsx
@@ -65,7 +65,7 @@ const ApiKeyContent: React.FC = () => {
     <PMVStack align="stretch" gap={4} width="full">
       <SectionCard
         title="API key"
-        description="Generate an API key and set it as the PACKMIND_API_KEY_V3 environment variable. It will expire after 3 months."
+        description="Generate an API key and set it as the PACKMIND_API_KEY environment variable. It will expire after 3 months."
       >
         <ApiKeyGenerator apiKey={apiKey} />
       </SectionCard>

--- a/scripts/precommit-lint.sh
+++ b/scripts/precommit-lint.sh
@@ -22,7 +22,7 @@ HOST=$(echo "$OUTPUT" | grep "^Host:" | awk '{print $2}')
 ORG=$(echo "$OUTPUT" | grep "^Organization:" | awk '{print $2}')
 
 if [[ "$HOST" != "$EXPECTED_HOST" || "$ORG" != "$EXPECTED_ORG" ]]; then
-  echo "ERROR: PACKMIND_API_KEY_V3 is incorrect."
+  echo "ERROR: PACKMIND_API_KEY is incorrect."
   echo "  Expected host: $EXPECTED_HOST, got: $HOST"
   echo "  Expected org:  $EXPECTED_ORG, got: $ORG"
   exit 1


### PR DESCRIPTION
Remove support for the legacy PACKMIND_API_KEY_V3 environment variable from the CLI credentials provider, and update every user-facing message, CI workflow, frontend setup UI, and doc that referenced it to use PACKMIND_API_KEY instead.

## Explanation

<!-- Describe the changes in this pull request -->

<!-- Reference any existing issue, drop the section otherwise -->
Relates to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

<!-- Help reviewers understand scope -->

- Domain packages affected:
- Frontend / Backend / Both:
- Breaking changes (if any):

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
<!-- Describe specific test scenarios -->


## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

<!-- Anything reviewers should pay special attention to? -->
<!-- Areas where you'd like specific feedback? -->

