### PR TITLE
ci: add weekly CLAUDE.md improvement workflow

### DIFF
--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -1,0 +1,89 @@
+name: Weekly CLAUDE.md Improvement
+
+on:
+  schedule:
+    - cron: '0 2 * * 1' # Every Monday at 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  improve-claude-md:
+    runs-on: ${{ vars.ACTION_RUNNER_TAG || 'self-hosted' }}
+    timeout-minutes: 45
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # PAT so the pull request opened below triggers CI (a PR opened with the
+          # default GITHUB_TOKEN would not).
+          token: ${{ secrets.PACKMIND_BOT_PAT }}
+          clean: true
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code@latest
+
+      - name: Install claude-md-management plugin
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: claude plugin install claude-md-management@claude-plugins-official
+
+      - name: Improve CLAUDE.md files with Claude
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          mapfile -t FILES < <(find . -name CLAUDE.md -not -path '*/node_modules/*')
+          echo "Found ${#FILES[@]} CLAUDE.md file(s)"
+          PROMPT_TEMPLATE=$(cat <<'EOF'
+          You are Claude Code running NON-INTERACTIVELY in CI (no human is available to confirm anything).
+          Use the claude-md-improver skill (from the installed claude-md-management plugin) to audit and
+          improve the CLAUDE.md file at: {{FILE}}
+
+          Because this is non-interactive, APPLY fixes directly to the file. Only apply HIGH and MEDIUM
+          priority fixes that have a clear, unambiguous positive impact (e.g. outdated or incorrect
+          commands, broken links or wrong file paths, stale structure or architecture references). Do NOT
+          make low-priority, subjective, or stylistic changes, and skip anything ambiguous.
+
+          CRITICAL: Never modify content inside sections delimited by the markers
+          "<!-- start: Packmind standards -->" and "<!-- end: Packmind standards -->". Leave those regions
+          byte-for-byte unchanged; only edit content outside them.
+
+          Do not create, delete, or rename files - only edit this one CLAUDE.md file.
+          EOF
+          )
+          for file in "${FILES[@]}"; do
+            [ -z "$file" ] && continue
+            echo "::group::Improving $file"
+            prompt="${PROMPT_TEMPLATE//\{\{FILE\}\}/$file}"
+            claude -p "$prompt" \
+              --permission-mode acceptEdits \
+              --allowedTools "Read,Edit,Glob,Grep"
+            echo "::endgroup::"
+          done
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.PACKMIND_BOT_PAT }}
+          branch: chore/weekly-claude-md-improvements
+          delete-branch: true
+          commit-message: 'chore: weekly CLAUDE.md improvements via claude-md-improver'
+          title: 'chore: weekly CLAUDE.md improvements'
+          body: |
+            Automated weekly run of the Anthropic `claude-md-improver` skill.
+
+            - Applied only high/medium priority fixes with clear impact.
+            - Packmind standards sections were left untouched.
+
+            Please review before merging.
+          labels: automated


### PR DESCRIPTION
## Explanation

Adds a scheduled GitHub Actions workflow (`.github/workflows/weekly-claude-md-improver.yml`) that keeps the repo's `CLAUDE.md` files current.

Every Monday at 02:00 UTC (matching the nightly job's slot), plus a manual `workflow_dispatch`, the job:
1. Installs the Claude Code CLI and the official `claude-md-management` plugin (`claude plugin install claude-md-management@claude-plugins-official`).
2. Discovers all `CLAUDE.md` files via `find . -name CLAUDE.md` (9 today).
3. Runs the `claude-md-improver` skill non-interactively on each file, applying only **high/medium** priority fixes with clear impact and leaving `<!-- start/end: Packmind standards -->` regions untouched.
4. Opens a pull request with the results for human review (no-op when nothing needs fixing).

Conventions mirror the existing `nightly-packmind-update.yml`: self-hosted runner, `contents`/`pull-requests: write`, checkout of `main` with `PACKMIND_BOT_PAT` so the generated PR triggers CI.

Relates to #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none (CI only — adds one workflow file)
- Frontend / Backend / Both: neither (CI/CD)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
- Validated workflow YAML parses cleanly.
- Dry-ran the step's shell logic locally: `find` + `mapfile` locate all 9 `CLAUDE.md` files and the `{{FILE}}` placeholder substitutes correctly per file.
- Full end-to-end run requires the new `CLAUDE_CODE_OAUTH_TOKEN` Actions secret (see Reviewer Notes), then trigger via **Actions → Weekly CLAUDE.md Improvement → Run workflow**.

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

- **Prerequisite before first run:** add a new repo Actions secret `CLAUDE_CODE_OAUTH_TOKEN` (generate via `claude setup-token`). `PACKMIND_BOT_PAT` already exists and is reused.
- The headless run is deliberately restricted with `--allowedTools "Read,Edit,Glob,Grep"` (no `Bash`/`Write`), so Claude can only edit existing `CLAUDE.md` files; git and PR creation are handled by the workflow itself.
- `--bare` is intentionally **not** used, since it would skip plugin discovery and the skill would not load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLmVqqhtcv9Y9c23yFS7hp)_