### PR TITLE
ci: refresh plugins marketplace before installing claude-md-management

### DIFF
--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -35,7 +35,13 @@ jobs:
       - name: Install claude-md-management plugin
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: claude plugin install claude-md-management@claude-plugins-official
+        run: |
+          # Refresh the official marketplace first: the CLI ships an auto-registered
+          # but stale snapshot that can predate this plugin. `add` fetches the latest
+          # manifest; if it's already registered, fall back to `update`.
+          claude plugin marketplace add anthropics/claude-plugins-official \
+            || claude plugin marketplace update claude-plugins-official
+          claude plugin install claude-md-management@claude-plugins-official
 
       - name: Improve CLAUDE.md files with Claude
         env:


### PR DESCRIPTION
## Explanation

Follow-up fix to the weekly CLAUDE.md improvement workflow added in #403.

The first `workflow_dispatch` run failed at the plugin install step:

```
✘ Failed to install plugin "claude-md-management@claude-plugins-official":
  Plugin "claude-md-management" not found in marketplace "claude-plugins-official".
  Your local copy may be out of date — try `claude plugin marketplace update claude-plugins-official`.
```

Root cause: the Claude Code CLI ships an auto-registered but **stale** snapshot of the `claude-plugins-official` marketplace that predates the `claude-md-management` plugin, so `plugin install` can't find it. The identifiers are correct (verified against the upstream `marketplace.json`); the marketplace just needs refreshing.

Fix: refresh the marketplace before installing — `plugin marketplace add` fetches the latest manifest, falling back to `plugin marketplace update` when it is already registered.

```yaml
claude plugin marketplace add anthropics/claude-plugins-official \
  || claude plugin marketplace update claude-plugins-official
claude plugin install claude-md-management@claude-plugins-official
```

Relates to #403

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none (CI only — one workflow file)
- Frontend / Backend / Both: neither (CI/CD)
- Breaking changes (if any): none

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [ ] Test coverage maintained or improved

**Test Details:**
- Reproduced the failure in run 30468308843 (plugin not found in stale marketplace).
- Validated the updated workflow YAML parses cleanly and the plugin step contains the marketplace refresh.
- Full end-to-end verification: trigger **Actions → Weekly CLAUDE.md Improvement → Run workflow** once merged (requires the `CLAUDE_CODE_OAUTH_TOKEN` secret).

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

- Single-line-of-effect change to the `Install claude-md-management plugin` step; nothing else in the workflow changed.
- The `|| update` fallback makes the step robust whether or not the marketplace is already registered on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLmVqqhtcv9Y9c23yFS7hp)_