### PR TITLE
Enhance claude-md-improver with skill inventory and deduplication

### DIFF
--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -50,31 +50,78 @@ jobs:
           set -euo pipefail
           mapfile -t FILES < <(find . -name CLAUDE.md -not -path '*/node_modules/*')
           echo "Found ${#FILES[@]} CLAUDE.md file(s)"
-          PROMPT_TEMPLATE=$(cat <<'EOF'
+
+          # Skill inventory: every SKILL.md under any .claude/skills tree, at any depth - .claude/skills
+          # can itself live in a sub-directory, and skills may be nested. Only the YAML frontmatter
+          # (name + description) is collected; skill bodies are never inlined into the prompt.
+          mapfile -t SKILL_FILES < <(find . -path '*/.claude/skills/*/SKILL.md' -not -path '*/node_modules/*' | sort)
+          SKILLS_INVENTORY=""
+          SKILLS_COUNT=0
+          for skill in "${SKILL_FILES[@]}"; do
+            [ -z "$skill" ] && continue
+            frontmatter=$(awk '
+              NR==1 && $0 !~ /^---[[:space:]]*$/ {exit}
+              /^---[[:space:]]*$/ {n++; if (n==2) exit; next}
+              n!=1 {next}
+              /^[A-Za-z0-9_-]+:/ {keep = ($0 ~ /^(name|description):/); if (keep) print; next}
+              keep
+            ' "$skill")
+            [ -z "$frontmatter" ] && continue
+            SKILLS_INVENTORY+="- ${skill}"$'\n'"${frontmatter}"$'\n\n'
+            SKILLS_COUNT=$((SKILLS_COUNT + 1))
+          done
+          echo "Loaded frontmatter for $SKILLS_COUNT skill(s)"
+          [ "$SKILLS_COUNT" -eq 0 ] && SKILLS_INVENTORY="(no skills found in this repository)"
+
+          for file in "${FILES[@]}"; do
+          [ -z "$file" ] && continue
+          echo "::group::Improving $file"
+          # Unquoted heredoc: the shell expands $file and $SKILLS_INVENTORY below. Keep the prompt text
+          # free of '$' and backticks so nothing else gets interpreted. (Do not switch back to
+          # placeholder substitution: '&' inside a bash replacement expands to the matched text, which
+          # corrupts any skill description containing an ampersand.) The heredoc body and its EOF
+          # terminator must stay flush with the enclosing block, hence the un-indented loop body.
+          prompt=$(cat <<EOF
           You are Claude Code running NON-INTERACTIVELY in CI (no human is available to confirm anything).
-          Use the claude-md-improver skill (from the installed claude-md-management plugin) to audit and
-          improve the CLAUDE.md file at: {{FILE}}
+
+          STEP 1 - Load the skill inventory below before doing anything else. It lists every skill available
+          in this repository (each SKILL.md found under any .claude/skills directory, at any depth), with
+          only its YAML frontmatter: the skill name and its description.
+
+          SKILL INVENTORY:
+          $SKILLS_INVENTORY
+
+          STEP 2 - Use the claude-md-improver skill (from the installed claude-md-management plugin) to
+          audit and improve the CLAUDE.md file at: $file
 
           Because this is non-interactive, APPLY fixes directly to the file. Only apply HIGH and MEDIUM
           priority fixes that have a clear, unambiguous positive impact (e.g. outdated or incorrect
           commands, broken links or wrong file paths, stale structure or architecture references). Do NOT
           make low-priority, subjective, or stylistic changes, and skip anything ambiguous.
 
+          DEDUPLICATION AGAINST SKILLS: CLAUDE.md must not restate what a skill already carries. Any
+          instruction, procedure, convention or example in this CLAUDE.md that is already covered by one of
+          the skills listed above is duplicate content: delete it outright, leaving no pointer or
+          cross-reference in its place. Rules:
+          - Delete only when the skill clearly and fully owns that topic. If a skill covers the topic only
+            partially, or you are in any doubt, leave the CLAUDE.md text untouched.
+          - You may read a SKILL.md body when its frontmatter description alone cannot settle whether
+            coverage is full.
+          - Never delete content that no skill covers.
+          - If the inventory above is "(no skills found in this repository)", skip deduplication entirely.
+
           CRITICAL: Never modify content inside sections delimited by the markers
           "<!-- start: Packmind standards -->" and "<!-- end: Packmind standards -->". Leave those regions
-          byte-for-byte unchanged; only edit content outside them.
+          byte-for-byte unchanged; only edit content outside them - this outranks the deduplication rules
+          above, even if a skill appears to cover that content.
 
           Do not create, delete, or rename files - only edit this one CLAUDE.md file.
           EOF
           )
-          for file in "${FILES[@]}"; do
-            [ -z "$file" ] && continue
-            echo "::group::Improving $file"
-            prompt="${PROMPT_TEMPLATE//\{\{FILE\}\}/$file}"
-            claude -p "$prompt" \
-              --permission-mode acceptEdits \
-              --allowedTools "Read,Edit,Glob,Grep"
-            echo "::endgroup::"
+          claude -p "$prompt" \
+            --permission-mode acceptEdits \
+            --allowedTools "Read,Edit,Glob,Grep"
+          echo "::endgroup::"
           done
 
       - name: Create Pull Request
@@ -89,6 +136,8 @@ jobs:
             Automated weekly run of the Anthropic `claude-md-improver` skill.
 
             - Applied only high/medium priority fixes with clear impact.
+            - Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
+              deletions are expected in this diff - please check none of them went too far.
             - Packmind standards sections were left untouched.
 
             Please review before merging.

--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -69,6 +69,10 @@ jobs:
             [ -z "$frontmatter" ] && continue
             SKILLS_INVENTORY+="- ${skill}"$'\n'"${frontmatter}"$'\n\n'
             SKILLS_COUNT=$((SKILLS_COUNT + 1))
+            # Logged per skill so a regression that silently empties the inventory (a gitignored
+            # .claude/skills, a narrowed checkout, an edited find pattern) is visible in the run log
+            # instead of quietly degrading into "skip deduplication".
+            echo "  + $skill"
           done
           echo "Loaded frontmatter for $SKILLS_COUNT skill(s)"
           [ "$SKILLS_COUNT" -eq 0 ] && SKILLS_INVENTORY="(no skills found in this repository)"


### PR DESCRIPTION
## Explanation

This PR enhances the weekly `claude-md-improver` workflow to make Claude aware of repository skills and automatically deduplicate content between CLAUDE.md files and `.claude/skills/*/SKILL.md` files.

**Key changes:**

1. **Skill Inventory Loading**: The workflow now discovers all SKILL.md files under any `.claude/skills` directory (at any depth) and extracts their YAML frontmatter (name and description only). This inventory is passed to Claude before processing each CLAUDE.md file.

2. **Deduplication Logic**: Claude is instructed to delete any content from CLAUDE.md that is already fully covered by a skill in the inventory, with clear rules:
   - Only delete when a skill clearly and fully owns the topic
   - Preserve content if coverage is partial or ambiguous
   - Never delete content not covered by any skill
   - Skip deduplication entirely if no skills are found

3. **Prompt Restructuring**: The prompt is now generated dynamically inside the loop (per file) rather than using template substitution, allowing proper shell variable expansion for both the file path and the skills inventory without escaping issues.

4. **Packmind Standards Protection**: Clarified that Packmind standards sections are protected even from deduplication rules.

5. **PR Description Update**: Added a note to the auto-generated PR body explaining that deletions are expected and should be reviewed.

## Type of Change

- [x] Improvement/Enhancement
- [x] Refactoring

## Affected Components

- CI/CD: `.github/workflows/weekly-claude-md-improver.yml`
- No code changes; workflow enhancement only

## Testing

N/A — This is a workflow configuration change. The workflow will be validated on its next scheduled run (weekly) and can be manually triggered for testing.

## TODO List

- [x] Documentation Updated (inline comments in workflow)

## Reviewer Notes

The key technical detail: the prompt is now generated with an unquoted heredoc inside the loop to allow proper shell variable expansion (`$file` and `$SKILLS_INVENTORY`). This avoids the pitfalls of placeholder substitution (where `&` in skill descriptions would corrupt the replacement).

The deduplication rules are intentionally conservative to avoid over-deleting content that might be only partially covered by skills or where the relationship is ambiguous.

https://claude.ai/code/session_014avgTV2qniBtWA62HRpvmT