### PR TITLE
ci: restrict weekly CLAUDE.md improver to PackmindHub/packmind

### DIFF
--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -11,6 +11,10 @@ permissions:
 
 jobs:
   improve-claude-md:
+    # This workflow file is synced into other repositories (including our proprietary
+    # codebase). It must only ever run on PackmindHub/packmind: everywhere else the job
+    # is skipped, so the schedule and workflow_dispatch triggers become no-ops.
+    if: github.repository == 'PackmindHub/packmind'
     runs-on: ${{ vars.ACTION_RUNNER_TAG || 'self-hosted' }}
     timeout-minutes: 45
     steps:


### PR DESCRIPTION
This workflow file is synced into other repositories, including our
proprietary codebase. Guard the job with a repository check so the
schedule and workflow_dispatch triggers are no-ops anywhere else.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0199JHEYeQ12V1n8ww7azZNk