### PR TITLE
chore: weekly CLAUDE.md improvements

### DIFF
--- a/apps/cli/CLAUDE.md
+++ b/apps/cli/CLAUDE.md
@@ -11,8 +11,6 @@ per-domain subdirectories under `src/infra/commands/`, gateway methods, use case
 by the three standards in `.claude/rules/packmind/`: *CLI Command Structure*, *CLI Gateway
 Implementation*, *CLI Use Case Structure*. A command file must **not** contain handler logic.
 
-E2E coverage for the CLI lives in `apps/cli-e2e-tests/`; see the **`cli-e2e-test-authoring`** skill.
-
 ## Stack specifics
 
 - **cmd-ts** for type-safe argument parsing and routing

--- a/packages/git/CLAUDE.md
+++ b/packages/git/CLAUDE.md
@@ -36,7 +36,7 @@ establish which before changing credential handling.
 
 ## Reuse
 
-`src/application/services/gitInfoHelpers.ts` already normalises owner/repo/branch/URL shapes across
+`src/application/services/gitInfoHelpers.ts` already normalises owner/repo/URL shapes across
 vendors. Use it instead of parsing remote URLs again.
 
 Shared package conventions (env tags, layout, `/test` subpath, branded IDs): [../CLAUDE.md](../CLAUDE.md)


### PR DESCRIPTION
Automated weekly run of the Anthropic `claude-md-improver` skill.

- Applied only high/medium priority fixes with clear impact.
- Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
  deletions are expected in this diff - please check none of them went too far.
- Packmind standards sections were left untouched.

Please review before merging.