### PR TITLE
chore: weekly CLAUDE.md improvements

### DIFF
--- a/apps/CLAUDE.md
+++ b/apps/CLAUDE.md
@@ -10,7 +10,7 @@ This directory contains all deployable applications in the Packmind monorepo.
 
 ### Frontend & CLI
 
-- **frontend** - React Router v7 SPA
+- **frontend** - React Router v8 SPA
 - **cli** - Command-line interface built with cmd-ts (Nx project name: `packmind-cli`)
 - **playground** - UI/UX prototype sandbox — see the `working-with-playground-app` skill, which owns
   how to run it and the rules for building a prototype. There is intentionally no

--- a/apps/cli/CLAUDE.md
+++ b/apps/cli/CLAUDE.md
@@ -8,10 +8,8 @@ Packmind CLI. Nx project name is `packmind-cli`.
 
 Everything else about authoring a command — the `*Command.ts` / `*Handler.ts` split, grouping into
 per-domain subdirectories under `src/infra/commands/`, gateway methods, use case structure — is owned
-by the three standards in `.claude/rules/packmind/`: *CLI Command Structure*, *CLI Gateway
+by the three standards in `apps/cli/.claude/rules/packmind/`: *CLI Command Structure*, *CLI Gateway
 Implementation*, *CLI Use Case Structure*. A command file must **not** contain handler logic.
-
-E2E coverage for the CLI lives in `apps/cli-e2e-tests/`; see the **`cli-e2e-test-authoring`** skill.
 
 ## Stack specifics
 

--- a/apps/e2e-tests/CLAUDE.md
+++ b/apps/e2e-tests/CLAUDE.md
@@ -6,7 +6,7 @@ Everything about writing and running these tests is owned elsewhere — do not l
 
 - **How to write and run a spec** (where files go, choosing a fixture, writing a Page Object, seeding
   through the API, feature flags, the commands): the **`create-run-e2e-tests`** skill.
-- **Mandatory conventions**: the two standards in `.claude/rules/packmind/` — *[E2E] Page object* and
+- **Mandatory conventions**: the two standards in `apps/e2e-tests/.claude/rules/packmind/` — *[E2E] Page object* and
   *[E2E] Writing E2E tests*. Both are `alwaysApply: true`, so they are already in context.
 
 Only `chromium` is enabled in `playwright.config.ts`; the Firefox, WebKit, mobile and branded-browser

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -1,16 +1,14 @@
 # Frontend Application
 
-React Router v7 SPA for Packmind.
+React Router v8 SPA for Packmind.
 
 ## Owned elsewhere
 
 - **Route data flow** — how routes fetch, where query options and hooks live, gateway typing:
-  `.claude/rules/packmind/standard-frontend-data-flow.md`. It is `alwaysApply: true`, so its rules are
-  already in context; do not look for them here.
+  `apps/frontend/.claude/rules/packmind/standard-frontend-data-flow.md`. It is `alwaysApply: true`, so
+  its rules are already in context; do not look for them here.
 - **Query keys**, **navigation** (the `routes` utility and `useNavigation()`), and **error handling**:
-  the other three standards in `.claude/rules/packmind/`.
-- **UI components** — use `@packmind/ui` PM components, never `@chakra-ui/react` directly: the
-  **`working-with-pm-design-kit`** skill.
+  the other three standards in `apps/frontend/.claude/rules/packmind/`.
 
 ## Stack specifics
 

--- a/packages/editions/CLAUDE.md
+++ b/packages/editions/CLAUDE.md
@@ -21,6 +21,7 @@ In OSS, all of these resolve to `packages/editions/src/index.ts`:
 - `@packmind/import-practices-legacy`
 - `@packmind/spaces-management`
 - `@packmind/playbook-change-management` (and `@packmind/playbook-change-management/test`)
+- `@packmind/marketplaces`
 
 So a "cannot find module `@packmind/linter`" or a missing export from one of those specifiers is
 almost always a missing `export *` in `src/index.ts`, not a missing dependency.
@@ -38,6 +39,7 @@ One folder per seam module, each with its own `*Hexa.ts`:
 | `src/oss/spaces-management/` | `SpacesManagementHexa` |
 | `src/oss/playbook-change-management/` | `PlaybookChangeManagementHexa` |
 | `src/oss/practices-import-legacy/` | `ImportPracticeLegacyHexa` |
+| `src/oss/marketplaces/` | `MarketplacesHexa` |
 
 `src/oss/apiHexaPlugins.ts` exports `apiHexaPlugins`, an array of `BaseHexa` constructors the API
 registers **in addition** to the core hexas. It is the documented override point for edition-specific

--- a/packages/integration-tests/CLAUDE.md
+++ b/packages/integration-tests/CLAUDE.md
@@ -46,7 +46,6 @@ targeted error.
 | `helpers/TestApp.ts` | reach a domain through `testContext.testApp.<domain>Hexa.getAdapter()` |
 | `helpers/createIntegrationTestFixture.ts` | schema created once per file, tables truncated between tests |
 | `helpers/DataFactory.ts` / `DataQuery.ts` | seed and read fixture data |
-| `helpers/testMatchers.ts` | shared custom matchers |
 | `helpers/StubStandardsListener.ts` | assert standards domain events without a real listener |
 
 `jest.config.ts` sets a 30s timeout and `maxWorkers: 4` — each spec file gets its own database


### PR DESCRIPTION
Automated weekly run of the `improve-claude-md` skill, which delegates the audit
to Anthropic's `claude-md-improver`.

- Applied only high/medium priority fixes with clear impact.
- Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
  deletions are expected in this diff - please check none of them went too far.
- Packmind standards sections were left untouched.

To change what this run does, edit `.claude/skills/improve-claude-md/SKILL.md`.

Please review before merging.