### PR TITLE
refactor: move weekly CLAUDE.md improver logic into dedicated skill

### DIFF
--- a/.claude/skills/improve-claude-md/SKILL.md
+++ b/.claude/skills/improve-claude-md/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: 'weekly-claude-md-improver'
-description: 'Audit and improve every CLAUDE.md in the Packmind monorepo: apply only high/medium priority fixes and delete instructions already fully covered by a repository skill. Invoked non-interactively by the "Weekly CLAUDE.md Improvement" GitHub workflow (.github/workflows/weekly-claude-md-improver.yml); not intended for interactive use.'
+name: 'improve-claude-md'
+description: 'Audit and improve every CLAUDE.md in the Packmind monorepo: apply only high/medium priority fixes and delete instructions already fully covered by a repository skill. Driven non-interactively by a GitHub workflow (.github/workflows/weekly-claude-md-improver.yml owns the schedule); not intended for interactive use.'
 model: opus
 allowed-tools: Read Edit Glob Grep Skill
 disable-model-invocation: true
 ---
 
-# Weekly CLAUDE.md Improver
+# CLAUDE.md Improver
 
 Audit and improve every `CLAUDE.md` file in this repository, then report what changed.
 
@@ -22,7 +22,7 @@ Before touching any `CLAUDE.md`, list every skill available in this repository.
 
 Use `Glob` with the pattern `**/.claude/skills/**/SKILL.md`. Match at any depth: a `.claude/skills`
 directory can itself live in a sub-directory, and skills may be nested. Ignore any hit under
-`node_modules`. Ignore **this** skill (`weekly-claude-md-improver`) — it is CI tooling, not a
+`node_modules`. Ignore **this** skill (`improve-claude-md`) — it is CI tooling, not a
 developer convention, so it never justifies deleting anything.
 
 For each remaining `SKILL.md`, collect **only** the YAML frontmatter `name` and `description`. Do not

--- a/.claude/skills/improve-claude-md/SKILL.md
+++ b/.claude/skills/improve-claude-md/SKILL.md
@@ -38,11 +38,16 @@ whole run.
 
 ## Step 2 — Enumerate the target files
 
-Use `Glob` with the pattern `**/CLAUDE.md`, ignoring anything under `node_modules`. State how many
-files you found.
+Use `Glob` with the pattern `**/CLAUDE.md`, ignoring anything under `node_modules`. Print the full
+list of paths you found, numbered, followed by the count — for example `Found 19 CLAUDE.md file(s)`.
+This printed list is the run's worklist and the only record of what the run was supposed to cover, so
+print it in full before editing anything.
 
-Process them **one at a time**, in the order returned. Announce each file path before you start on it,
-so the CI log shows progress.
+Process the files **one at a time**, in the order returned. Announce each path as `[n/total] <path>`
+before you start on it, so the CI log shows progress and a run that stops early is visible at a glance.
+
+Never narrow the worklist on your own: no sampling, no "the rest look fine", no stopping once the
+edits feel sufficient. Every file in the list gets its own pass through Steps 3-4.
 
 ## Step 3 — Audit each file
 
@@ -96,3 +101,9 @@ End the run with a summary the pull-request reviewer can scan:
 - anything you deliberately skipped as ambiguous.
 
 Files you left unchanged need no more than a single closing line listing them.
+
+**Reconcile against the worklist.** Every path printed in Step 2 must appear in this summary, as
+edited, unchanged, or skipped — the counts have to add up. If any file went unaudited for any reason
+(you ran out of room, a read failed, you lost track), do not paper over it: end the report with a line
+that starts `INCOMPLETE RUN:` and names every file you did not audit. A silently partial run is worse
+than a loudly partial one, because the pull request it produces looks like a full audit.

--- a/.claude/skills/weekly-claude-md-improver/SKILL.md
+++ b/.claude/skills/weekly-claude-md-improver/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: 'weekly-claude-md-improver'
+description: 'Audit and improve every CLAUDE.md in the Packmind monorepo: apply only high/medium priority fixes and delete instructions already fully covered by a repository skill. Invoked non-interactively by the "Weekly CLAUDE.md Improvement" GitHub workflow (.github/workflows/weekly-claude-md-improver.yml); not intended for interactive use.'
+model: opus
+allowed-tools: Read Edit Glob Grep Skill
+disable-model-invocation: true
+---
+
+# Weekly CLAUDE.md Improver
+
+Audit and improve every `CLAUDE.md` file in this repository, then report what changed.
+
+You are running **NON-INTERACTIVELY in CI**: no human is available to confirm anything. Never ask a
+question — either apply a change that is clearly correct, or skip it and say so in the final summary.
+Apply fixes directly to the files as you go.
+
+These are standing instructions for the whole run, not a one-time checklist.
+
+## Step 1 — Build the skill inventory
+
+Before touching any `CLAUDE.md`, list every skill available in this repository.
+
+Use `Glob` with the pattern `**/.claude/skills/**/SKILL.md`. Match at any depth: a `.claude/skills`
+directory can itself live in a sub-directory, and skills may be nested. Ignore any hit under
+`node_modules`. Ignore **this** skill (`weekly-claude-md-improver`) — it is CI tooling, not a
+developer convention, so it never justifies deleting anything.
+
+For each remaining `SKILL.md`, collect **only** the YAML frontmatter `name` and `description`. Do not
+read skill bodies at this stage — inlining them wastes the context you need for the audit itself.
+
+Then state the count out loud, for example `Loaded frontmatter for 10 skill(s)`, and list the paths.
+This line matters: a regression that silently empties the inventory (a gitignored `.claude/skills`, a
+narrowed checkout, a changed glob) must be visible in the run log instead of quietly degrading into
+"skip deduplication".
+
+If the inventory is empty, say so explicitly and **skip Step 4 (deduplication) entirely** for the
+whole run.
+
+## Step 2 — Enumerate the target files
+
+Use `Glob` with the pattern `**/CLAUDE.md`, ignoring anything under `node_modules`. State how many
+files you found.
+
+Process them **one at a time**, in the order returned. Announce each file path before you start on it,
+so the CI log shows progress.
+
+## Step 3 — Audit each file
+
+For each `CLAUDE.md`, use the `claude-md-improver` skill (from the `claude-md-management` plugin,
+installed by the workflow) to audit and improve that file.
+
+Apply only **HIGH** and **MEDIUM** priority fixes that have a clear, unambiguous positive impact —
+for example:
+
+- outdated or incorrect commands
+- broken links or wrong file paths
+- stale structure or architecture references
+
+Do **not** make low-priority, subjective, or stylistic changes, and skip anything ambiguous. When in
+doubt, leave the text alone and note it in the summary.
+
+## Step 4 — Deduplicate against skills
+
+`CLAUDE.md` must not restate what a skill already carries. Any instruction, procedure, convention, or
+example in the file that is already covered by one of the skills from Step 1 is duplicate content:
+delete it outright, leaving **no** pointer or cross-reference in its place.
+
+Rules:
+
+- Delete only when the skill **clearly and fully** owns that topic. If a skill covers the topic only
+  partially, or you are in any doubt, leave the `CLAUDE.md` text untouched.
+- You may read a `SKILL.md` body when its frontmatter description alone cannot settle whether
+  coverage is full. Read it only for that decision.
+- Never delete content that no skill covers.
+- If the Step 1 inventory was empty, skip this step entirely.
+
+## Guardrails
+
+**Packmind standards regions are untouchable.** Never modify content inside sections delimited by the
+markers `<!-- start: Packmind standards -->` and `<!-- end: Packmind standards -->`. Leave those
+regions byte-for-byte unchanged and only edit content outside them. This outranks the deduplication
+rules above, even if a skill appears to cover that content.
+
+**Edit only, never restructure the tree.** Do not create, delete, or rename any file. The only
+permitted writes are `Edit` calls against existing `CLAUDE.md` files. In particular, do not move
+content from a `CLAUDE.md` into a new skill or doc.
+
+## Step 5 — Report
+
+End the run with a summary the pull-request reviewer can scan:
+
+- the skill count and the `CLAUDE.md` count from Steps 1-2;
+- one line per file you edited, with what you fixed;
+- every deletion made for deduplication, naming the skill that justified it, so a reviewer can check
+  none of them went too far;
+- anything you deliberately skipped as ambiguous.
+
+Files you left unchanged need no more than a single closing line listing them.

--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Improve CLAUDE.md files with Claude
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        # The whole procedure lives in .claude/skills/weekly-claude-md-improver/SKILL.md:
+        # The whole procedure lives in .claude/skills/improve-claude-md/SKILL.md:
         # which files to visit, what to fix, how to deduplicate against repository skills,
         # and which regions never to touch. Change the rules there, not here. The skill's
         # frontmatter also pins the model and the tool grant, so no --model / --allowedTools
         # flags belong on this call.
-        run: claude -p "/weekly-claude-md-improver" --permission-mode acceptEdits
+        run: claude -p "/improve-claude-md" --permission-mode acceptEdits
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -66,7 +66,7 @@ jobs:
           commit-message: 'chore: weekly CLAUDE.md improvements via claude-md-improver'
           title: 'chore: weekly CLAUDE.md improvements'
           body: |
-            Automated weekly run of the `weekly-claude-md-improver` skill, which delegates the audit
+            Automated weekly run of the `improve-claude-md` skill, which delegates the audit
             to Anthropic's `claude-md-improver`.
 
             - Applied only high/medium priority fixes with clear impact.
@@ -74,7 +74,7 @@ jobs:
               deletions are expected in this diff - please check none of them went too far.
             - Packmind standards sections were left untouched.
 
-            To change what this run does, edit `.claude/skills/weekly-claude-md-improver/SKILL.md`.
+            To change what this run does, edit `.claude/skills/improve-claude-md/SKILL.md`.
 
             Please review before merging.
           labels: automated

--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -50,87 +50,12 @@ jobs:
       - name: Improve CLAUDE.md files with Claude
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        run: |
-          set -euo pipefail
-          mapfile -t FILES < <(find . -name CLAUDE.md -not -path '*/node_modules/*')
-          echo "Found ${#FILES[@]} CLAUDE.md file(s)"
-
-          # Skill inventory: every SKILL.md under any .claude/skills tree, at any depth - .claude/skills
-          # can itself live in a sub-directory, and skills may be nested. Only the YAML frontmatter
-          # (name + description) is collected; skill bodies are never inlined into the prompt.
-          mapfile -t SKILL_FILES < <(find . -path '*/.claude/skills/*/SKILL.md' -not -path '*/node_modules/*' | sort)
-          SKILLS_INVENTORY=""
-          SKILLS_COUNT=0
-          for skill in "${SKILL_FILES[@]}"; do
-            [ -z "$skill" ] && continue
-            frontmatter=$(awk '
-              NR==1 && $0 !~ /^---[[:space:]]*$/ {exit}
-              /^---[[:space:]]*$/ {n++; if (n==2) exit; next}
-              n!=1 {next}
-              /^[A-Za-z0-9_-]+:/ {keep = ($0 ~ /^(name|description):/); if (keep) print; next}
-              keep
-            ' "$skill")
-            [ -z "$frontmatter" ] && continue
-            SKILLS_INVENTORY+="- ${skill}"$'\n'"${frontmatter}"$'\n\n'
-            SKILLS_COUNT=$((SKILLS_COUNT + 1))
-            # Logged per skill so a regression that silently empties the inventory (a gitignored
-            # .claude/skills, a narrowed checkout, an edited find pattern) is visible in the run log
-            # instead of quietly degrading into "skip deduplication".
-            echo "  + $skill"
-          done
-          echo "Loaded frontmatter for $SKILLS_COUNT skill(s)"
-          [ "$SKILLS_COUNT" -eq 0 ] && SKILLS_INVENTORY="(no skills found in this repository)"
-
-          for file in "${FILES[@]}"; do
-          [ -z "$file" ] && continue
-          echo "::group::Improving $file"
-          # Unquoted heredoc: the shell expands $file and $SKILLS_INVENTORY below. Keep the prompt text
-          # free of '$' and backticks so nothing else gets interpreted. (Do not switch back to
-          # placeholder substitution: '&' inside a bash replacement expands to the matched text, which
-          # corrupts any skill description containing an ampersand.) The heredoc body and its EOF
-          # terminator must stay flush with the enclosing block, hence the un-indented loop body.
-          prompt=$(cat <<EOF
-          You are Claude Code running NON-INTERACTIVELY in CI (no human is available to confirm anything).
-
-          STEP 1 - Load the skill inventory below before doing anything else. It lists every skill available
-          in this repository (each SKILL.md found under any .claude/skills directory, at any depth), with
-          only its YAML frontmatter: the skill name and its description.
-
-          SKILL INVENTORY:
-          $SKILLS_INVENTORY
-
-          STEP 2 - Use the claude-md-improver skill (from the installed claude-md-management plugin) to
-          audit and improve the CLAUDE.md file at: $file
-
-          Because this is non-interactive, APPLY fixes directly to the file. Only apply HIGH and MEDIUM
-          priority fixes that have a clear, unambiguous positive impact (e.g. outdated or incorrect
-          commands, broken links or wrong file paths, stale structure or architecture references). Do NOT
-          make low-priority, subjective, or stylistic changes, and skip anything ambiguous.
-
-          DEDUPLICATION AGAINST SKILLS: CLAUDE.md must not restate what a skill already carries. Any
-          instruction, procedure, convention or example in this CLAUDE.md that is already covered by one of
-          the skills listed above is duplicate content: delete it outright, leaving no pointer or
-          cross-reference in its place. Rules:
-          - Delete only when the skill clearly and fully owns that topic. If a skill covers the topic only
-            partially, or you are in any doubt, leave the CLAUDE.md text untouched.
-          - You may read a SKILL.md body when its frontmatter description alone cannot settle whether
-            coverage is full.
-          - Never delete content that no skill covers.
-          - If the inventory above is "(no skills found in this repository)", skip deduplication entirely.
-
-          CRITICAL: Never modify content inside sections delimited by the markers
-          "<!-- start: Packmind standards -->" and "<!-- end: Packmind standards -->". Leave those regions
-          byte-for-byte unchanged; only edit content outside them - this outranks the deduplication rules
-          above, even if a skill appears to cover that content.
-
-          Do not create, delete, or rename files - only edit this one CLAUDE.md file.
-          EOF
-          )
-          claude -p "$prompt" \
-            --permission-mode acceptEdits \
-            --allowedTools "Read,Edit,Glob,Grep"
-          echo "::endgroup::"
-          done
+        # The whole procedure lives in .claude/skills/weekly-claude-md-improver/SKILL.md:
+        # which files to visit, what to fix, how to deduplicate against repository skills,
+        # and which regions never to touch. Change the rules there, not here. The skill's
+        # frontmatter also pins the model and the tool grant, so no --model / --allowedTools
+        # flags belong on this call.
+        run: claude -p "/weekly-claude-md-improver" --permission-mode acceptEdits
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -141,12 +66,15 @@ jobs:
           commit-message: 'chore: weekly CLAUDE.md improvements via claude-md-improver'
           title: 'chore: weekly CLAUDE.md improvements'
           body: |
-            Automated weekly run of the Anthropic `claude-md-improver` skill.
+            Automated weekly run of the `weekly-claude-md-improver` skill, which delegates the audit
+            to Anthropic's `claude-md-improver`.
 
             - Applied only high/medium priority fixes with clear impact.
             - Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
               deletions are expected in this diff - please check none of them went too far.
             - Packmind standards sections were left untouched.
+
+            To change what this run does, edit `.claude/skills/weekly-claude-md-improver/SKILL.md`.
 
             Please review before merging.
           labels: automated


### PR DESCRIPTION
## Explanation

Extracted the inline procedural logic from the GitHub workflow into a dedicated `.claude/skills/improve-claude-md/SKILL.md` skill file. This refactoring:

- **Centralizes the audit rules** in a single, maintainable location (the skill) rather than embedding them in the workflow YAML
- **Simplifies the workflow** to a single `claude` invocation that delegates to the skill
- **Removes the shell hazards** — the prompt previously lived in an unquoted heredoc inside a `find`/`mapfile`/`awk` step, whose own comments were about ampersand-expansion and heredoc indentation pitfalls
- **Enables easier updates** — future changes to the audit procedure only require editing the skill, not the workflow

The skill encodes all standing instructions:
- Building the skill inventory from repository `SKILL.md` files (frontmatter only, never skill bodies)
- Enumerating and processing `CLAUDE.md` files one at a time, each announced as `[n/total] path`
- Applying only high/medium priority fixes
- Deduplicating content against repository skills
- Protecting Packmind standards regions
- Reconciling the final summary against the printed worklist, emitting `INCOMPLETE RUN:` when the counts do not add up

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [x] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- **CI/CD**: `.github/workflows/weekly-claude-md-improver.yml` — 153 lines down to 80, simplified to delegate to the skill
- **Skills**: New `.claude/skills/improve-claude-md/SKILL.md` — contains all audit logic
- **No code changes** to applications or packages

## Testing

No automated test covers this. Verified locally: the skill frontmatter and the workflow YAML both parse, Prettier is clean on both files, and no stale `weekly-claude-md-improver` skill reference remains. Behaviour is unchanged apart from running as one session instead of one per file, plus the new completeness reporting.

## TODO List

- [x] CHANGELOG Updated (N/A — internal tooling change)
- [x] Documentation Updated (skill documentation is self-contained in SKILL.md)

## Reviewer Notes

Three things moved from CLI flags into the skill's frontmatter, so the workflow call carries neither `--model` nor `--allowedTools`:

- `model: opus` — pins the run to Opus 5 on the Anthropic API. Requested change; previously the job ran on the CLI default.
- `allowed-tools: Read Edit Glob Grep Skill` — replaces the old `--allowedTools "Read,Edit,Glob,Grep"`. `Skill` is newly granted because the skill delegates the audit itself to `claude-md-improver` from the `claude-md-management` plugin, which the old flag list did not cover.
- `disable-model-invocation: true` — stops **Claude** from auto-invoking the skill during an ordinary dev session, which would rewrite every `CLAUDE.md` in the repo. It does not block `claude -p "/improve-claude-md"`: that is a direct user invocation, and the rendered `SKILL.md` becomes the prompt.

Cadence deliberately stays in the workflow (filename, `name`, cron, PR branch) rather than the skill name — the schedule is a runtime concern, not part of the skill's identity.

All guardrails and deduplication rules remain identical to the previous inline version.

https://claude.ai/code/session_01Wp4m4k1Qjq5XrFtvnwFwB1