### PR TITLE
Extend CLAUDE.md improver to create missing files and support dual-repo sync

### DIFF
--- a/.claude/skills/improve-claude-md/SKILL.md
+++ b/.claude/skills/improve-claude-md/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: 'improve-claude-md'
-description: 'Audit and improve every CLAUDE.md in the Packmind monorepo: apply only high/medium priority fixes and delete instructions already fully covered by a repository skill. Driven non-interactively by a GitHub workflow (.github/workflows/weekly-claude-md-improver.yml owns the schedule); not intended for interactive use.'
+description: 'Audit and improve the CLAUDE.md files listed in the run worklist: apply only high/medium priority fixes, create the ones that are missing, and delete instructions already fully covered by a repository skill. Driven non-interactively by a GitHub workflow (.github/workflows/weekly-claude-md-improver.yml owns the schedule and resolves the worklist, which differs per repository); not intended for interactive use.'
 model: opus
-allowed-tools: Read Edit Glob Grep Skill
+allowed-tools: Read Edit Write Glob Grep Skill
 disable-model-invocation: true
 ---
 
 # CLAUDE.md Improver
 
-Audit and improve every `CLAUDE.md` file in this repository, then report what changed.
+Audit and improve the `CLAUDE.md` files this run owns, create the ones that are missing, then report
+what changed.
 
 You are running **NON-INTERACTIVELY in CI**: no human is available to confirm anything. Never ask a
 question — either apply a change that is clearly correct, or skip it and say so in the final summary.
@@ -33,23 +34,78 @@ This line matters: a regression that silently empties the inventory (a gitignore
 narrowed checkout, a changed glob) must be visible in the run log instead of quietly degrading into
 "skip deduplication".
 
-If the inventory is empty, say so explicitly and **skip Step 4 (deduplication) entirely** for the
+If the inventory is empty, say so explicitly and **skip Step 5 (deduplication) entirely** for the
 whole run.
 
-## Step 2 — Enumerate the target files
+## Step 2 — Read the worklist
 
-Use `Glob` with the pattern `**/CLAUDE.md`, ignoring anything under `node_modules`. Print the full
-list of paths you found, numbered, followed by the count — for example `Found 19 CLAUDE.md file(s)`.
-This printed list is the run's worklist and the only record of what the run was supposed to cover, so
-print it in full before editing anything.
+`Read` `tmp/claude-md-worklist.txt`. It holds one repository-relative `CLAUDE.md` path per line, and
+it is **authoritative**: the workflow resolved it for this repository, and the scope differs between
+repositories on purpose. In the open-source repository it is every `CLAUDE.md` in the tree; in the
+proprietary fork it is only the packages that do not exist upstream, because every shared file is
+owned by the other repository's run of this same workflow. Editing a file outside the worklist
+diverges it between the two repositories and conflicts on the next sync.
 
-Process the files **one at a time**, in the order returned. Announce each path as `[n/total] <path>`
+So: **do not glob for `CLAUDE.md` files, and never add a path of your own.** If the worklist is
+missing or empty, stop immediately — do not fall back to a glob — and end the run with a single line
+starting `INCOMPLETE RUN:` that says the worklist could not be read. A silent full-tree fallback is
+exactly the failure this file exists to prevent.
+
+Print the paths, numbered, followed by the count — for example `Worklist: 8 file(s)`. This printed
+list is the only record of what the run was supposed to cover, so print it in full before editing
+anything.
+
+Some paths may not exist yet. That is intentional: a listed path with no file behind it is a package
+whose `CLAUDE.md` has to be **created** (Step 3).
+
+Process the files **one at a time**, in worklist order. Announce each path as `[n/total] <path>`
 before you start on it, so the CI log shows progress and a run that stops early is visible at a glance.
 
 Never narrow the worklist on your own: no sampling, no "the rest look fine", no stopping once the
-edits feel sufficient. Every file in the list gets its own pass through Steps 3-4.
+edits feel sufficient. Every file in the list gets its own pass through Steps 3-5.
 
-## Step 3 — Audit each file
+## Step 3 — Create a missing CLAUDE.md
+
+When a worklist path does not exist, author it. Its directory is a package root — call it
+`packages/<pkg>/`.
+
+**First, check the package is worth documenting.** `Glob` `packages/<pkg>/src/**/*`. If it holds two
+files or fewer, the package is a stub barrel with nothing to say: **skip it**, create nothing, and
+record it in the Step 6 report as deliberately skipped with its file count. A `CLAUDE.md` that only
+restates the package name is worse than no file at all.
+
+Otherwise read enough of the package to describe it honestly — never guess:
+
+- `project.json` (the Nx project name, and the `env:*` tag) and `package.json`
+- `README.md`, if there is one
+- `src/index.ts` (the public barrel) and `src/<Name>Hexa.ts` (the entry point)
+- the shape of `src/application/`, `src/domain/`, `src/infra/`, `src/nest-api/`, `test/` — whichever
+  are present
+
+Then `Write` the file, matching the house style of the packages that already have one.
+`packages/git/CLAUDE.md` and `packages/llm/CLAUDE.md` are the two best models — read one before you
+start writing:
+
+- `# <Name> Package` heading, then one or two sentences on what the package owns.
+- Only sections that earn their place: what is non-obvious, what surprises a newcomer, what to reuse
+  instead of rewriting, how to add a new case to an existing switch or factory. Concrete file paths
+  and type names, not adjectives.
+- **Do not restate the shared conventions.** The generic package layout, the `env:*` tags and import
+  boundaries, the `/test` subpath rule and branded IDs are all in `packages/CLAUDE.md` — a package
+  file that repeats them is duplicate content, which Step 5 would delete anyway.
+- Aim for 30-70 lines, in line with the existing package docs.
+- Close with the pointer line every sibling uses, verbatim:
+
+  `Shared package conventions (env tags, layout, /test subpath, branded IDs): [../CLAUDE.md](../CLAUDE.md)`
+
+- Respect the repository's own standards. In the proprietary fork,
+  `.claude/rules/packmind/standard-packmind-proprietary.md` forbids importing from
+  `@packmind/editions` — never write an example that does.
+
+Then put the new file through Steps 4 and 5 like any other, so bootstrapped and pre-existing files
+meet the same bar.
+
+## Step 4 — Audit each file
 
 For each `CLAUDE.md`, use the `claude-md-improver` skill (from the `claude-md-management` plugin,
 installed by the workflow) to audit and improve that file.
@@ -64,7 +120,7 @@ for example:
 Do **not** make low-priority, subjective, or stylistic changes, and skip anything ambiguous. When in
 doubt, leave the text alone and note it in the summary.
 
-## Step 4 — Deduplicate against skills
+## Step 5 — Deduplicate against skills
 
 `CLAUDE.md` must not restate what a skill already carries. Any instruction, procedure, convention, or
 example in the file that is already covered by one of the skills from Step 1 is duplicate content:
@@ -86,24 +142,29 @@ markers `<!-- start: Packmind standards -->` and `<!-- end: Packmind standards -
 regions byte-for-byte unchanged and only edit content outside them. This outranks the deduplication
 rules above, even if a skill appears to cover that content.
 
-**Edit only, never restructure the tree.** Do not create, delete, or rename any file. The only
-permitted writes are `Edit` calls against existing `CLAUDE.md` files. In particular, do not move
-content from a `CLAUDE.md` into a new skill or doc.
+**The worklist bounds every write.** The only permitted writes are `Edit` on a `CLAUDE.md` that is on
+the worklist, and `Write` to **create** a `CLAUDE.md` at a path that is on the worklist. Never delete
+or rename any file, never write anywhere else — not to a `CLAUDE.md` outside the worklist, not to any
+other file — and never move content from a `CLAUDE.md` into a new skill or doc.
 
-## Step 5 — Report
+## Step 6 — Report
 
 End the run with a summary the pull-request reviewer can scan:
 
-- the skill count and the `CLAUDE.md` count from Steps 1-2;
+- the skill count and the worklist count from Steps 1-2;
+- one line per file you **created**, saying in a sentence what the package does — these are new files
+  with no diff to compare against, so this is the reviewer's only summary of them;
 - one line per file you edited, with what you fixed;
 - every deletion made for deduplication, naming the skill that justified it, so a reviewer can check
   none of them went too far;
+- every package skipped as too thin to document, with its `src/` file count;
 - anything you deliberately skipped as ambiguous.
 
 Files you left unchanged need no more than a single closing line listing them.
 
 **Reconcile against the worklist.** Every path printed in Step 2 must appear in this summary, as
-edited, unchanged, or skipped — the counts have to add up. If any file went unaudited for any reason
-(you ran out of room, a read failed, you lost track), do not paper over it: end the report with a line
+created, edited, unchanged, or skipped — the counts have to add up. If any file went unaudited for
+any reason (you ran out of room, a read failed, you lost track), do not paper over it: end the
+report with a line
 that starts `INCOMPLETE RUN:` and names every file you did not audit. A silently partial run is worse
 than a loudly partial one, because the pull request it produces looks like a full audit.

--- a/.github/workflows/weekly-claude-md-improver.yml
+++ b/.github/workflows/weekly-claude-md-improver.yml
@@ -11,12 +11,18 @@ permissions:
 
 jobs:
   improve-claude-md:
-    # This workflow file is synced into other repositories (including our proprietary
-    # codebase). It must only ever run on PackmindHub/packmind: everywhere else the job
-    # is skipped, so the schedule and workflow_dispatch triggers become no-ops.
-    if: github.repository == 'PackmindHub/packmind'
+    # This workflow file is synced between PackmindHub/packmind and our proprietary fork,
+    # and runs in both. What differs is the *scope* of the run, not whether it runs: the
+    # "Resolve CLAUDE.md worklist" step below decides which files each repository owns, so
+    # the two runs never touch the same file. Anywhere else the job is skipped, making the
+    # schedule and workflow_dispatch triggers no-ops.
+    if: >-
+      github.repository == 'PackmindHub/packmind' ||
+      github.repository == 'PackmindHub/packmind-proprietary'
     runs-on: ${{ vars.ACTION_RUNNER_TAG || 'self-hosted' }}
-    timeout-minutes: 45
+    # 60 rather than 45: the proprietary run authors missing CLAUDE.md files from scratch,
+    # which is heavier than auditing existing ones.
+    timeout-minutes: 60
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -47,6 +53,54 @@ jobs:
             || claude plugin marketplace update claude-plugins-official
           claude plugin install claude-md-management@claude-plugins-official
 
+      - name: Resolve CLAUDE.md worklist
+        run: |
+          set -euo pipefail
+          mkdir -p tmp
+
+          if [ "${{ github.repository }}" = 'PackmindHub/packmind-proprietary' ]; then
+            # Proprietary run: only projects that do NOT exist in OSS. Every shared
+            # CLAUDE.md is owned by the OSS repository's run of this same workflow -
+            # auditing it in both repositories would diverge the files and conflict on the
+            # next sync-from-oss-repository merge.
+            git clone --depth 1 --branch main \
+              https://github.com/PackmindHub/Packmind.git /tmp/packmind-oss
+
+            if [ ! -d /tmp/packmind-oss/packages ]; then
+              echo "::error::OSS checkout has no packages/ directory. Aborting."
+              exit 1
+            fi
+
+            : > tmp/claude-md-worklist.txt
+            for DIR in apps/*/ packages/*/; do
+              PROJ="${DIR%/}"
+              [ -d "/tmp/packmind-oss/${PROJ}" ] && continue
+              # Listed whether or not the file exists yet: a missing entry is what tells
+              # the skill to bootstrap that package's CLAUDE.md.
+              echo "${PROJ}/CLAUDE.md" >> tmp/claude-md-worklist.txt
+            done
+
+            if [ ! -s tmp/claude-md-worklist.txt ]; then
+              echo "::error::No proprietary-only project found - the OSS diff looks broken."
+              exit 1
+            fi
+
+            echo 'SCOPE_NOTE=Scope: proprietary-only packages (projects absent from PackmindHub/packmind).' >> "$GITHUB_ENV"
+          else
+            find . -name CLAUDE.md -not -path './node_modules/*' \
+              | sed 's|^\./||' | sort > tmp/claude-md-worklist.txt
+
+            if [ ! -s tmp/claude-md-worklist.txt ]; then
+              echo "::error::No CLAUDE.md found in the checkout. Aborting."
+              exit 1
+            fi
+
+            echo 'SCOPE_NOTE=Scope: every CLAUDE.md in the repository.' >> "$GITHUB_ENV"
+          fi
+
+          echo "=== worklist ($(wc -l < tmp/claude-md-worklist.txt) entries) ==="
+          cat tmp/claude-md-worklist.txt
+
       - name: Improve CLAUDE.md files with Claude
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -69,7 +123,10 @@ jobs:
             Automated weekly run of the `improve-claude-md` skill, which delegates the audit
             to Anthropic's `claude-md-improver`.
 
+            ${{ env.SCOPE_NOTE }}
+
             - Applied only high/medium priority fixes with clear impact.
+            - Missing `CLAUDE.md` files inside the run's scope were created from scratch.
             - Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
               deletions are expected in this diff - please check none of them went too far.
             - Packmind standards sections were left untouched.


### PR DESCRIPTION
## Explanation

This change extends the `improve-claude-md` skill and its GitHub workflow to support:

1. **Creating missing `CLAUDE.md` files** — The skill now authors new documentation files for packages that lack them, following the house style and conventions of existing package docs. It validates that packages are substantial enough to document (>2 files in `src/`) before creating files.

2. **Worklist-based scoping** — Instead of globbing for all `CLAUDE.md` files, the workflow now resolves a worklist (`tmp/claude-md-worklist.txt`) that differs per repository:
   - In the OSS repository (`PackmindHub/packmind`): every `CLAUDE.md` in the tree
   - In the proprietary fork: only packages that don't exist upstream, preventing conflicts on sync

3. **Dual-repository support** — The workflow now runs in both `PackmindHub/packmind` and `PackmindHub/packmind-proprietary`, with the proprietary run cloning the OSS repository to determine which projects are proprietary-only.

The skill's steps are renumbered to accommodate the new Step 3 (create missing files), and the workflow timeout is increased from 45 to 60 minutes to account for authoring files from scratch.

## Type of Change

- [x] New feature
- [x] Improvement/Enhancement
- [x] Documentation

## Affected Components

- `.claude/skills/improve-claude-md/SKILL.md` — Extended instructions for creating missing files, reading worklist, and deduplication rules
- `.github/workflows/weekly-claude-md-improver.yml` — Added worklist resolution step, dual-repo support, increased timeout

## Testing

No testing needed — this is a workflow and skill documentation change. The workflow itself will validate the changes when it runs on schedule or via `workflow_dispatch`.

## Reviewer Notes

Key points for review:

1. **Worklist resolution logic** — The proprietary run clones the OSS repo to determine scope. Verify the directory comparison logic correctly identifies proprietary-only packages.

2. **File creation criteria** — The skill only creates `CLAUDE.md` for packages with >2 files in `src/`, to avoid documenting stub barrels. Review the guidance on what to include in new files.

3. **Deduplication bounds** — The worklist now bounds all writes: only files on the worklist can be edited or created. Verify this prevents accidental edits outside scope.

4. **Sync safety** — The proprietary run explicitly avoids touching shared files (those that exist in OSS), preventing divergence on the next sync-from-OSS merge.

https://claude.ai/code/session_01YHJQoyFJPnSwe9C55RkiV6