### PR TITLE
⚡️ Frontend Vitest suite: 52s → 21s in CI by evaluating the module graph once per worker

### DIFF
--- a/apps/frontend/eslint.config.mjs
+++ b/apps/frontend/eslint.config.mjs
@@ -9,4 +9,30 @@ export default [
     // Override or add rules here
     rules: {},
   },
+  {
+    files: [
+      '**/*.spec.ts',
+      '**/*.spec.tsx',
+      '**/*.test.ts',
+      '**/*.test.tsx',
+      'src/test-setup.ts',
+    ],
+    rules: {
+      // The suite runs with `isolate: false` (see vite.config.ts), so a module's
+      // mock registration outlives the spec file that made it. A bare automock
+      // and a factory mock for the same module share one registration, and the
+      // spec that runs second silently inherits the other's shape — an
+      // order-dependent failure that moves around between runs. Passing a
+      // factory makes each spec's mock self-describing and immune to that.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='vi'][callee.property.name=/^(mock|doMock)$/][arguments.length=1]",
+          message:
+            'Give vi.mock a factory: vi.mock(path, () => ({ ... })). A bare automock shares its registration with any factory mock of the same module, and under isolate:false the spec that runs second inherits the wrong shape.',
+        },
+      ],
+    },
+  },
 ];

--- a/apps/frontend/src/domain/accounts/components/DeployWithCliModal.spec.tsx
+++ b/apps/frontend/src/domain/accounts/components/DeployWithCliModal.spec.tsx
@@ -10,9 +10,20 @@ import { useGetSpacesQuery } from '../../spaces/api/queries/SpacesQueries';
 import { useListPackagesBySpaceQuery } from '../../deployments/api/queries/DeploymentsQueries';
 import type { MockedFunction } from 'vitest';
 
-vi.mock('../hooks/useAuthContext');
-vi.mock('../../spaces/api/queries/SpacesQueries');
-vi.mock('../../deployments/api/queries/DeploymentsQueries');
+// Named factories rather than bare automocks: an automock and a sibling spec's
+// factory mock for the same module share one mock entry, so whichever ran first
+// in the worker decides the shape. Every other spec mocking these modules uses a
+// factory, so this spec used to inherit their plain arrow exports and lose the
+// `vi.fn()` controls it needs.
+vi.mock('../hooks/useAuthContext', () => ({
+  useAuthContext: vi.fn(),
+}));
+vi.mock('../../spaces/api/queries/SpacesQueries', () => ({
+  useGetSpacesQuery: vi.fn(),
+}));
+vi.mock('../../deployments/api/queries/DeploymentsQueries', () => ({
+  useListPackagesBySpaceQuery: vi.fn(),
+}));
 vi.mock('./LocalEnvironmentSetup/hooks', () => ({
   useCliLoginCode: vi.fn(() => ({
     loginCode: 'TEST-CODE-123',

--- a/apps/frontend/src/domain/accounts/components/DeployWithCliModal.spec.tsx
+++ b/apps/frontend/src/domain/accounts/components/DeployWithCliModal.spec.tsx
@@ -10,11 +10,6 @@ import { useGetSpacesQuery } from '../../spaces/api/queries/SpacesQueries';
 import { useListPackagesBySpaceQuery } from '../../deployments/api/queries/DeploymentsQueries';
 import type { MockedFunction } from 'vitest';
 
-// Named factories rather than bare automocks: an automock and a sibling spec's
-// factory mock for the same module share one mock entry, so whichever ran first
-// in the worker decides the shape. Every other spec mocking these modules uses a
-// factory, so this spec used to inherit their plain arrow exports and lose the
-// `vi.fn()` controls it needs.
 vi.mock('../hooks/useAuthContext', () => ({
   useAuthContext: vi.fn(),
 }));

--- a/apps/frontend/src/domain/deployments/components/PackageCountBadge/PackageCountBadge.spec.tsx
+++ b/apps/frontend/src/domain/deployments/components/PackageCountBadge/PackageCountBadge.spec.tsx
@@ -8,7 +8,14 @@ import { formatPackageNames } from './PackagesDropdown';
 import { createPackageId, createStandardId, Package } from '@packmind/types';
 import * as usePackagesForArtifactModule from '../../hooks/usePackagesForArtifact';
 
-vi.mock('../../hooks/usePackagesForArtifact');
+// A factory rather than a bare automock, so the shape is this file's own and
+// cannot be decided by another spec's registration for the same module — see the
+// isolate:false note in vite.config.ts. Both exports are stubbed, matching what
+// the automock used to produce.
+vi.mock('../../hooks/usePackagesForArtifact', () => ({
+  usePackagesForArtifact: vi.fn(),
+  getArtifactPackages: vi.fn(),
+}));
 
 const mockUsePackagesForArtifact = vi.spyOn(
   usePackagesForArtifactModule,

--- a/apps/frontend/src/domain/deployments/components/PackageCountBadge/PackageCountBadge.spec.tsx
+++ b/apps/frontend/src/domain/deployments/components/PackageCountBadge/PackageCountBadge.spec.tsx
@@ -8,10 +8,7 @@ import { formatPackageNames } from './PackagesDropdown';
 import { createPackageId, createStandardId, Package } from '@packmind/types';
 import * as usePackagesForArtifactModule from '../../hooks/usePackagesForArtifact';
 
-// A factory rather than a bare automock, so the shape is this file's own and
-// cannot be decided by another spec's registration for the same module — see the
-// isolate:false note in vite.config.ts. Both exports are stubbed, matching what
-// the automock used to produce.
+// Both exports stubbed, matching what the bare automock used to produce.
 vi.mock('../../hooks/usePackagesForArtifact', () => ({
   usePackagesForArtifact: vi.fn(),
   getArtifactPackages: vi.fn(),

--- a/apps/frontend/src/domain/organizations/components/dashboard/DashboardKPI.spec.tsx
+++ b/apps/frontend/src/domain/organizations/components/dashboard/DashboardKPI.spec.tsx
@@ -6,11 +6,6 @@ import * as SpacesQueries from '../../../spaces/api/queries/SpacesQueries';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router';
 
-// Named factories rather than bare automocks: a module's mock registration
-// survives the spec file that made it, and an automock loses to a factory mock
-// registered for the same module by another spec. Five other specs mock
-// DeploymentsQueries with a factory and three mock SpacesQueries, so an
-// automock here resolves to whichever shape registered first.
 vi.mock('../../../deployments/api/queries/DeploymentsQueries', () => ({
   useGetDashboardKpiQuery: vi.fn(),
   useGetDashboardNonLiveQuery: vi.fn(),

--- a/apps/frontend/src/domain/organizations/components/dashboard/DashboardKPI.spec.tsx
+++ b/apps/frontend/src/domain/organizations/components/dashboard/DashboardKPI.spec.tsx
@@ -6,8 +6,18 @@ import * as SpacesQueries from '../../../spaces/api/queries/SpacesQueries';
 import '@testing-library/jest-dom';
 import { BrowserRouter } from 'react-router';
 
-vi.mock('../../../deployments/api/queries/DeploymentsQueries');
-vi.mock('../../../spaces/api/queries/SpacesQueries');
+// Named factories rather than bare automocks: a module's mock registration
+// survives the spec file that made it, and an automock loses to a factory mock
+// registered for the same module by another spec. Five other specs mock
+// DeploymentsQueries with a factory and three mock SpacesQueries, so an
+// automock here resolves to whichever shape registered first.
+vi.mock('../../../deployments/api/queries/DeploymentsQueries', () => ({
+  useGetDashboardKpiQuery: vi.fn(),
+  useGetDashboardNonLiveQuery: vi.fn(),
+}));
+vi.mock('../../../spaces/api/queries/SpacesQueries', () => ({
+  useGetSpacesQuery: vi.fn(),
+}));
 vi.mock('../../../spaces/hooks/useCurrentSpace', () => ({
   useCurrentSpace: () => ({
     spaceId: 'space-id-1',

--- a/apps/frontend/src/services/api/ApiService.test.ts
+++ b/apps/frontend/src/services/api/ApiService.test.ts
@@ -4,10 +4,7 @@ import { PackmindError } from './errors/PackmindError';
 import { PackmindConflictError } from './errors/PackmindConflictError';
 import type { Mock, Mocked } from 'vitest';
 
-// Mock axios. A factory rather than a bare automock, so the shape is this
-// file's own and cannot be decided by another spec's registration for the same
-// module — see the isolate:false note in vite.config.ts. `create` is the only
-// axios export ApiService touches; the rest are type-only imports.
+// `create` is the only axios export ApiService touches; the rest are type-only.
 vi.mock('axios', () => ({
   default: { create: vi.fn() },
 }));

--- a/apps/frontend/src/services/api/ApiService.test.ts
+++ b/apps/frontend/src/services/api/ApiService.test.ts
@@ -4,8 +4,13 @@ import { PackmindError } from './errors/PackmindError';
 import { PackmindConflictError } from './errors/PackmindConflictError';
 import type { Mock, Mocked } from 'vitest';
 
-// Mock axios
-vi.mock('axios');
+// Mock axios. A factory rather than a bare automock, so the shape is this
+// file's own and cannot be decided by another spec's registration for the same
+// module — see the isolate:false note in vite.config.ts. `create` is the only
+// axios export ApiService touches; the rest are type-only imports.
+vi.mock('axios', () => ({
+  default: { create: vi.fn() },
+}));
 
 const mockedAxios = axios as Mocked<typeof axios>;
 

--- a/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
@@ -4,12 +4,16 @@ import '@testing-library/jest-dom';
 import { UIProvider } from '@packmind/ui';
 import { CopiableTextField } from './CopiableTextField';
 
-// Mock the clipboard API
+// Mock the clipboard API. `Object.assign` would go through the setter, and
+// jsdom exposes `navigator.clipboard` as a getter-only accessor — so once a
+// sibling spec in the same worker has installed its own stub, the assignment
+// throws "Cannot set property clipboard of #<Navigator> which has only a
+// getter". Defining the property outright is order-independent.
 const mockWriteText = vi.fn();
-Object.assign(navigator, {
-  clipboard: {
-    writeText: mockWriteText,
-  },
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: mockWriteText },
+  configurable: true,
+  writable: true,
 });
 
 const renderWithUI = (component: React.ReactElement) => {

--- a/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
@@ -9,11 +9,28 @@ import { CopiableTextField } from './CopiableTextField';
 // sibling spec in the same worker has installed its own stub, the assignment
 // throws "Cannot set property clipboard of #<Navigator> which has only a
 // getter". Defining the property outright is order-independent.
+// jsdom's `navigator` is shared by every spec in the worker, so the stub is put
+// back at the end of the file rather than left on the global for whoever runs
+// next.
 const mockWriteText = vi.fn();
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  'clipboard',
+);
 Object.defineProperty(navigator, 'clipboard', {
   value: { writeText: mockWriteText },
   configurable: true,
   writable: true,
+});
+
+afterAll(() => {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard);
+  } else {
+    // Nothing owned it before: dropping the own property re-exposes jsdom's
+    // prototype accessor.
+    delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+  }
 });
 
 const renderWithUI = (component: React.ReactElement) => {

--- a/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextField.spec.tsx
@@ -4,14 +4,10 @@ import '@testing-library/jest-dom';
 import { UIProvider } from '@packmind/ui';
 import { CopiableTextField } from './CopiableTextField';
 
-// Mock the clipboard API. `Object.assign` would go through the setter, and
-// jsdom exposes `navigator.clipboard` as a getter-only accessor — so once a
-// sibling spec in the same worker has installed its own stub, the assignment
-// throws "Cannot set property clipboard of #<Navigator> which has only a
-// getter". Defining the property outright is order-independent.
-// jsdom's `navigator` is shared by every spec in the worker, so the stub is put
-// back at the end of the file rather than left on the global for whoever runs
-// next.
+// jsdom's `navigator` is shared by every spec in the worker, so the clipboard
+// stub is defined rather than assigned — `Object.assign` goes through jsdom's
+// getter-only `clipboard` accessor and throws once a sibling spec has installed
+// its own — and put back afterwards rather than left on the global.
 const mockWriteText = vi.fn();
 const originalClipboard = Object.getOwnPropertyDescriptor(
   navigator,
@@ -20,7 +16,6 @@ const originalClipboard = Object.getOwnPropertyDescriptor(
 Object.defineProperty(navigator, 'clipboard', {
   value: { writeText: mockWriteText },
   configurable: true,
-  writable: true,
 });
 
 afterAll(() => {

--- a/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
@@ -9,11 +9,28 @@ import { CopiableTextarea } from './CopiableTextarea';
 // sibling spec in the same worker has installed its own stub, the assignment
 // throws "Cannot set property clipboard of #<Navigator> which has only a
 // getter". Defining the property outright is order-independent.
+// jsdom's `navigator` is shared by every spec in the worker, so the stub is put
+// back at the end of the file rather than left on the global for whoever runs
+// next.
 const mockWriteText = vi.fn();
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  'clipboard',
+);
 Object.defineProperty(navigator, 'clipboard', {
   value: { writeText: mockWriteText },
   configurable: true,
   writable: true,
+});
+
+afterAll(() => {
+  if (originalClipboard) {
+    Object.defineProperty(navigator, 'clipboard', originalClipboard);
+  } else {
+    // Nothing owned it before: dropping the own property re-exposes jsdom's
+    // prototype accessor.
+    delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+  }
 });
 
 const renderWithUI = (component: React.ReactElement) => {

--- a/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
@@ -4,14 +4,10 @@ import '@testing-library/jest-dom';
 import { UIProvider } from '@packmind/ui';
 import { CopiableTextarea } from './CopiableTextarea';
 
-// Mock the clipboard API. `Object.assign` would go through the setter, and
-// jsdom exposes `navigator.clipboard` as a getter-only accessor — so once a
-// sibling spec in the same worker has installed its own stub, the assignment
-// throws "Cannot set property clipboard of #<Navigator> which has only a
-// getter". Defining the property outright is order-independent.
-// jsdom's `navigator` is shared by every spec in the worker, so the stub is put
-// back at the end of the file rather than left on the global for whoever runs
-// next.
+// jsdom's `navigator` is shared by every spec in the worker, so the clipboard
+// stub is defined rather than assigned — `Object.assign` goes through jsdom's
+// getter-only `clipboard` accessor and throws once a sibling spec has installed
+// its own — and put back afterwards rather than left on the global.
 const mockWriteText = vi.fn();
 const originalClipboard = Object.getOwnPropertyDescriptor(
   navigator,
@@ -20,7 +16,6 @@ const originalClipboard = Object.getOwnPropertyDescriptor(
 Object.defineProperty(navigator, 'clipboard', {
   value: { writeText: mockWriteText },
   configurable: true,
-  writable: true,
 });
 
 afterAll(() => {

--- a/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
+++ b/apps/frontend/src/shared/components/inputs/CopiableTextarea.spec.tsx
@@ -4,12 +4,16 @@ import '@testing-library/jest-dom';
 import { UIProvider } from '@packmind/ui';
 import { CopiableTextarea } from './CopiableTextarea';
 
-// Mock the clipboard API
+// Mock the clipboard API. `Object.assign` would go through the setter, and
+// jsdom exposes `navigator.clipboard` as a getter-only accessor — so once a
+// sibling spec in the same worker has installed its own stub, the assignment
+// throws "Cannot set property clipboard of #<Navigator> which has only a
+// getter". Defining the property outright is order-independent.
 const mockWriteText = vi.fn();
-Object.assign(navigator, {
-  clipboard: {
-    writeText: mockWriteText,
-  },
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: mockWriteText },
+  configurable: true,
+  writable: true,
 });
 
 const renderWithUI = (component: React.ReactElement) => {

--- a/apps/frontend/src/test-setup.ts
+++ b/apps/frontend/src/test-setup.ts
@@ -21,6 +21,26 @@ afterAll(async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
   vi.clearAllTimers();
   vi.useRealTimers();
+
+  // Restores the per-file module reset that `isolate: false` turns off.
+  //
+  // Vitest's worker loop only resets the module registry between spec files when
+  // `isolate` is true (see the `if (config.isolate)` branch in its worker's run
+  // loop). `vite.config.ts` sets `isolate: false` so the module graph is
+  // evaluated once per worker instead of once per file — the change that makes
+  // the suite ~2.8x faster — which leaves the registry shared. A spec that calls
+  // `vi.mock` would then hand its mocked module to whichever spec runs next in
+  // the same worker: the mock leaks *forward* onto innocent neighbours, so the
+  // failures land on specs that never mocked anything and drift run to run.
+  //
+  // Clearing the registry here restores file-level module isolation while
+  // keeping the win: externalised node_modules (Chakra, React) live in Node's
+  // own ESM cache, which this does not touch, so they stay loaded per worker.
+  //
+  // Registered in the setup file, so it runs last — Vitest unwinds `afterAll`
+  // hooks in reverse registration order, which leaves each spec's own teardown
+  // running before the modules it closes over are dropped.
+  vi.resetModules();
 });
 
 // Mock winston globally to prevent PackmindLogger instantiation issues in frontend tests

--- a/apps/frontend/src/test-setup.ts
+++ b/apps/frontend/src/test-setup.ts
@@ -22,24 +22,14 @@ afterAll(async () => {
   vi.clearAllTimers();
   vi.useRealTimers();
 
-  // Restores the per-file module reset that `isolate: false` turns off.
+  // Vitest resets the module registry between spec files only when `isolate` is
+  // true, and vite.config.ts sets it to false. Without this, a spec's `vi.mock`
+  // leaks forward onto whichever spec runs next in the same worker, so the
+  // failures land on specs that never mocked anything. Restoring the reset keeps
+  // the speed-up: externalised node_modules stay in Node's own ESM cache, which
+  // `vi.resetModules()` does not touch.
   //
-  // Vitest's worker loop only resets the module registry between spec files when
-  // `isolate` is true (see the `if (config.isolate)` branch in its worker's run
-  // loop). `vite.config.ts` sets `isolate: false` so the module graph is
-  // evaluated once per worker instead of once per file — the change that makes
-  // the suite ~2.8x faster — which leaves the registry shared. A spec that calls
-  // `vi.mock` would then hand its mocked module to whichever spec runs next in
-  // the same worker: the mock leaks *forward* onto innocent neighbours, so the
-  // failures land on specs that never mocked anything and drift run to run.
-  //
-  // Clearing the registry here restores file-level module isolation while
-  // keeping the win: externalised node_modules (Chakra, React) live in Node's
-  // own ESM cache, which this does not touch, so they stay loaded per worker.
-  //
-  // Registered in the setup file, so it runs last — Vitest unwinds `afterAll`
-  // hooks in reverse registration order, which leaves each spec's own teardown
-  // running before the modules it closes over are dropped.
+  // Lives in the setup file so it unwinds last, after each spec's own `afterAll`.
   vi.resetModules();
 });
 

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -126,6 +126,18 @@ export default defineConfig(() => {
       // which is not enough for the heavier component suites under full-suite
       // parallelism — the shortfall showed up as an intermittent timeout.
       testTimeout: 15000,
+      // Vitest's default `isolate: true` recycles the worker for every spec, so
+      // each file re-evaluates the whole module graph from scratch — Chakra plus
+      // the `@packmind/ui` barrel is ~3s of import on its own, and nearly every
+      // spec pulls it in. That per-file re-evaluation, not the tests, dominated
+      // the suite's wall clock (~110s for 95 files on a 4-core runner).
+      //
+      // Sharing the worker collapses those imports to once per worker (~2.8x
+      // faster). The catch is that Vitest only resets the module and mock
+      // registries between files when `isolate` is true, so mocks would leak
+      // across specs; `src/test-setup.ts` restores that reset by hand. Keep the
+      // two settings together — `isolate: false` without that hook is unsound.
+      isolate: false,
       reporters: ['default'],
       coverage: {
         reportsDirectory: '../../coverage/apps/frontend',

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -127,16 +127,13 @@ export default defineConfig(() => {
       // parallelism — the shortfall showed up as an intermittent timeout.
       testTimeout: 15000,
       // Vitest's default `isolate: true` recycles the worker for every spec, so
-      // each file re-evaluates the whole module graph from scratch — Chakra plus
-      // the `@packmind/ui` barrel is ~3s of import on its own, and nearly every
-      // spec pulls it in. That per-file re-evaluation, not the tests, dominated
-      // the suite's wall clock (~110s for 95 files on a 4-core runner).
-      //
-      // Sharing the worker collapses those imports to once per worker (~2.8x
-      // faster). The catch is that Vitest only resets the module and mock
-      // registries between files when `isolate` is true, so mocks would leak
-      // across specs; `src/test-setup.ts` restores that reset by hand. Keep the
-      // two settings together — `isolate: false` without that hook is unsound.
+      // each file re-evaluates the whole module graph — Chakra plus the
+      // `@packmind/ui` barrel, which nearly every spec pulls in. That
+      // re-evaluation, not the tests, dominated the suite's wall clock; sharing
+      // the worker collapses it to once per worker and roughly triples the
+      // speed. Turning isolation off also disables Vitest's per-file module
+      // reset, so `src/test-setup.ts` restores that by hand — keep the two
+      // together, `isolate: false` alone lets mocks leak between specs.
       isolate: false,
       reporters: ['default'],
       coverage: {


### PR DESCRIPTION
## Explanation

The frontend Vitest suite spent most of its wall clock importing, not testing. Vitest's default `isolate: true` recycles the worker for every spec file, so each of the 95 specs re-evaluates the whole module graph from scratch — Chakra plus the `@packmind/ui` barrel is ~3s of import on its own (measured: Chakra ~1.4s, the barrel's own source ~1.1s), and nearly every spec pulls it in.

This PR sets `isolate: false` so the graph is evaluated once per worker instead of once per file.

On its own that is unsound, and this is the part worth understanding. Vitest resets the module registry between spec files inside an `if (config.isolate)` branch in its worker loop — so turning isolation off doesn't just share the module graph (the intended win), it also silently disables that reset. A spec's `vi.mock` then leaks *forward* onto whichever spec runs next in the same worker, and the failures land on specs that never mocked anything, drifting run to run. `src/test-setup.ts` restores the reset with `vi.resetModules()` in the `afterAll` it already had. Externalised node_modules (Chakra, React) live in Node's own ESM cache, which the reset does not touch, so they stay loaded per worker and the win survives.

Six specs then needed real fixes, because they had been relying on a private per-file registry:

- **Clipboard global (2 specs)** — `CopiableTextField` / `CopiableTextarea` assigned `navigator.clipboard` via `Object.assign`. jsdom exposes it as a getter-only accessor and its `navigator` is shared across specs in a worker, so the second spec to run threw. Now installed with `Object.defineProperty` and restored in `afterAll`.
- **Automock inheriting a sibling's shape (4 specs)** — a module's mock registration outlives the spec that made it, and a bare `vi.mock(path)` shares one registration with any factory mock of the same module, so the spec that runs second silently inherits the other's shape (its exports are not `vi.fn()`, so `mockReturnValue` is missing). `DeployWithCliModal` was failing on this; `DashboardKPI` was a live collision passing only because ordering happened to favour it (it bare-automocked `DeploymentsQueries`, factory-mocked by five other specs, and `SpacesQueries`, by three). `ApiService` and `PackageCountBadge` had no factory counterpart today but were the same trap waiting for one.

A `no-restricted-syntax` rule now rejects bare `vi.mock(path)` in frontend specs with the reason attached, so that class surfaces at review time instead of becoming an order-dependent flake later. There is no automock/factory overlap left in the tree.

Relates to #436. **Supersedes #437** — that PR quarantined 48 of 95 specs into a separate isolated project via a filesystem scan plus a hand-listed set, which is why it only reached 47s. This branch is based on `main` rather than on `agent/issue-436`, so `LEAKY_SPECS`, `ALWAYS_ISOLATE` and the scan are gone entirely; there are no spec-path lists in the config.

## Type of Change

- [x] Bug fix
- [x] Improvement/Enhancement

## Affected Components

- Domain packages affected: none — `apps/frontend` test configuration and six of its specs
- Frontend / Backend / Both: Frontend (test tooling only; no application code changed)
- Breaking changes (if any): none. No product behaviour changes.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**

No test *cases* were added or removed — all 95 files / 1280 tests are the same before and after, and green.

`Test Frontend` step in `build / build-frontend`, all on the same `depot-ubuntu-24.04-4` runner class:

| head | Test Frontend |
|---|---|
| `main` (baseline) | ~52s |
| #437 | 47s |
| `da1e23f` | 22s |
| `70b321e` (current) | **21s** |

Locally, alternating both configurations back to back on a 4-core box with the Nx cache bypassed, to control for machine drift:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| `isolate: true` | 187.4s | 113.1s | 110.7s |
| `isolate: false` + reset | 38.6s | 40.1s | 39.1s |

~2.8x locally and far more consistent — the baseline's slowest run tripped the 15s test timeout twice under its own load.

Each isolation fix was verified with a purpose-built two-file probe rather than by observing the suite go green, since these failures are order-dependent:

- **Module leak** — each file mocks its own module and asserts the neighbour's mock is not visible, so either execution order exercises the leak. Direct imports never leaked; the case that does is transitive (a cached intermediate module holding a mocked dependency) and flips from failing to passing with `vi.resetModules()`.
- **Automock/factory collision** — each file automocks one module and factory-mocks another, so either order exercises it. Fails before the spec conversions, passes after. Worth recording: this one is *not* repairable from the teardown — neither `vi.resetModules()` nor `__vitest_mocker__.reset()` plus a full sweep of `evaluatedModules` fixes it, because the automock-vs-factory decision is resolved server-side.
- **Global leak** — each file records the marker it observes at module-eval time before installing its own; confirms jsdom's `navigator` is shared, and that the descriptor restore closes it.

Full suite run green repeatedly across the work (5 consecutive runs on the reset hook alone, 3 after the automock conversions), plus `nx lint frontend` (0 errors), `nx typecheck frontend`, and Prettier. Also verified green twice against `main` merged in.

## TODO List

- [ ] CHANGELOG Updated — n/a, no root CHANGELOG in this repo
- [ ] Documentation Updated — n/a, rationale lives in the config comments this PR adds

## Reviewer Notes

**The two settings are a pair.** `isolate: false` in `vite.config.ts` and `vi.resetModules()` in `test-setup.ts` must stay together — `isolate: false` without that hook reintroduces the drifting cross-file mock failures. Both carry comments saying so.

**One genuine trade-off, worth knowing when reviewing future specs.** Global mutations now outlive the spec file that made them, where under `isolate: true` they did not. Module state is handled by the reset; globals are not — a global isn't a module. The tree is clean today (the clipboard specs were the only offenders), but a future spec that patches a global and doesn't restore it can affect its neighbours. That is the thing to watch for in review; the clipboard specs show the capture-and-restore pattern.

**Not pursued, if anyone wonders why.** Pre-bundling the heavy dependencies via `test.deps.optimizer` was measured and does nothing here: it collapses resolution and transform, which Vite already caches, while the actual cost is *re-evaluating* the graph in a fresh registry. Splitting the `@packmind/ui` barrel would help (~40% of the per-file import) but is a refactor across every import site in the frontend, for less than this change already delivers. `environment` time (~62s cumulative, jsdom at ~640ms per file) is untouched and is the next largest remaining item — roughly a quarter of the specs never touch the DOM and could declare `// @vitest-environment node` in their own header, worth perhaps 4s for ~25 file edits.

https://claude.ai/code/session_01D6cY6GfcZaTdPycF6Cmvr2