### PR TITLE
perf(ci): cut the packages build+typecheck step from 35s to 13s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,11 +169,14 @@ jobs:
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}
         run: node scripts/select-tsconfig.mjs
-      - name: Build packages
+      # `build` is transpile-only (see nx.json). Type errors are caught by the
+      # `typecheck` target, which resolves deps from source and so needs no
+      # build ordering - both targets fan out with no chain between them.
+      - name: Build and typecheck packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}
           NODE_OPTIONS: '--max-old-space-size=16384 --no-experimental-strip-types'
-        run: ./node_modules/.bin/nx run-many -t build -p packages/*
+        run: ./node_modules/.bin/nx run-many -t build,typecheck -p packages/*
       - name: Test packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,10 +143,9 @@ jobs:
           path: apps/frontend/build/client
 
   build-packages:
-    # Wider runner than the other jobs: build and typecheck fan out to 45 tasks
-    # with a ~6s critical path, so the step is bound by available cores rather
-    # than by task ordering (Nx reported 16.5s of 22.4s as recoverable on 4).
-    # Falls back to the standard tag where the 8-core variable is not set.
+    # Wider runner: this job fans out to 45 tasks with a ~6s critical path, so
+    # it is bound by cores rather than task ordering. Falls back to the standard
+    # tag where the 8-core variable is not set.
     runs-on: ${{ vars.ACTION_RUNNER_TAG_8_CORES || vars.ACTION_RUNNER_TAG || 'self-hosted' }}
     timeout-minutes: ${{ github.actor == 'dependabot[bot]' && 15 || 30 }}
     outputs:
@@ -173,12 +172,9 @@ jobs:
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}
         run: node scripts/select-tsconfig.mjs
-      # `build` type checks via `dependsOn: [typecheck]` (see nx.json), so the
-      # gate holds for `nx build` anywhere. `typecheck` is still listed here to
-      # cover `migrations`, which has a typecheck target but no build target.
-      # `--parallel=100%` because Nx otherwise defaults to 3 workers, which
-      # would leave most of this job's wider runner idle; the percentage form
-      # resolves to availableParallelism() so it tracks the runner size.
+      # `build` type checks via dependsOn (see nx.json); `typecheck` is listed
+      # too for `migrations`, which has no build target. `--parallel=100%`
+      # because Nx defaults to 3 workers whatever the machine size.
       - name: Build and typecheck packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,9 +169,9 @@ jobs:
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}
         run: node scripts/select-tsconfig.mjs
-      # `build` is transpile-only (see nx.json). Type errors are caught by the
-      # `typecheck` target, which resolves deps from source and so needs no
-      # build ordering - both targets fan out with no chain between them.
+      # `build` type checks via `dependsOn: [typecheck]` (see nx.json), so the
+      # gate holds for `nx build` anywhere. `typecheck` is still listed here to
+      # cover `migrations`, which has a typecheck target but no build target.
       - name: Build and typecheck packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,11 @@ jobs:
           path: apps/frontend/build/client
 
   build-packages:
-    runs-on: ${{ vars.ACTION_RUNNER_TAG || 'self-hosted' }}
+    # Wider runner than the other jobs: build and typecheck fan out to 45 tasks
+    # with a ~6s critical path, so the step is bound by available cores rather
+    # than by task ordering (Nx reported 16.5s of 22.4s as recoverable on 4).
+    # Falls back to the standard tag where the 8-core variable is not set.
+    runs-on: ${{ vars.ACTION_RUNNER_TAG_8_CORES || vars.ACTION_RUNNER_TAG || 'self-hosted' }}
     timeout-minutes: ${{ github.actor == 'dependabot[bot]' && 15 || 30 }}
     outputs:
       standard-samples-artifact: standard-samples-${{ vars.PACKMIND_EDITION }}-${{ github.run_number }}-${{ github.sha }}
@@ -172,11 +176,14 @@ jobs:
       # `build` type checks via `dependsOn: [typecheck]` (see nx.json), so the
       # gate holds for `nx build` anywhere. `typecheck` is still listed here to
       # cover `migrations`, which has a typecheck target but no build target.
+      # `--parallel=100%` because Nx otherwise defaults to 3 workers, which
+      # would leave most of this job's wider runner idle; the percentage form
+      # resolves to availableParallelism() so it tracks the runner size.
       - name: Build and typecheck packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}
           NODE_OPTIONS: '--max-old-space-size=16384 --no-experimental-strip-types'
-        run: ./node_modules/.bin/nx run-many -t build,typecheck -p packages/*
+        run: ./node_modules/.bin/nx run-many -t build,typecheck -p packages/* --parallel=100%
       - name: Test packages
         env:
           PACKMIND_EDITION: ${{ vars.PACKMIND_EDITION }}

--- a/nx.json
+++ b/nx.json
@@ -107,7 +107,7 @@
       "dependsOn": ["^build"],
       "inputs": ["default", "^default"]
     },
-    "// @nx/js:swc": "Building a package still type checks it, via 'dependsOn: [typecheck]'. What changed is HOW. The executor's own type check (on by default, hence skipTypeCheck here) ran tsc --emitDeclarationOnly and resolved each dependency from its dist/ .d.ts, so it needed '^build' - which serialised the 22 packages into a 9-deep chain and cost ~2s/package regardless of size. The 'typecheck' target resolves dependencies from source instead (every @packmind/* path in tsconfig.base.json maps to packages/*/src), so it needs no build ordering: 'typecheck' has no '^', so each package depends only on its OWN type check and packages stay parallel. The declarations that emitDeclarationOnly produced were dead output - nothing reads dist/packages/*, since api/frontend/cli all bundle from source.",
+    "// @nx/js:swc": "Transpile only; the type gate is the project's own 'typecheck' target, via dependsOn below. The executor's built-in check ran 'tsc --emitDeclarationOnly' resolving each dependency from its dist/ .d.ts, which forced '^build' and serialised the packages into a 9-deep chain - for declarations nothing consumes. 'typecheck' has no '^', so packages stay parallel.",
     "@nx/js:swc": {
       "cache": true,
       "dependsOn": ["typecheck"],
@@ -116,8 +116,13 @@
         "skipTypeCheck": true
       }
     },
+    "// typecheck": "Shared definition: a project opts in with '\"typecheck\": {}' and inherits the command. A project that omits it has no type gate at all, since 'dependsOn: [typecheck]' on a missing target is silently a no-op.",
     "typecheck": {
       "cache": true,
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project {projectRoot}/tsconfig.lib.json"
+      },
       "inputs": ["default", "^default", "{workspaceRoot}/tsconfig.base.json"]
     },
     "test": {

--- a/nx.json
+++ b/nx.json
@@ -107,10 +107,13 @@
       "dependsOn": ["^build"],
       "inputs": ["default", "^default"]
     },
+    "// @nx/js:swc": "Transpile only. Without skipTypeCheck the executor also runs tsc --emitDeclarationOnly per package, which costs ~2s/package and resolves each dependency from its dist/ .d.ts - that is what forced 'dependsOn: ^build' and serialised the 22 package builds into a 9-deep chain. Nothing consumes dist/packages/*, so the declarations were dead output: every @packmind/* path in tsconfig.base.json maps to packages/*/src, and api/frontend/cli all bundle from source. Type errors are caught by each package's 'typecheck' target instead, which checks against source and needs no build ordering.",
     "@nx/js:swc": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "inputs": ["default", "^default"],
+      "options": {
+        "skipTypeCheck": true
+      }
     },
     "typecheck": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -107,9 +107,10 @@
       "dependsOn": ["^build"],
       "inputs": ["default", "^default"]
     },
-    "// @nx/js:swc": "Transpile only. Without skipTypeCheck the executor also runs tsc --emitDeclarationOnly per package, which costs ~2s/package and resolves each dependency from its dist/ .d.ts - that is what forced 'dependsOn: ^build' and serialised the 22 package builds into a 9-deep chain. Nothing consumes dist/packages/*, so the declarations were dead output: every @packmind/* path in tsconfig.base.json maps to packages/*/src, and api/frontend/cli all bundle from source. Type errors are caught by each package's 'typecheck' target instead, which checks against source and needs no build ordering.",
+    "// @nx/js:swc": "Building a package still type checks it, via 'dependsOn: [typecheck]'. What changed is HOW. The executor's own type check (on by default, hence skipTypeCheck here) ran tsc --emitDeclarationOnly and resolved each dependency from its dist/ .d.ts, so it needed '^build' - which serialised the 22 packages into a 9-deep chain and cost ~2s/package regardless of size. The 'typecheck' target resolves dependencies from source instead (every @packmind/* path in tsconfig.base.json maps to packages/*/src), so it needs no build ordering: 'typecheck' has no '^', so each package depends only on its OWN type check and packages stay parallel. The declarations that emitDeclarationOnly produced were dead output - nothing reads dist/packages/*, since api/frontend/cli all bundle from source.",
     "@nx/js:swc": {
       "cache": true,
+      "dependsOn": ["typecheck"],
       "inputs": ["default", "^default"],
       "options": {
         "skipTypeCheck": true

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -150,7 +150,11 @@ packages. What it does not tell you:
 > `nx.json`). So a `project.json` that lists only `build` still has a `test` target — check with
 > `./node_modules/.bin/nx show project <package-name>` instead of reading `project.json`.
 >
-> `ui` is the one package with a hand-declared target that is not inferred:
-> `./node_modules/.bin/nx typecheck ui`. Its build output goes to `dist/packages/packmind-ui`.
+> Every package declares `typecheck` (`tsc --noEmit`), and `build` depends on it, so building a
+> package type checks it. The target is one line — `"typecheck": {}` — inheriting its command from
+> `targetDefaults` in `nx.json`; a package that omits it silently gets no type gate.
+>
+> `ui` is the one package whose `build` is not purely inferred: it declares `dependsOn` so the vite
+> build gates on `typecheck` too. Its build output goes to `dist/packages/packmind-ui`.
 
 **Example packages**: `types`, `logger`, `accounts`, `standards`, `ui`, `node-utils`, `test-utils`

--- a/packages/accounts/project.json
+++ b/packages/accounts/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/accounts/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/assets/project.json
+++ b/packages/assets/project.json
@@ -4,12 +4,7 @@
   "sourceRoot": "packages/assets/src",
   "projectType": "library",
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/assets/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/coding-agent/project.json
+++ b/packages/coding-agent/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/coding-agent/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/coding-agent/project.json
+++ b/packages/coding-agent/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/coding-agent/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/commands/project.json
+++ b/packages/commands/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/commands/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/deployments/project.json
+++ b/packages/deployments/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/deployments/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/deployments/project.json
+++ b/packages/deployments/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/deployments/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/editions/project.json
+++ b/packages/editions/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/editions/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/editions/project.json
+++ b/packages/editions/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/editions/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/feature-flags/project.json
+++ b/packages/feature-flags/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/feature-flags/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/feature-flags/project.json
+++ b/packages/feature-flags/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/feature-flags/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/frontend/project.json
+++ b/packages/frontend/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:browser"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/frontend/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/frontend/project.json
+++ b/packages/frontend/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:browser"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/frontend/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/git/project.json
+++ b/packages/git/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/git/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/integration-tests/project.json
+++ b/packages/integration-tests/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/integration-tests/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/integration-tests/project.json
+++ b/packages/integration-tests/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/integration-tests/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/linter-ast/project.json
+++ b/packages/linter-ast/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/linter-ast/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/linter-ast/project.json
+++ b/packages/linter-ast/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/linter-ast/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/linter-execution/project.json
+++ b/packages/linter-execution/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/linter-execution/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/linter-execution/project.json
+++ b/packages/linter-execution/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/linter-execution/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/llm/project.json
+++ b/packages/llm/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/llm/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/llm/project.json
+++ b/packages/llm/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/llm/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/logger/project.json
+++ b/packages/logger/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/logger/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/logger/project.json
+++ b/packages/logger/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/logger/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/migrations/project.json
+++ b/packages/migrations/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/migrations/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "bundle": {
       "executor": "@nx/esbuild:esbuild",
       "outputs": ["{options.outputPath}"],

--- a/packages/node-utils/project.json
+++ b/packages/node-utils/project.json
@@ -6,12 +6,7 @@
   "tags": ["env:node"],
   "implicitDependencies": [],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/node-utils/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/playbook-change-applier/project.json
+++ b/packages/playbook-change-applier/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/playbook-change-applier/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/playbook-change-applier/project.json
+++ b/packages/playbook-change-applier/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/playbook-change-applier/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/skills/project.json
+++ b/packages/skills/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/skills/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/skills/project.json
+++ b/packages/skills/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/skills/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/spaces/project.json
+++ b/packages/spaces/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/spaces/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/standards/project.json
+++ b/packages/standards/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/standards/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/test-utils/project.json
+++ b/packages/test-utils/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["type:util", "scope:test", "env:node"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/test-utils/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/test-utils/project.json
+++ b/packages/test-utils/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["type:util", "scope:test", "env:node"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/test-utils/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project packages/types/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": ["env:shared"],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project packages/types/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.1",
   "type": "module",
   "main": "./index.js",
-  "types": "./index.d.ts",
   "exports": {
     ".": {
       "import": "./index.mjs",

--- a/packages/ui/project.json
+++ b/packages/ui/project.json
@@ -5,7 +5,8 @@
   "projectType": "library",
   "tags": ["env:browser"],
   "// targets": "to see all targets run: nx show project ui --web",
-  "// build": "The 'build' entry below only adds dependsOn; the rest of the target is inferred from vite.config.ts by @nx/vite/plugin. It has to be declared here because the 'dependsOn: [typecheck]' that nx.json puts on @nx/js:swc never reaches ui - ui builds with vite, not swc - and without it 'nx build ui' bundles without type checking. '^build' is what the inferred target already carried; keep it.",
+  "// build": "Adds dependsOn only; the rest is inferred from vite.config.ts. Needed because ui builds with vite, so the 'dependsOn: [typecheck]' nx.json sets on @nx/js:swc does not reach it. '^build' comes from the inferred target; keep it.",
+  "// typecheck": "Kept explicit, unlike the other packages: @nx/vite/plugin also infers a 'typecheck' target here, and an empty '{}' would let that one win instead of the targetDefaults command.",
   "targets": {
     "typecheck": {
       "executor": "nx:run-commands",

--- a/packages/ui/project.json
+++ b/packages/ui/project.json
@@ -5,12 +5,16 @@
   "projectType": "library",
   "tags": ["env:browser"],
   "// targets": "to see all targets run: nx show project ui --web",
+  "// build": "The 'build' entry below only adds dependsOn; the rest of the target is inferred from vite.config.ts by @nx/vite/plugin. It has to be declared here because the 'dependsOn: [typecheck]' that nx.json puts on @nx/js:swc never reaches ui - ui builds with vite, not swc - and without it 'nx build ui' bundles without type checking. '^build' is what the inferred target already carried; keep it.",
   "targets": {
     "typecheck": {
       "executor": "nx:run-commands",
       "options": {
         "command": "tsc --noEmit --project packages/ui/tsconfig.lib.json"
       }
+    },
+    "build": {
+      "dependsOn": ["^build", "typecheck"]
     }
   }
 }

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import dts from 'vite-plugin-dts';
-import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 import tsconfigPaths from 'vite-tsconfig-paths';
@@ -13,11 +11,6 @@ export default defineConfig(() => ({
     react(),
     nxViteTsPaths(),
     nxCopyAssetsPlugin(['*.md']),
-    dts({
-      entryRoot: 'src',
-      tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
-      pathsToAliases: false,
-    }),
     tsconfigPaths(),
   ],
   // Uncomment this if you are using workers.

--- a/tools/packmind-plugin/project.json
+++ b/tools/packmind-plugin/project.json
@@ -5,12 +5,7 @@
   "projectType": "library",
   "tags": [],
   "targets": {
-    "typecheck": {
-      "executor": "nx:run-commands",
-      "options": {
-        "command": "tsc --noEmit --project tools/packmind-plugin/tsconfig.lib.json"
-      }
-    },
+    "typecheck": {},
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/tools/packmind-plugin/project.json
+++ b/tools/packmind-plugin/project.json
@@ -5,6 +5,12 @@
   "projectType": "library",
   "tags": [],
   "targets": {
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit --project tools/packmind-plugin/tsconfig.lib.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],


### PR DESCRIPTION
## Explanation

`nx run-many -t build -p packages/*` took **34.5s** in CI. It now takes **13s**, and type checks more than it did before.

The actual SWC work for all 21 packages is **2.6s**. Almost everything else was overhead, from two coupled causes.

**1. `@nx/js:swc` was type checking behind the scenes.** The executor runs `tsc --emitDeclarationOnly` unless told not to, so every package paid a full `tsc` program on top of the transpile. That cost is fixed, not proportional to package size:

| package | source files | raw `swc` | Nx task |
|---|---|---|---|
| `logger` | 4 | 69ms | 3.4s |
| `accounts` | 137 | 179ms | 3.9s |
| `types` | 531 | 365ms | 3.4s |

**2. That `tsc` resolved each dependency from its `dist/` `.d.ts`**, which is why the build carried `dependsOn: ["^build"]` — serialising 22 packages into a 9-deep chain:

```
logger → test-utils → node-utils → accounts → git → commands → coding-agent → deployments → integration-tests
```

That chain was 26.5s of the 30.1s Nx run duration. `test-utils` sits in it only because Nx sees it imported from `*.spec.ts` files; no production file imports it.

**The declarations it produced were dead output.** Every `@packmind/*` path in `tsconfig.base.json` maps to `packages/*/src`, and api (webpack), frontend (vite) and cli (esbuild) all bundle from source — nothing reads `dist/packages/*`. The job's only uploaded artifact, `dist/packages/standards/samples/generated/`, is an asset-glob copy of committed JSON.

### What changed

- **`build` is transpile-only** (`skipTypeCheck`), and the `^build` edge is gone, so packages fan out in parallel.
- **Type checking moved to a `typecheck` target** that resolves dependencies from source, so it needs no build ordering. `build` gates on it via `dependsOn: ["typecheck"]` — no `^` prefix, so each package depends only on its *own* type check and the chain does not come back. The target is **defined once** in `targetDefaults` using `{projectRoot}`; a package opts in with one line, `"typecheck": {}`.
- **`vite-plugin-dts` dropped from `ui`**, which was 12.2s of `ui:build`'s 14.2s and also produced output nothing consumes.
- **CI**: the packages job moves to `ACTION_RUNNER_TAG_8_CORES` with `--parallel=100%`. Once unchained, the job became core-bound rather than order-bound (Nx reported 16.5s of 22.4s as recoverable on 4 vCPUs). Nx caps at 3 concurrent tasks by default regardless of machine size, so without the flag the wider runner would have sat mostly idle.

Net effect on the repo: **54 insertions, 63 deletions** — the shared definition removes more duplication than the change adds, including 8 copies that predate this PR.

### Results (CI, `Build and typecheck packages`)

| | runner | Nx parallel | critical path | step |
|---|---|---|---|---|
| before | 4 cores | 3 | 26.5s / 9 tasks | **34.5s** |
| unchained | 4 cores | 3 | 5.9s / 1 task | **25.0s** |
| + 8 cores, `--parallel=100%` | 8 cores | 8 | ~6s | **13.0s** |

`Test packages` also inherits the wider runner: 113s → 80s. Job total 34.5s + 113s → 13s + 80s.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: none functionally. Build configuration only — all 21 SWC packages, `ui`, and `tools/packmind-plugin`.
- Frontend / Backend / Both: neither; this is build tooling and CI.
- Breaking changes (if any): none. No runtime or published artifact changes.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**

No runtime code changed, so no new tests. Verification focused on proving the type gate still holds and the output is unchanged.

*Output equivalence* — all 3221 emitted `.js`/asset files are byte-identical to pre-PR. The only difference anywhere in `dist/` is one line: `"types": "./index.d.ts"` removed from `dist/packages/packmind-ui/package.json`, matching the declarations the build no longer emits.

*Type gate* — all 23 projects under `packages/` and `tools/` gate `build` on their own `typecheck`, each verified by injecting a type error, and re-verified after the `targetDefaults` consolidation for an inherited target (`logger`), the explicit one (`ui`) and the tool (`packmind-plugin`). Confirmed failing for `nx build <pkg>`, `nx run-many -t build` (the `pnpm build` path), and across a package boundary. Coverage is **wider** than before: 23 projects rather than the 22 that had a build target.

*Cache correctness* — a stale cached typecheck would silently miss cross-package type errors, so this was tested directly: a repeat run hits the cache; editing only a dependency's source makes the dependent's typecheck miss and re-run; a cross-package type error fails rather than serving a stale hit. `nx affected` still resolves 32 projects from a `types/src` edit.

*Consumers* — `nx build api`, `nx build frontend`, `nx build-publish packmind-cli` and `nx run migrations:bundle-docker` all pass. Both Dockerfile.api inputs are intact (`dist/packages/migrations-bundle`, and the 37 standard-samples JSON files).

*Suite* — 21 test projects pass, lint clean across 31 projects (0 errors), `prettier -c .` clean. Full CI pipeline green including e2e, cli-e2e, SonarQube and GitGuardian.

## TODO List

- [ ] CHANGELOG Updated — not applicable; no user-facing change (the CHANGELOG tracks product, CLI and web-app behaviour)
- [x] Documentation Updated — `packages/CLAUDE.md` claimed `ui` was the only package with a hand-declared target, which this PR makes false

## Reviewer Notes

**Where to look first:** `nx.json`. Two `targetDefaults` entries carry the whole change — `@nx/js:swc` (transpile-only, gated on `typecheck`) and `typecheck` (the shared `tsc --noEmit` command). Everything in `packages/*/project.json` is the one-line opt-in. Both entries have a `"// ..."` comment explaining the reasoning.

**A missing `typecheck` target silently disables the gate.** `dependsOn: ["typecheck"]` on a project that has no such target is a no-op, not an error — verified by deleting `logger`'s target, after which `nx build logger` passed with a type error in the file. That is why every project declares it, and why the caveat is written into `nx.json` and `packages/CLAUDE.md`. Worth knowing when adding a package.

**`ui` is a special case, twice.** Its `build` is a vite target, so the `dependsOn: ["typecheck"]` on the SWC default does not reach it — declared explicitly in `packages/ui/project.json`, without which `nx build ui` would bundle a type error silently (it briefly did, earlier in this PR). And its `typecheck` stays explicit rather than `{}`, because `@nx/vite/plugin` infers a competing `typecheck` target that an empty `{}` would let win; keeping it explicit means `ui:typecheck` resolves exactly as it does on `main`.

**Both Greptile findings are addressed** (threads resolved). P1 (type gate only held in the CI job) drove the `dependsOn: ["typecheck"]` approach and the missing `packmind-plugin` target. P2 (stale `types` field) is the removed line in `packages/ui/package.json`.

**Two pre-existing issues found while working here, deliberately left alone:**

1. Every package tsconfig extends `tsconfig.base.effective.json` (gitignored, regenerated per edition by `select-tsconfig.mjs`), but Nx's cache inputs only list `tsconfig.base.json`. Switching `PACKMIND_EDITION` locally therefore serves stale cached results — demonstrated. Unchanged by this PR (`namedInputs` is untouched), and CI is unaffected since containers are fresh and there is no remote cache. One-line fix if wanted: add the effective tsconfig to `sharedGlobals`.
2. `packmind-cli` has no `typecheck` target, so `apps/cli/src` may not be type checked anywhere. esbuild never type checked, so this predates the PR.

Also pre-existing: `packages/ui/package.json` has `exports.import` pointing at `./index.mjs`, which the build has never emitted (`formats: ['es']` produces `index.js` only).

**Deliberately not done:** consolidating the 23 per-package `tsc` programs into one. Measured at ~4x less total CPU (8.2s vs ~35s), but it costs per-package caching and `nx affected` scoping, and at 13s the step no longer justifies the trade.