### PR TITLE
chore: weekly CLAUDE.md improvements

### DIFF
--- a/apps/api/CLAUDE.md
+++ b/apps/api/CLAUDE.md
@@ -8,7 +8,11 @@ Main backend API for Packmind, built with NestJS. Business logic follows hexagon
 - **Database**: PostgreSQL with TypeORM 0.3 for entity persistence
 - **Authentication**: JWT-based authentication via `@nestjs/jwt` (cookie and API-key based), no Passport strategy or refresh tokens
 - **Background Jobs**: BullMQ (via shared `packages/node-utils` and other packages) for asynchronous task processing
-- **Error Tracking**: Sentry for production error monitoring
+- **Error Tracking**: Sentry, initialised in `apps/api/src/instrument.ts`
+- **Tracing**: OpenTelemetry in `apps/api/src/otel.ts`, entirely gated on
+  `OTEL_EXPORTER_OTLP_ENDPOINT` — unset (the local default) means no exporter is started. It also
+  refuses to export when that endpoint is set but `OTEL_RESOURCE_ATTRIBUTES` carries no deployment
+  environment, rather than mislabel the deployment.
 - **API Style**: RESTful (no OpenAPI/Swagger documentation set up)
 
 ## Technologies
@@ -19,6 +23,7 @@ Main backend API for Packmind, built with NestJS. Business logic follows hexagon
 - **Redis**: Used for SSE pub/sub across instances and caching
 - **BullMQ**: Background job processing (via shared packages)
 - **Sentry**: Error tracking and monitoring
+- **OpenTelemetry**: Traces and logs export, off unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set
 
 ## Main Commands
 

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -76,7 +76,7 @@ src/application/services/               always
 src/index.ts                            always — public barrel; nothing is importable until exported here
 src/application/useCases/<useCaseName>/ all but spaces (which drives everything through services)
 src/domain/repositories|useCases|errors/ most
-src/domain/entities/                    only accounts, standards, deployments
+src/domain/entities/                    only accounts and standards
 src/infra/schemas/                      persistence packages only — <name>Schemas.ts barrel of TypeORM EntitySchemas
 src/infra/repositories/                 persistence packages only
 src/application/jobs/ + src/domain/jobs/ only commands, deployments, git

--- a/packages/coding-agent/CLAUDE.md
+++ b/packages/coding-agent/CLAUDE.md
@@ -23,7 +23,7 @@ snake_case strings, not the folder names:
 | `opencode` | `opencode/` |
 | `codex` | `codex/` |
 
-Two sibling folders are **not** agents:
+Four sibling folders are **not** registry-backed agents:
 
 - `genericSectionWriter/` — shared writers for agents whose output is a single marked-up file
   (`GenericSectionWriter`, `GenericStandardSectionWriter`, `GenericCommandSectionWriter`,
@@ -31,6 +31,11 @@ Two sibling folders are **not** agents:
   marker handling.
 - `defaultSkillsDeployer/` — deploys the built-in skills (`OnboardDeployer`,
   `UpdatePlaybookDeployer`) on top of `AbstractDefaultSkillDeployer`.
+- `utils/` — `FileUtils`, `SkillMdContentBuilder`, `YamlFrontmatterUtils`.
+- `copilotPlugin/` — `CopilotPluginDeployer` implements `ICodingAgentDeployer` but has **no**
+  `CodingAgent` key and is absent from the registry. `RenderPackageAsPluginUseCase` in
+  `packages/deployments` instantiates it directly, the same way it does `ClaudePluginDeployer`. Do not
+  expect registry changes to reach it.
 
 ## Adding an agent
 

--- a/packages/git/CLAUDE.md
+++ b/packages/git/CLAUDE.md
@@ -36,7 +36,8 @@ establish which before changing credential handling.
 
 ## Reuse
 
-`src/application/services/gitInfoHelpers.ts` already normalises owner/repo/branch/URL shapes across
-vendors. Use it instead of parsing remote URLs again.
+Owner/repo/URL parsing is **not** in this package — `@packmind/node-utils` exports `parseGitRepoInfo`,
+`parseGitProviderVendor` and `extractBaseUrl` from `packages/node-utils/src/git/`. Use those instead of
+parsing remote URLs again here.
 
 Shared package conventions (env tags, layout, `/test` subpath, branded IDs): [../CLAUDE.md](../CLAUDE.md)

--- a/packages/node-utils/CLAUDE.md
+++ b/packages/node-utils/CLAUDE.md
@@ -35,6 +35,7 @@ Note `IRepository` and `QueryOption` come from `@packmind/types`, **not** from h
 | `isFeatureEnabled` | `src/featureFlags/` | backend feature-flag gate (see the `feature-flags-authoring` skill) |
 | `Public`, `authRequest` | `src/nest/` | NestJS decorators/helpers usable without depending on the API app |
 | `migrationColumns`, `database/schemas`, `database/types` | `src/database/` | shared TypeORM column definitions and schema helpers — use these so entities stay consistent |
+| `instrumentMethods`, `withSpan` | `src/observability/` | OpenTelemetry span helpers |
 | `localDataSource` | `src/dataSources/local.ts` | |
 
 ## Text and error utilities — check here first
@@ -45,6 +46,8 @@ These are the ones most often reimplemented by hand:
   blocks into existing file content — what agent-file deployment is built on), `normalizeLineEndings`,
   `removeTrailingSlash`
 - `src/skillMd/`: `parseSkillMd`, `parseSkillMdContent` — SKILL.md frontmatter + body parsing
+- `src/git/`: `parseGitRepoInfo`, `parseGitProviderVendor`, `extractBaseUrl` — remote-URL and
+  owner/repo parsing. This, not `packages/git`, is where that logic lives
 - `src/errors/`: the shared error types
 
 Shared package conventions (env tags, layout, `/test` subpath, branded IDs): [../CLAUDE.md](../CLAUDE.md)

--- a/packages/test-utils/CLAUDE.md
+++ b/packages/test-utils/CLAUDE.md
@@ -42,6 +42,6 @@ be undone; enable `restoreMocks` in the project's `jest.config.ts` rather than r
 `jest.clearAllMocks()`.
 
 Test-writing style (naming, assertions, mock cleanup) is covered by
-`.claude/rules/packmind/standard-backend-tests-redaction.md` — not repeated here.
+the repository-root `.claude/rules/packmind/standard-backend-tests-redaction.md` — not repeated here.
 
 Shared package conventions (env tags, layout, `/test` subpath, branded IDs): [../CLAUDE.md](../CLAUDE.md)


### PR DESCRIPTION
Automated weekly run of the `improve-claude-md` skill, which delegates the audit
to Anthropic's `claude-md-improver`.

Scope: every CLAUDE.md in the repository.

- Applied only high/medium priority fixes with clear impact.
- Missing `CLAUDE.md` files inside the run's scope were created from scratch.
- Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
  deletions are expected in this diff - please check none of them went too far.
- Packmind standards sections were left untouched.

To change what this run does, edit `.claude/skills/improve-claude-md/SKILL.md`.

Please review before merging.