### PR TITLE
chore: weekly CLAUDE.md improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ This is an Nx monorepo containing applications and reusable packages.
 
 Local development uses Docker Compose to run all services (API, frontend, Redis, PostgreSQL).
 Docker Compose automatically provisions PostgreSQL and Redis - no manual setup required.
+
 ## Working with Nx
 
 The following commands apply for both NX apps and packages (use `./node_modules/.bin/nx show projects` to list actual apps and packages.)

--- a/apps/frontend/CLAUDE.md
+++ b/apps/frontend/CLAUDE.md
@@ -32,6 +32,7 @@ React Router v8 SPA for Packmind.
   `API_HOSTNAME`:`API_PORT` **only when both are set**; otherwise requests go to the frontend's own
   origin.
 - **Build output**: `apps/frontend/build/client/` — `react-router build` owns the location, not
-  `vite.config.ts`'s `build.outDir`. It is what `project.json` declares as the target's output and
-  what `dockerfile/Dockerfile.frontend` copies into nginx's document root. A `build/server/` is also
+  `vite.config.ts`'s `build.outDir`. The `build` target's outputs are inferred by `@nx/react/router-plugin`
+  (registered in the root `nx.json`), not declared in `apps/frontend/project.json`. This is what
+  `dockerfile/Dockerfile.frontend` copies into nginx's document root. A `build/server/` is also
   emitted; `ssr: false` means it exists only to prerender `index.html`, and it is not deployed.

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -8,7 +8,7 @@ This directory contains reusable domain and infrastructure packages shared acros
 
 - **types** - Shared TypeScript types and interfaces used across packages and apps
 - **logger** - Logging utilities with console and structured output support
-- **node-utils** - Node.js utility functions for file system, path manipulation, and common operations
+- **node-utils** - Shared backend framework: `BaseHexa`/`HexaRegistry`, scoped repositories, config, cache, jobs, SSE, mail
 - **test-utils** - Test factories, fixtures, and utilities for consistent test data creation
 - **migrations** - TypeORM database migrations for schema evolution
 
@@ -42,7 +42,7 @@ This directory contains reusable domain and infrastructure packages shared acros
 
 ### Supporting
 
-- **assets** - Static assets, WASM files, and embedded resources
+- **assets** - Static assets: fonts, icons, images, styles (tree-sitter WASM grammars live in `linter-ast/res/`, not here)
 - **integration-tests** - Cross-package integration test suites (deployments, standards, tracked repositories, etc.)
 
 ## Environment Tags and Import Boundaries
@@ -71,14 +71,14 @@ them; the rest exist where the package needs them, so check before assuming a di
 
 ```
 src/<Name>Hexa.ts                       always — entry point, extends BaseHexa
-src/application/adapter/<Name>Adapter.ts always
-src/application/services/               always
+src/application/adapter/<Name>Adapter.ts always — plural `adapters/` in `spaces`
+src/application/services/               most — `llm` uses `src/infra/services/` instead
 src/index.ts                            always — public barrel; nothing is importable until exported here
-src/application/useCases/<useCaseName>/ all but spaces (which drives everything through services)
+src/application/useCases/<useCaseName>/ most — `spaces` and `llm` use flat `src/application/usecases/<UseCaseName>.ts` files instead of one folder per use case
 src/domain/repositories|useCases|errors/ most
 src/domain/entities/                    only accounts and standards
 src/infra/schemas/                      persistence packages only — <name>Schemas.ts barrel of TypeORM EntitySchemas
-src/infra/repositories/                 persistence packages only
+src/infra/repositories/                 persistence packages, plus `coding-agent` (deployer implementations, not persisted entities)
 src/application/jobs/ + src/domain/jobs/ only commands, deployments, git
 test/                                   only the 7 packages listed below
 ```
@@ -87,7 +87,8 @@ test/                                   only the 7 packages listed below
 (`packages/node-utils/src/hexa/`).
 
 Two of the packages above are **not** persistence domains and diverge most: `coding-agent` has no
-`infra/schemas/`, no `test/` and stores nothing, and `llm` has schemas but no `test/`.
+`infra/schemas/` and no `test/` (its `infra/repositories/` holds deployer implementations, not
+persisted entities — see its own `CLAUDE.md`), and `llm` has schemas but no `test/`.
 
 ### Architecture rules live in `packages/.claude/rules/packmind/`
 
@@ -150,11 +151,11 @@ packages. What it does not tell you:
 > `nx.json`). So a `project.json` that lists only `build` still has a `test` target — check with
 > `./node_modules/.bin/nx show project <package-name>` instead of reading `project.json`.
 >
-> Every package declares `typecheck` (`tsc --noEmit`), and `build` depends on it, so building a
-> package type checks it. The target is one line — `"typecheck": {}` — inheriting its command from
-> `targetDefaults` in `nx.json`; a package that omits it silently gets no type gate.
+> Every package declares `typecheck` (`tsc --noEmit`). Most `build` targets depend on it via the
+> `@nx/js:swc` executor's `targetDefaults` in `nx.json`, so building one of those packages type checks
+> it; the target is one line — `"typecheck": {}` — inheriting its command from the same file. `migrations`
+> builds with `@nx/esbuild:esbuild` instead, whose `targetDefaults` do **not** depend on `typecheck`, so
+> `nx build migrations` does not type check despite the target existing.
 >
 > `ui` is the one package whose `build` is not purely inferred: it declares `dependsOn` so the vite
 > build gates on `typecheck` too. Its build output goes to `dist/packages/packmind-ui`.
-
-**Example packages**: `types`, `logger`, `accounts`, `standards`, `ui`, `node-utils`, `test-utils`

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -74,7 +74,7 @@ src/<Name>Hexa.ts                       always — entry point, extends BaseHexa
 src/application/adapter/<Name>Adapter.ts always — plural `adapters/` in `spaces`
 src/application/services/               most — `llm` uses `src/infra/services/` instead
 src/index.ts                            always — public barrel; nothing is importable until exported here
-src/application/useCases/<useCaseName>/ most — `spaces` and `llm` use flat `src/application/usecases/<UseCaseName>.ts` files instead of one folder per use case
+src/application/useCases/<useCaseName>/ most — `spaces` uses flat `src/application/usecases/<UseCaseName>.ts` files instead of one folder per use case
 src/domain/repositories|useCases|errors/ most
 src/domain/entities/                    only accounts and standards
 src/infra/schemas/                      persistence packages only — <name>Schemas.ts barrel of TypeORM EntitySchemas
@@ -153,9 +153,10 @@ packages. What it does not tell you:
 >
 > Every package declares `typecheck` (`tsc --noEmit`). Most `build` targets depend on it via the
 > `@nx/js:swc` executor's `targetDefaults` in `nx.json`, so building one of those packages type checks
-> it; the target is one line — `"typecheck": {}` — inheriting its command from the same file. `migrations`
-> builds with `@nx/esbuild:esbuild` instead, whose `targetDefaults` do **not** depend on `typecheck`, so
-> `nx build migrations` does not type check despite the target existing.
+> it; the target is one line — `"typecheck": {}` — inheriting its command from the same file.
+> `migrations` has **no** `build` target at all — its esbuild output is produced by `bundle`
+> (`@nx/esbuild:esbuild`), whose `targetDefaults` depend on `^build` but not on `typecheck`, so
+> `nx bundle migrations` does not type check. Run `nx typecheck migrations` separately.
 >
 > `ui` is the one package whose `build` is not purely inferred: it declares `dependsOn` so the vite
 > build gates on `typecheck` too. Its build output goes to `dist/packages/packmind-ui`.

--- a/packages/coding-agent/CLAUDE.md
+++ b/packages/coding-agent/CLAUDE.md
@@ -22,6 +22,7 @@ snake_case strings, not the folder names:
 | `continue` | `continue/` |
 | `opencode` | `opencode/` |
 | `codex` | `codex/` |
+| `kiro` | `kiro/` |
 
 Four sibling folders are **not** registry-backed agents:
 
@@ -61,8 +62,9 @@ These do **not** fail at compile time — miss one and the agent misbehaves at r
 - **`createDeployer`'s switch** in the same file — its `default` throws at runtime rather than
   failing the build.
 - **`CODING_AGENT_ARTEFACT_PATHS`** — `packages/types/src/coding-agent/CodingAgentArtefactPaths.ts`.
-  It is a `Partial<Record<…>>`, so a missing entry compiles fine; needed only for agents that write
-  artefacts to their own directories.
+  It is total over `MultiFileCodingAgent` (the compiler forces an entry there) and only
+  `Partial<Record<CodingAgent, …>>` over the rest, so a missing entry compiles fine **only** for an
+  agent outside `MultiFileCodingAgent`.
 
 Then:
 

--- a/packages/editions/CLAUDE.md
+++ b/packages/editions/CLAUDE.md
@@ -9,9 +9,11 @@ builds swap the aliases to real implementations.
 `PACKMIND_EDITION` (or `VITE_PACKMIND_EDITION`, defaulting to `oss`) is read by
 `scripts/select-tsconfig.mjs`, which merges `tsconfig.base.json` with either
 `tsconfig.paths.oss.json` or `tsconfig.paths.proprietary.json` and writes the **generated**
-`tsconfig.base.effective.json`. Most `jest.config.ts` files `require` that generated file and feed
-its `paths` to `pathsToModuleNameMapper`, so nothing type-checks or tests until it has been
-produced; a handful of packages still point their jest config at the plain `tsconfig.base.json`.
+`tsconfig.base.effective.json`. Nearly every `tsconfig.json` extends it, so **nothing type-checks**
+until it has been produced. Tests are more uneven: half of the `jest.config.ts` files `require` the
+generated file and feed its `paths` to `pathsToModuleNameMapper` (those need it too), `deployments`
+still reads the plain `tsconfig.base.json`, and the rest declare no path mapping at all and run
+without it.
 
 In OSS, all of these resolve to `packages/editions/src/index.ts`:
 

--- a/packages/editions/CLAUDE.md
+++ b/packages/editions/CLAUDE.md
@@ -9,9 +9,9 @@ builds swap the aliases to real implementations.
 `PACKMIND_EDITION` (or `VITE_PACKMIND_EDITION`, defaulting to `oss`) is read by
 `scripts/select-tsconfig.mjs`, which merges `tsconfig.base.json` with either
 `tsconfig.paths.oss.json` or `tsconfig.paths.proprietary.json` and writes the **generated**
-`tsconfig.base.effective.json`. Every `jest.config.ts` in the monorepo `require`s that generated
-file and feeds its `paths` to `pathsToModuleNameMapper`, so nothing type-checks or tests until it
-has been produced.
+`tsconfig.base.effective.json`. Most `jest.config.ts` files `require` that generated file and feed
+its `paths` to `pathsToModuleNameMapper`, so nothing type-checks or tests until it has been
+produced; a handful of packages still point their jest config at the plain `tsconfig.base.json`.
 
 In OSS, all of these resolve to `packages/editions/src/index.ts`:
 

--- a/packages/editions/CLAUDE.md
+++ b/packages/editions/CLAUDE.md
@@ -9,11 +9,15 @@ builds swap the aliases to real implementations.
 `PACKMIND_EDITION` (or `VITE_PACKMIND_EDITION`, defaulting to `oss`) is read by
 `scripts/select-tsconfig.mjs`, which merges `tsconfig.base.json` with either
 `tsconfig.paths.oss.json` or `tsconfig.paths.proprietary.json` and writes the **generated**
-`tsconfig.base.effective.json`. Nearly every `tsconfig.json` extends it, so **nothing type-checks**
-until it has been produced. Tests are more uneven: half of the `jest.config.ts` files `require` the
-generated file and feed its `paths` to `pathsToModuleNameMapper` (those need it too), `deployments`
-still reads the plain `tsconfig.base.json`, and the rest declare no path mapping at all and run
-without it.
+`tsconfig.base.effective.json`. Most projects need it before they type check or test, but not all —
+check the project you are in rather than assuming:
+
+- **typecheck**: 25 of the 31 `tsconfig.json` files extend the generated config and fail until it
+  exists. The six that extend the plain `tsconfig.base.json` instead need no setup: `linter-ast`,
+  `linter-execution`, `llm`, `logger`, `test-utils` and `apps/cli-e2e-tests`.
+- **test**: 13 of the 26 `jest.config.ts` files `require` the generated config and feed its `paths`
+  to `pathsToModuleNameMapper`; `deployments` reads the plain `tsconfig.base.json`; the other twelve
+  declare no path mapping at all and run without either.
 
 In OSS, all of these resolve to `packages/editions/src/index.ts`:
 

--- a/packages/integration-tests/CLAUDE.md
+++ b/packages/integration-tests/CLAUDE.md
@@ -42,7 +42,7 @@ targeted error.
 
 | Helper | Use |
 | --- | --- |
-| `helpers/integrationTest.ts` | `integrationTest` / `integrationTestWithUser` wrappers; give the `getContext` accessor |
+| `helpers/integrationTest.ts` | `integrationTest` / `integrationTestWithUser` wrappers; the test callback takes a `getContext` accessor |
 | `helpers/TestApp.ts` | reach a domain through `testContext.testApp.<domain>Hexa.getAdapter()` |
 | `helpers/createIntegrationTestFixture.ts` | schema created once per file; `snapshot()` / `cleanup()` rewind between tests |
 | `helpers/DataFactory.ts` / `DataQuery.ts` | seed and read fixture data |

--- a/packages/linter-ast/CLAUDE.md
+++ b/packages/linter-ast/CLAUDE.md
@@ -23,6 +23,12 @@ Registered keys: `typescript`, `javascript`, `python`, `java`, `go`, `kotlin`, `
 > `TypeScriptTSXParser` exists in `src/parsers/` and is exported from `src/index.ts`, but is **not**
 > in `parserClasses` — `getParser('tsx')` throws. Use it directly if you need TSX.
 
+> `css` is registered but `res/` has no `tree-sitter-css.wasm` — only `tree-sitter-scss.wasm`.
+> `getParser('css')` throws `ParserInitializationError` at runtime; add the missing grammar file
+> before relying on it. Separately, `YAMLParser` is registered in `parserClasses` but not
+> re-exported from `src/index.ts` — the other 15 parsers are, so this is likely an oversight rather
+> than intentional.
+
 Other entry points: `src/core/BaseParser.ts` (the class to extend) and
 `src/application/LinterAstAdapter.ts` (what consumers outside the package use).
 

--- a/packages/node-utils/CLAUDE.md
+++ b/packages/node-utils/CLAUDE.md
@@ -33,8 +33,8 @@ Note `IRepository` and `QueryOption` come from `@packmind/types`, **not** from h
 | `SSEEventPublisher`, `RedisSSEClient` | `src/sse/` | server-sent events to the frontend |
 | `MailService`, `SmtpMailService` | `src/mail/` | |
 | `isFeatureEnabled` | `src/featureFlags/` | backend feature-flag gate (see the `feature-flags-authoring` skill) |
-| `Public`, `authRequest` | `src/nest/` | NestJS decorators/helpers usable without depending on the API app |
-| `migrationColumns`, `database/schemas`, `database/types` | `src/database/` | shared TypeORM column definitions and schema helpers — use these so entities stay consistent |
+| `Public`, `AuthenticatedRequest` | `src/nest/` | NestJS decorators/helpers usable without depending on the API app |
+| `uuidMigrationColumn`, `timestampsMigrationColumns`, `softDeleteMigrationColumns`, `database/schemas`, `database/types` | `src/database/` | shared TypeORM column definitions and schema helpers — use these so entities stay consistent |
 | `instrumentMethods`, `withSpan` | `src/observability/` | OpenTelemetry span helpers |
 | `localDataSource` | `src/dataSources/local.ts` | |
 

--- a/packages/playbook-change-applier/CLAUDE.md
+++ b/packages/playbook-change-applier/CLAUDE.md
@@ -40,7 +40,8 @@ the reporting and rollback paths will silently omit the new type.
 1. Add the version type to `ApplierObjectVersions` in
    `packages/types/src/playbookChangeManagement/applier/`, alongside the per-type
    `*ChangeProposalApplier` helpers the appliers build on, and extend
-   `getItemTypeFromChangeProposalType`.
+   `getItemTypeFromChangeProposalType` (one level up, in
+   `packages/types/src/playbookChangeManagement/ChangeProposalType.ts`).
 2. Add `src/appliers/<Type>ChangesApplier.ts` and export it from `src/appliers/index.ts`.
 3. Widen every inline `itemType: 'standard' | 'command' | 'skill'` annotation, then update each
    switch in `ApplyPlaybookUseCase`:

--- a/packages/test-utils/CLAUDE.md
+++ b/packages/test-utils/CLAUDE.md
@@ -11,10 +11,11 @@ own — most of what a new spec needs already exists.
 
 > **`src/factories/standards/`, `git/`, `deployments/` and `commands/` are stale duplicates.** They
 > re-declare factories that also exist in the domain packages' `test/` folders (e.g. `standardFactory`
-> is byte-identical to the one in `packages/standards/test/`). They are exported from `src/index.ts`
-> but have **no call sites** — every spec imports from `@packmind/<pkg>/test`. Do not add entity
-> factories here, and when you touch one of these, change the `@packmind/<pkg>/test` copy: that is the
-> one actually under test.
+> is byte-identical to the one in `packages/standards/test/`). They are exported from `src/index.ts`;
+> almost every spec imports from `@packmind/<pkg>/test` instead, with two known exceptions
+> (`apps/frontend/src/domain/deployments/components/{StandardCentricView,CommandCentricView}/*.spec.tsx`).
+> Do not add entity factories here, and when you touch one of these, change the `@packmind/<pkg>/test`
+> copy: that is the one actually under test.
 
 ## What's available
 


### PR DESCRIPTION
Automated weekly run of the `improve-claude-md` skill, which delegates the audit
to Anthropic's `claude-md-improver`.

Scope: every CLAUDE.md in the repository.

- Applied only high/medium priority fixes with clear impact.
- Missing `CLAUDE.md` files inside the run's scope were created from scratch.
- Removed instructions that duplicate a repository skill (`.claude/skills/*/SKILL.md`), so
  deletions are expected in this diff - please check none of them went too far.
- Packmind standards sections were left untouched.

To change what this run does, edit `.claude/skills/improve-claude-md/SKILL.md`.

Please review before merging.