### PR TITLE
Remove orga-space-management feature flag

### DIFF
--- a/apps/frontend/app/routes/org.$orgSlug._protected.settings.spaces._index.tsx
+++ b/apps/frontend/app/routes/org.$orgSlug._protected.settings.spaces._index.tsx
@@ -1,11 +1,6 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { useLoaderData } from 'react-router';
-import {
-  DEFAULT_FEATURE_DOMAIN_MAP,
-  ORGA_SPACE_MANAGEMENT_FEATURE_KEY,
-  PMFeatureFlag,
-  PMPage,
-} from '@packmind/ui';
+import { PMPage } from '@packmind/ui';
 import { queryClient } from '../../src/shared/data/queryClient';
 import { ensureOrgContext } from '../../src/shared/data/ensureOrgContext';
 import { getSpacesQueryOptions } from '../../src/domain/spaces/api/queries/SpacesQueries';
@@ -26,7 +21,7 @@ export async function clientLoader({ params }: LoaderFunctionArgs) {
 }
 
 export default function SettingsSpacesRouteModule() {
-  const { user, organization } = useAuthContext();
+  const { organization } = useAuthContext();
   const { spaceCount } = useLoaderData<typeof clientLoader>();
 
   if (!organization) {
@@ -41,14 +36,8 @@ export default function SettingsSpacesRouteModule() {
         }`;
 
   return (
-    <PMFeatureFlag
-      featureKeys={[ORGA_SPACE_MANAGEMENT_FEATURE_KEY]}
-      featureDomainMap={DEFAULT_FEATURE_DOMAIN_MAP}
-      userEmail={user?.email}
-    >
-      <PMPage title="Spaces" subtitle={subtitle} actions={<SpacesToolbar />}>
-        <SpacesManagementPage />
-      </PMPage>
-    </PMFeatureFlag>
+    <PMPage title="Spaces" subtitle={subtitle} actions={<SpacesToolbar />}>
+      <SpacesManagementPage />
+    </PMPage>
   );
 }

--- a/packages/feature-flags/src/registry.ts
+++ b/packages/feature-flags/src/registry.ts
@@ -2,8 +2,6 @@
 export const ADD_CHANGE_PROPOSALS_IN_WEBAPP_FEATURE_KEY =
   'change-proposals-in-webapp';
 
-export const ORGA_SPACE_MANAGEMENT_FEATURE_KEY = 'orga-space-management';
-
 /**
  * Gates the switch that flips a space's navigation between the current
  * information architecture and the plugin-first one. The flag guards the
@@ -29,7 +27,6 @@ export const COPILOT_MARKETPLACE_FEATURE_KEY = 'copilot-marketplace';
  */
 export type FeatureFlagKey =
   | 'change-proposals-in-webapp'
-  | 'orga-space-management'
   | 'space-nav-plugin-first'
   | 'copilot-marketplace';
 
@@ -41,7 +38,6 @@ export const DEFAULT_FEATURE_DOMAIN_MAP: Record<
     '@packmind.com',
     '@promyze.com',
   ],
-  [ORGA_SPACE_MANAGEMENT_FEATURE_KEY]: ['@packmind.com', '@promyze.com'],
   [SPACE_NAV_PLUGIN_FIRST_FEATURE_KEY]: ['@packmind.com', '@promyze.com'],
   [COPILOT_MARKETPLACE_FEATURE_KEY]: ['@packmind.com', '@promyze.com'],
 };

--- a/packages/node-utils/src/featureFlags/isFeatureEnabled.spec.ts
+++ b/packages/node-utils/src/featureFlags/isFeatureEnabled.spec.ts
@@ -24,14 +24,6 @@ describe('isFeatureEnabled', () => {
       );
     });
 
-    it('reads the SCREAMING_SNAKE env key for the orga-space-management flag', async () => {
-      getConfigSpy.mockResolvedValue('on');
-
-      await isFeatureEnabled('orga-space-management', {});
-
-      expect(getConfigSpy).toHaveBeenCalledWith('FF_ORGA_SPACE_MANAGEMENT');
-    });
-
     describe('when set to "on"', () => {
       it('returns true', async () => {
         getConfigSpy.mockResolvedValue('on');
@@ -118,16 +110,6 @@ describe('isFeatureEnabled', () => {
       });
 
       expect(result).toBe(false);
-    });
-
-    it('gates the orga-space-management flag by its allowed domain', async () => {
-      getConfigSpy.mockResolvedValue(null);
-
-      const result = await isFeatureEnabled('orga-space-management', {
-        userEmail: 'user@packmind.com',
-      });
-
-      expect(result).toBe(true);
     });
   });
 

--- a/packages/ui/src/lib/components/content/PMFeatureFlag/PMFeatureFlag.tsx
+++ b/packages/ui/src/lib/components/content/PMFeatureFlag/PMFeatureFlag.tsx
@@ -12,7 +12,6 @@ import {
  */
 export {
   ADD_CHANGE_PROPOSALS_IN_WEBAPP_FEATURE_KEY,
-  ORGA_SPACE_MANAGEMENT_FEATURE_KEY,
   DEFAULT_FEATURE_DOMAIN_MAP,
   isFeatureFlagEnabled,
 } from '@packmind/feature-flags';


### PR DESCRIPTION
## Explanation

This PR removes the `orga-space-management` feature flag, which has been fully rolled out and is no longer needed. The flag was used to gate the spaces management page in organization settings, but is now enabled for all users.

Changes include:
- Removed the `PMFeatureFlag` wrapper from the spaces settings route, exposing the spaces management page to all users
- Removed the `ORGA_SPACE_MANAGEMENT_FEATURE_KEY` constant and its domain mapping from the feature flags registry
- Removed the feature flag type definition and related test cases
- Cleaned up unused imports in the frontend route

## Type of Change

- [x] Refactoring
- [x] Breaking change (removal of exported constant)

## Affected Components

- Domain packages affected: `@packmind/feature-flags`, `@packmind/node-utils`
- Frontend / Backend: Frontend
- Breaking changes: `ORGA_SPACE_MANAGEMENT_FEATURE_KEY` constant removed from `@packmind/feature-flags` exports

## Testing

- [x] Unit tests updated (removed test cases for orga-space-management flag)
- Existing tests pass

**Test Details:**
Removed test cases that specifically validated the orga-space-management feature flag behavior:
- Test for reading the `FF_ORGA_SPACE_MANAGEMENT` environment variable
- Test for domain-based gating of the orga-space-management flag

## TODO List

- [ ] CHANGELOG Updated
- [ ] Documentation Updated

## Reviewer Notes

This is a straightforward cleanup of a fully-rolled-out feature flag. The spaces management page is now accessible to all users without any feature flag checks. No functional changes to the actual spaces management feature itself.

https://claude.ai/code/session_01NSCmXbHtSz8Qwi3uQiAXoT