### PR TITLE
👷 ci(node-utils): type check the tests, not just the lib

### DIFF
--- a/packages/node-utils/project.json
+++ b/packages/node-utils/project.json
@@ -5,8 +5,13 @@
   "projectType": "library",
   "tags": ["env:node"],
   "implicitDependencies": [],
+  "// typecheck": "Overrides the targetDefaults command so the gate also covers tsconfig.spec.json (specs plus the shared suites in test/), which tsconfig.lib.json excludes.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/node-utils/tsconfig.lib.json && tsc --noEmit --project packages/node-utils/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/node-utils/src/application/AbstractAdminUseCase.spec.ts
+++ b/packages/node-utils/src/application/AbstractAdminUseCase.spec.ts
@@ -68,6 +68,7 @@ describe('AbstractAdminUseCase', () => {
   const buildUser = (overrides?: Partial<User>): User => ({
     id: userId,
     email: 'admin@test.com',
+    displayName: null,
     passwordHash: 'hash',
     active: true,
     memberships: [buildMembership()],

--- a/packages/node-utils/src/application/AbstractMemberUseCase.spec.ts
+++ b/packages/node-utils/src/application/AbstractMemberUseCase.spec.ts
@@ -67,6 +67,7 @@ describe('AbstractMemberUseCase', () => {
   const buildUser = (overrides?: Partial<User>): User => ({
     id: userId,
     email: 'member@test.com',
+    displayName: null,
     passwordHash: 'hash',
     active: true,
     memberships: [

--- a/packages/node-utils/src/application/AbstractSpaceAdminUseCase.spec.ts
+++ b/packages/node-utils/src/application/AbstractSpaceAdminUseCase.spec.ts
@@ -85,6 +85,7 @@ describe('AbstractSpaceAdminUseCase', () => {
   const buildUser = (overrides?: Partial<User>): User => ({
     id: userId,
     email: 'user@test.com',
+    displayName: null,
     passwordHash: 'hash',
     active: true,
     memberships: [buildOrgMembership()],

--- a/packages/node-utils/src/application/AbstractSpaceMemberUseCase.spec.ts
+++ b/packages/node-utils/src/application/AbstractSpaceMemberUseCase.spec.ts
@@ -85,6 +85,7 @@ describe('AbstractSpaceMemberUseCase', () => {
   const buildUser = (overrides?: Partial<User>): User => ({
     id: userId,
     email: 'user@test.com',
+    displayName: null,
     passwordHash: 'hash',
     active: true,
     memberships: [buildOrgMembership()],

--- a/packages/node-utils/src/hexa/events/PackmindEventEmitterService.spec.ts
+++ b/packages/node-utils/src/hexa/events/PackmindEventEmitterService.spec.ts
@@ -1,14 +1,25 @@
-import { UserEvent } from '@packmind/types';
+import {
+  createOrganizationId,
+  createUserId,
+  UserEvent,
+  UserEventPayload,
+} from '@packmind/types';
 import { DataSource } from 'typeorm';
 import { PackmindEventEmitterService } from './PackmindEventEmitterService';
 
-class TestUserCreatedEvent extends UserEvent<{ userId: string }> {
+class TestUserCreatedEvent extends UserEvent {
   static override readonly eventName = 'test.user.created';
 }
 
-class TestUserDeletedEvent extends UserEvent<{ userId: string }> {
+class TestUserDeletedEvent extends UserEvent {
   static override readonly eventName = 'test.user.deleted';
 }
+
+const buildPayload = (userId: string): UserEventPayload => ({
+  userId: createUserId(userId),
+  organizationId: createOrganizationId('organization-id'),
+  source: 'ui',
+});
 
 describe('PackmindEventEmitterService', () => {
   let service: PackmindEventEmitterService;
@@ -33,7 +44,7 @@ describe('PackmindEventEmitterService', () => {
         service.on(TestUserCreatedEvent, jest.fn());
 
         const result = service.emit(
-          new TestUserCreatedEvent({ userId: 'user-123' }),
+          new TestUserCreatedEvent(buildPayload('user-123')),
         );
 
         expect(result).toBe(true);
@@ -43,7 +54,7 @@ describe('PackmindEventEmitterService', () => {
     describe('when event has no listeners', () => {
       it('returns false', () => {
         const result = service.emit(
-          new TestUserCreatedEvent({ userId: 'user-123' }),
+          new TestUserCreatedEvent(buildPayload('user-123')),
         );
 
         expect(result).toBe(false);
@@ -54,21 +65,22 @@ describe('PackmindEventEmitterService', () => {
       const handler = jest.fn();
       service.on(TestUserCreatedEvent, handler);
 
-      const event = new TestUserCreatedEvent({ userId: 'user-123' });
+      const event = new TestUserCreatedEvent(buildPayload('user-123'));
       service.emit(event);
 
       expect(handler).toHaveBeenCalledWith(event);
     });
 
     it('provides access to payload in handler', () => {
-      let receivedPayload: { userId: string } | undefined;
+      const payload = buildPayload('user-456');
+      let receivedPayload: UserEventPayload | undefined;
       service.on(TestUserCreatedEvent, (event) => {
         receivedPayload = event.payload;
       });
 
-      service.emit(new TestUserCreatedEvent({ userId: 'user-456' }));
+      service.emit(new TestUserCreatedEvent(payload));
 
-      expect(receivedPayload).toEqual({ userId: 'user-456' });
+      expect(receivedPayload).toEqual(payload);
     });
   });
 
@@ -77,7 +89,7 @@ describe('PackmindEventEmitterService', () => {
       const handler = jest.fn();
 
       service.on(TestUserCreatedEvent, handler);
-      service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
+      service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
 
       expect(handler).toHaveBeenCalledTimes(1);
     });
@@ -91,7 +103,7 @@ describe('PackmindEventEmitterService', () => {
         handler2 = jest.fn();
         service.on(TestUserCreatedEvent, handler1);
         service.on(TestUserCreatedEvent, handler2);
-        service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
+        service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
       });
 
       it('calls first handler once', () => {
@@ -112,7 +124,7 @@ describe('PackmindEventEmitterService', () => {
         deletedHandler = jest.fn();
         service.on(TestUserCreatedEvent, createdHandler);
         service.on(TestUserDeletedEvent, deletedHandler);
-        service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
+        service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
       });
 
       it('calls handler for emitted event type', () => {
@@ -184,8 +196,8 @@ describe('PackmindEventEmitterService', () => {
         service.on(TestUserCreatedEvent, handler1);
         service.on(TestUserDeletedEvent, handler2);
         service.removeAllListeners();
-        service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
-        service.emit(new TestUserDeletedEvent({ userId: 'user-456' }));
+        service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
+        service.emit(new TestUserDeletedEvent(buildPayload('user-456')));
       });
 
       it('does not call first event handler', () => {
@@ -210,7 +222,7 @@ describe('PackmindEventEmitterService', () => {
       service.on(TestUserCreatedEvent, handler);
 
       service.destroy();
-      service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
+      service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
 
       expect(handler).not.toHaveBeenCalled();
     });
@@ -225,7 +237,7 @@ describe('PackmindEventEmitterService', () => {
         results.push(event.payload.userId);
       });
 
-      service.emit(new TestUserCreatedEvent({ userId: 'user-123' }));
+      service.emit(new TestUserCreatedEvent(buildPayload('user-123')));
 
       await new Promise((resolve) => setTimeout(resolve, 20));
 

--- a/packages/node-utils/src/hexa/events/PackmindListener.spec.ts
+++ b/packages/node-utils/src/hexa/events/PackmindListener.spec.ts
@@ -1,10 +1,15 @@
-import { UserEvent, SystemEvent } from '@packmind/types';
+import {
+  createOrganizationId,
+  createUserId,
+  UserEvent,
+  UserEventPayload,
+  SystemEvent,
+} from '@packmind/types';
 import { DataSource } from 'typeorm';
 import { PackmindEventEmitterService } from './PackmindEventEmitterService';
 import { PackmindListener } from './PackmindListener';
 
 class TestUserCreatedEvent extends UserEvent<{
-  userId: string;
   email: string;
 }> {
   static override readonly eventName = 'test.user.created';
@@ -16,6 +21,16 @@ class TestSyncCompletedEvent extends SystemEvent<{
 }> {
   static override readonly eventName = 'test.sync.completed';
 }
+
+const buildUserCreatedPayload = (
+  userId: string,
+  email: string,
+): UserEventPayload & { email: string } => ({
+  userId: createUserId(userId),
+  organizationId: createOrganizationId('organization-id'),
+  source: 'ui',
+  email,
+});
 
 interface StubAdapter {
   handleUserCreated(userId: string, email: string): void;
@@ -91,10 +106,9 @@ describe('PackmindListener', () => {
       listener.initialize(eventService);
 
       eventService.emit(
-        new TestUserCreatedEvent({
-          userId: 'user-123',
-          email: 'test@example.com',
-        }),
+        new TestUserCreatedEvent(
+          buildUserCreatedPayload('user-123', 'test@example.com'),
+        ),
       );
 
       expect(stubAdapter.handleUserCreated).toHaveBeenCalledWith(
@@ -108,10 +122,9 @@ describe('PackmindListener', () => {
       listener.initialize(eventService);
 
       eventService.emit(
-        new TestUserCreatedEvent({
-          userId: 'user-456',
-          email: 'another@example.com',
-        }),
+        new TestUserCreatedEvent(
+          buildUserCreatedPayload('user-456', 'another@example.com'),
+        ),
       );
 
       expect(stubAdapter.handleUserCreated).toHaveBeenCalledTimes(1);
@@ -123,10 +136,9 @@ describe('PackmindListener', () => {
         listener.initialize(eventService);
 
         eventService.emit(
-          new TestUserCreatedEvent({
-            userId: 'user-123',
-            email: 'test@example.com',
-          }),
+          new TestUserCreatedEvent(
+            buildUserCreatedPayload('user-123', 'test@example.com'),
+          ),
         );
         eventService.emit(
           new TestSyncCompletedEvent({
@@ -158,10 +170,9 @@ describe('PackmindListener', () => {
       listener.initialize(eventService);
 
       eventService.emit(
-        new TestUserCreatedEvent({
-          userId: 'user-789',
-          email: 'user@test.com',
-        }),
+        new TestUserCreatedEvent(
+          buildUserCreatedPayload('user-789', 'user@test.com'),
+        ),
       );
 
       expect(stubAdapter.handleUserCreated).toHaveBeenCalledWith(
@@ -211,10 +222,9 @@ describe('PackmindListener', () => {
       listener2.initialize(eventService);
 
       eventService.emit(
-        new TestUserCreatedEvent({
-          userId: 'user-shared',
-          email: 'shared@example.com',
-        }),
+        new TestUserCreatedEvent(
+          buildUserCreatedPayload('user-shared', 'shared@example.com'),
+        ),
       );
     });
 
@@ -240,10 +250,9 @@ describe('PackmindListener', () => {
         listener.initialize(eventService);
 
         eventService.emit(
-          new TestUserCreatedEvent({
-            userId: 'user-123',
-            email: 'test@example.com',
-          }),
+          new TestUserCreatedEvent(
+            buildUserCreatedPayload('user-123', 'test@example.com'),
+          ),
         );
       });
 

--- a/packages/node-utils/src/skillMd/parseSkillMdContent.spec.ts
+++ b/packages/node-utils/src/skillMd/parseSkillMdContent.spec.ts
@@ -44,7 +44,7 @@ describe('parseSkillMdContent', () => {
     it('normalises allowed-tools to allowedTools', () => {
       const result = parseSkillMdContent(content);
 
-      expect(result?.properties.allowedTools).toBe('Read, Write');
+      expect(result?.properties['allowedTools']).toBe('Read, Write');
     });
 
     it('does not include the original allowed-tools key', () => {
@@ -92,7 +92,7 @@ describe('parseSkillMdContent', () => {
     it('trims content before parsing', () => {
       const result = parseSkillMdContent(content);
 
-      expect(result?.properties.name).toBe('Trimmed');
+      expect(result?.properties['name']).toBe('Trimmed');
     });
   });
 

--- a/packages/node-utils/tsconfig.spec.json
+++ b/packages/node-utils/tsconfig.spec.json
@@ -11,6 +11,7 @@
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
     "src/**/*.d.ts",
-    "src/testUtils/**/*.ts"
+    "src/testUtils/**/*.ts",
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Explanation

`node-utils` inherited the shared `typecheck` target, which only builds `tsconfig.lib.json` — specs are excluded there and `test/` was in neither project, so @swc/jest was stripping their types unchecked. Enabling `tsconfig.spec.json` surfaced 23 errors across 7 spec files; all were fixture drift, fixed in the first commit, then the gate is wired in the second.

Drift: 4 user fixtures missing the required `displayName`, 17 event payloads redeclaring `userId` as a bare string (discarding the `UserId` brand) and omitting `organizationId`/`source`, 2 index-signature property accesses under `noPropertyAccessFromIndexSignature`.

## Type of Change

- [x] Improvement/Enhancement

## Affected Components

- Domain packages affected: `node-utils` only
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:** `nx run-many -t typecheck -p packages/*` (23 projects green), `nx test node-utils` (425 pass, none skipped), `nx lint node-utils`, `prettier -c`. Gate verified by injecting a type error into a spec and into a `test/` helper no spec imports — both fail the run-many command.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

No production bug — all 23 were fixture drift, and the tests pass unchanged. Separately worth noting: `packages/node-utils/test/sharedTests/` duplicates the suites in `@packmind/test-utils` and nothing imports it; it is now type checked, but a follow-up could delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKgzhMudhLwKrUSMuuGZXz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKgzhMudhLwKrUSMuuGZXz)_