### PR TITLE
👷 build(accounts): restore type checking on the test files

### DIFF
--- a/packages/accounts/project.json
+++ b/packages/accounts/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/accounts/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Overrides the shared nx.json command to add tsconfig.spec.json: @swc/jest strips types without checking them, so the specs and the test/ factories are otherwise unchecked.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/accounts/tsconfig.lib.json && tsc --noEmit --project packages/accounts/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/accounts/src/application/adapter/AccountsAdapter.spec.ts
+++ b/packages/accounts/src/application/adapter/AccountsAdapter.spec.ts
@@ -13,6 +13,10 @@ import {
 import { EnhancedAccountsServices } from '../services/EnhancedAccountsServices';
 import { AccountsAdapter } from './AccountsAdapter';
 
+// Derived from the adapter itself so the "no ports" cases below cannot drift
+// away from the real signature the way a re-declared literal did.
+type AccountsAdapterPorts = Parameters<AccountsAdapter['initialize']>[0];
+
 describe('AccountsAdapter', () => {
   let adapter: AccountsAdapter;
   let mockLogger: PackmindLogger;
@@ -78,27 +82,13 @@ describe('AccountsAdapter', () => {
     describe('when called with no ports', () => {
       it('throws an error', async () => {
         await expect(
-          adapter.initialize(
-            {} as {
-              [ISpacesPortName]: ISpacesPort;
-              [IGitPortName]: IGitPort;
-              [IStandardsPortName]: IStandardsPort;
-              [IDeploymentPortName]: IDeploymentPort;
-            },
-          ),
+          adapter.initialize({} as AccountsAdapterPorts),
         ).rejects.toThrow();
       });
 
       it('sets adapter as ready', async () => {
         try {
-          await adapter.initialize(
-            {} as {
-              [ISpacesPortName]: ISpacesPort;
-              [IGitPortName]: IGitPort;
-              [IStandardsPortName]: IStandardsPort;
-              [IDeploymentPortName]: IDeploymentPort;
-            },
-          );
+          await adapter.initialize({} as AccountsAdapterPorts);
         } catch {
           // Expected to throw
         }

--- a/packages/accounts/src/application/services/ApiKeyService.spec.ts
+++ b/packages/accounts/src/application/services/ApiKeyService.spec.ts
@@ -2,6 +2,7 @@ import { ApiKeyService, IJwtService } from './ApiKeyService';
 import { User, createUserId } from '@packmind/types';
 import { Organization, createOrganizationId } from '@packmind/types';
 import { PackmindLogger, LogLevel } from '@packmind/logger';
+import { organizationFactory, userFactory } from '../../../test';
 
 // Mock JWT service
 class MockJwtService implements IJwtService {
@@ -75,11 +76,9 @@ describe('ApiKeyService', () => {
 
     const userId = createUserId('user-123');
 
-    mockUser = {
+    mockUser = userFactory({
       id: userId,
-      email: 'testuser@packmind.com',
       passwordHash: 'hash',
-      active: true,
       memberships: [
         {
           userId,
@@ -87,13 +86,12 @@ describe('ApiKeyService', () => {
           role: 'admin',
         },
       ],
-    };
+    });
 
-    mockOrganization = {
+    mockOrganization = organizationFactory({
       id: createOrganizationId('org-456'),
-      name: 'Test Organization',
       slug: 'test-org',
-    };
+    });
   });
 
   describe('generateApiKey', () => {

--- a/packages/accounts/src/application/services/UserMetadataService.spec.ts
+++ b/packages/accounts/src/application/services/UserMetadataService.spec.ts
@@ -1,6 +1,10 @@
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
-import { createUserId, createUserMetadataId } from '@packmind/types';
+import {
+  createUserId,
+  createUserMetadataId,
+  UserMetadata,
+} from '@packmind/types';
 import { IUserMetadataRepository } from '../../domain/repositories/IUserMetadataRepository';
 import { UserMetadataService } from './UserMetadataService';
 
@@ -47,7 +51,7 @@ describe('UserMetadataService', () => {
 
     describe('when user has metadata without this provider', () => {
       it('appends the provider', async () => {
-        const existing = {
+        const existing: UserMetadata = {
           id: createUserMetadataId('meta-1'),
           userId,
           onboardingCompleted: true,
@@ -68,7 +72,7 @@ describe('UserMetadataService', () => {
 
     describe('when user already has this provider', () => {
       it('does not duplicate the provider', async () => {
-        const existing = {
+        const existing: UserMetadata = {
           id: createUserMetadataId('meta-1'),
           userId,
           onboardingCompleted: true,

--- a/packages/accounts/src/application/services/UserService.spec.ts
+++ b/packages/accounts/src/application/services/UserService.spec.ts
@@ -177,13 +177,12 @@ describe('UserService', () => {
           organizationId,
           role: 'admin',
         };
-        user = {
+        user = userFactory({
           id: existingMembership.userId,
           email: 'member@packmind.com',
           passwordHash: null,
-          active: true,
           memberships: [existingMembership],
-        };
+        });
         result = await userService.addOrganizationMembership(
           user,
           organizationId,

--- a/packages/accounts/src/application/useCases/activateUserAccount/ActivateUserAccountUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/activateUserAccount/ActivateUserAccountUseCase.spec.ts
@@ -20,6 +20,7 @@ import {
 import { InvitationService } from '../../services/InvitationService';
 import { UserService } from '../../services/UserService';
 import { ActivateUserAccountUseCase } from './ActivateUserAccountUseCase';
+import { userFactory } from '../../../../test';
 
 describe('ActivateUserAccountUseCase', () => {
   let useCase: ActivateUserAccountUseCase;
@@ -33,7 +34,7 @@ describe('ActivateUserAccountUseCase', () => {
   const mockInvitationId = createInvitationId('invitation-123');
   const mockToken = createInvitationToken('valid-token-123');
 
-  const mockUser: User = {
+  const mockUser: User = userFactory({
     id: mockUserId,
     email: 'test@example.com',
     passwordHash: null,
@@ -45,7 +46,7 @@ describe('ActivateUserAccountUseCase', () => {
         role: 'member',
       },
     ],
-  };
+  });
 
   const mockInvitation: Invitation = {
     id: mockInvitationId,

--- a/packages/accounts/src/application/useCases/createCliLoginCode/CreateCliLoginCodeUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/createCliLoginCode/CreateCliLoginCodeUseCase.spec.ts
@@ -21,7 +21,11 @@ describe('CreateCliLoginCodeUseCase', () => {
       save: jest.fn(),
       delete: jest.fn(),
       deleteExpired: jest.fn(),
-    } as unknown as jest.Mocked<ICliLoginCodeRepository>;
+      addMany: jest.fn(),
+      deleteById: jest.fn(),
+      restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
+    } as jest.Mocked<ICliLoginCodeRepository>;
 
     useCase = new CreateCliLoginCodeUseCase(mockRepository);
   });

--- a/packages/accounts/src/application/useCases/createCliLoginCode/CreateCliLoginCodeUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/createCliLoginCode/CreateCliLoginCodeUseCase.spec.ts
@@ -21,7 +21,7 @@ describe('CreateCliLoginCodeUseCase', () => {
       save: jest.fn(),
       delete: jest.fn(),
       deleteExpired: jest.fn(),
-    } as jest.Mocked<ICliLoginCodeRepository>;
+    } as unknown as jest.Mocked<ICliLoginCodeRepository>;
 
     useCase = new CreateCliLoginCodeUseCase(mockRepository);
   });

--- a/packages/accounts/src/application/useCases/createOrganization/CreateOrganizationUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/createOrganization/CreateOrganizationUseCase.spec.ts
@@ -14,6 +14,7 @@ import {
   UserSpaceRole,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { userFactory } from '../../../../test';
 
 describe('CreateOrganizationUseCase', () => {
   let createOrganizationUseCase: CreateOrganizationUseCase;
@@ -74,13 +75,12 @@ describe('CreateOrganizationUseCase', () => {
       let mockUser: User;
 
       beforeEach(() => {
-        mockUser = {
+        mockUser = userFactory({
           id: userId,
           email: 'test@example.com',
           passwordHash: 'hash',
-          active: true,
           memberships: [],
-        };
+        });
       });
 
       describe('when user exists', () => {
@@ -247,13 +247,12 @@ describe('CreateOrganizationUseCase', () => {
       let mockUser: User;
 
       beforeEach(() => {
-        mockUser = {
+        mockUser = userFactory({
           id: userId,
           email: 'test@example.com',
           passwordHash: 'hash',
-          active: true,
           memberships: [],
-        };
+        });
 
         mockUserService.getUserById.mockResolvedValue(mockUser);
         mockOrganizationService.createOrganization.mockResolvedValue(
@@ -432,13 +431,12 @@ describe('CreateOrganizationUseCase', () => {
       let mockUser: User;
 
       beforeEach(async () => {
-        mockUser = {
+        mockUser = userFactory({
           id: userId,
           email: 'test@example.com',
           passwordHash: 'hash',
-          active: true,
           memberships: [],
-        };
+        });
 
         mockUserService.getUserById.mockResolvedValue(mockUser);
         const serviceError = new Error('Organization already exists');
@@ -478,13 +476,12 @@ describe('CreateOrganizationUseCase', () => {
 
     describe('with non-Error exception', () => {
       beforeEach(() => {
-        const mockUser: User = {
+        const mockUser: User = userFactory({
           id: userId,
           email: 'test@example.com',
           passwordHash: 'hash',
-          active: true,
           memberships: [],
-        };
+        });
 
         mockUserService.getUserById.mockResolvedValue(mockUser);
         const serviceError = 'Database connection failed';
@@ -505,13 +502,12 @@ describe('CreateOrganizationUseCase', () => {
       let minimalOrganization: Organization;
 
       beforeEach(() => {
-        mockUser = {
+        mockUser = userFactory({
           id: userId,
           email: 'test@example.com',
           passwordHash: 'hash',
-          active: true,
           memberships: [],
-        };
+        });
         minimalOrganization = {
           ...mockOrganization,
           name: 'A',

--- a/packages/accounts/src/application/useCases/exchangeCliLoginCode/ExchangeCliLoginCodeUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/exchangeCliLoginCode/ExchangeCliLoginCodeUseCase.spec.ts
@@ -35,7 +35,11 @@ describe('ExchangeCliLoginCodeUseCase', () => {
       save: jest.fn(),
       delete: jest.fn(),
       deleteExpired: jest.fn(),
-    } as unknown as jest.Mocked<ICliLoginCodeRepository>;
+      addMany: jest.fn(),
+      deleteById: jest.fn(),
+      restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
+    } as jest.Mocked<ICliLoginCodeRepository>;
 
     mockUserService = {
       getUserById: jest.fn(),

--- a/packages/accounts/src/application/useCases/exchangeCliLoginCode/ExchangeCliLoginCodeUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/exchangeCliLoginCode/ExchangeCliLoginCodeUseCase.spec.ts
@@ -35,7 +35,7 @@ describe('ExchangeCliLoginCodeUseCase', () => {
       save: jest.fn(),
       delete: jest.fn(),
       deleteExpired: jest.fn(),
-    } as jest.Mocked<ICliLoginCodeRepository>;
+    } as unknown as jest.Mocked<ICliLoginCodeRepository>;
 
     mockUserService = {
       getUserById: jest.fn(),

--- a/packages/accounts/src/application/useCases/updateUserDisplayName/UpdateUserDisplayNameUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/updateUserDisplayName/UpdateUserDisplayNameUseCase.spec.ts
@@ -1,5 +1,4 @@
 import { PackmindLogger } from '@packmind/logger';
-import { MemberContext } from '@packmind/node-utils';
 import { stubLogger } from '@packmind/test-utils';
 import {
   IAccountsPort,
@@ -45,26 +44,28 @@ describe('UpdateUserDisplayNameUseCase', () => {
     jest.clearAllMocks();
   });
 
-  describe('executeForMembers', () => {
-    const user = userFactory({ id: userId });
-    const organization = organizationFactory({ id: organizationId });
+  describe('execute', () => {
     const membership = {
       userId,
       organizationId,
       role: 'member' as const,
     };
+    const user = userFactory({ id: userId, memberships: [membership] });
+    const organization = organizationFactory({ id: organizationId });
+
+    beforeEach(() => {
+      mockAccountsPort.getUserById.mockResolvedValue(user);
+      mockAccountsPort.getOrganizationById.mockResolvedValue(organization);
+    });
 
     describe('when setting a display name', () => {
       let result: UpdateUserDisplayNameResponse;
 
       beforeEach(async () => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: 'Joan Racenet',
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -72,7 +73,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: 'Joan Racenet',
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       it('calls updateUser with the new display name', () => {
@@ -91,13 +92,10 @@ describe('UpdateUserDisplayNameUseCase', () => {
       let result: UpdateUserDisplayNameResponse;
 
       beforeEach(async () => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: null,
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -105,7 +103,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: null,
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       it('calls updateUser with null display name', () => {
@@ -124,13 +122,10 @@ describe('UpdateUserDisplayNameUseCase', () => {
       let result: UpdateUserDisplayNameResponse;
 
       beforeEach(async () => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: '  Joan Racenet  ',
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -138,7 +133,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: 'Joan Racenet',
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       it('trims the display name before saving', () => {
@@ -157,13 +152,10 @@ describe('UpdateUserDisplayNameUseCase', () => {
       let result: UpdateUserDisplayNameResponse;
 
       beforeEach(async () => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: 'Joan    Racenet',
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -171,7 +163,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: 'Joan Racenet',
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       it('normalizes consecutive spaces to single space', () => {
@@ -190,16 +182,13 @@ describe('UpdateUserDisplayNameUseCase', () => {
       let executePromise: Promise<UpdateUserDisplayNameResponse>;
 
       beforeEach(() => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: 'a'.repeat(256),
-          user,
-          organization,
-          membership,
         };
 
-        executePromise = useCase.executeForMembers(command);
+        executePromise = useCase.execute(command);
       });
 
       it('throws InvalidDisplayNameError', async () => {
@@ -217,13 +206,10 @@ describe('UpdateUserDisplayNameUseCase', () => {
 
       beforeEach(async () => {
         const name = 'a'.repeat(255);
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: name,
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -231,7 +217,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: name,
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       it('accepts the display name', () => {
@@ -247,13 +233,10 @@ describe('UpdateUserDisplayNameUseCase', () => {
       let result: UpdateUserDisplayNameResponse;
 
       beforeEach(async () => {
-        const command: UpdateUserDisplayNameCommand & MemberContext = {
+        const command: UpdateUserDisplayNameCommand = {
           userId: String(userId),
           organizationId,
           displayName: '   ',
-          user,
-          organization,
-          membership,
         };
 
         mockUserService.updateUser.mockResolvedValue({
@@ -261,7 +244,7 @@ describe('UpdateUserDisplayNameUseCase', () => {
           displayName: null,
         });
 
-        result = await useCase.executeForMembers(command);
+        result = await useCase.execute(command);
       });
 
       describe('when only whitespace', () => {

--- a/packages/accounts/src/application/useCases/validateInvitationToken/ValidateInvitationTokenUseCase.spec.ts
+++ b/packages/accounts/src/application/useCases/validateInvitationToken/ValidateInvitationTokenUseCase.spec.ts
@@ -10,6 +10,7 @@ import {
 import { createUserId, User } from '@packmind/types';
 import { createOrganizationId } from '@packmind/types';
 import { stubLogger } from '@packmind/test-utils';
+import { userFactory } from '../../../../test';
 
 describe('ValidateInvitationTokenUseCase', () => {
   let useCase: ValidateInvitationTokenUseCase;
@@ -22,7 +23,7 @@ describe('ValidateInvitationTokenUseCase', () => {
   const mockInvitationId = createInvitationId('invitation-123');
   const mockToken = createInvitationToken('valid-token-123');
 
-  const mockUser: User = {
+  const mockUser: User = userFactory({
     id: mockUserId,
     email: 'test@example.com',
     passwordHash: null,
@@ -34,7 +35,7 @@ describe('ValidateInvitationTokenUseCase', () => {
         role: 'member',
       },
     ],
-  };
+  });
 
   const mockInvitation: Invitation = {
     id: mockInvitationId,

--- a/packages/accounts/tsconfig.spec.json
+++ b/packages/accounts/tsconfig.spec.json
@@ -10,6 +10,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Explanation

`packages/accounts`' specs were never type checked: the shared `typecheck` in `nx.json` only runs `tsc -p tsconfig.lib.json`, which excludes `src/**/*.spec.ts`, and `@swc/jest` strips types without checking them. Turning the check on surfaced 22 errors, all fixture drift. Fixed the tests, then wired `tsconfig.spec.json` into the package's `typecheck` command so it stays on.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: `accounts` (tests and build config only — no `src/` production code touched)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

**Drift categories:** missing `User.displayName` on hand-written literals (9), `executeForMembers` called past its `protected` modifier (7), `UserMetadata.socialProviders` widened to `string[]` (2), partial `ICliLoginCodeRepository` mocks missing 4 `IRepository` methods (2), re-declared `AccountsAdapter.initialize` port literal missing `eventEmitterService` (2).

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**
`nx test accounts` (42 suites / 721 tests, same count as before), `nx lint accounts`, `prettier -c`, and `nx run-many -t typecheck -p packages/*` — verified failing by injecting a type error into a spec and into an unimported `test/` helper.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

No production bug — all 22 were fixture drift, and the tests pass unchanged.

Two fixes are worth a look because they go beyond patching a literal:

- `UpdateUserDisplayNameUseCase.spec.ts` reached into the `protected executeForMembers`. It now drives the public `execute()` with `getUserById`/`getOrganizationById` stubbed, matching `RemoveUserFromOrganizationUseCase.spec.ts`; assertions are unchanged.
- `AccountsAdapter.spec.ts` hand-duplicated `initialize`'s parameter type in two `{} as {...}` casts, which is how it drifted. Both now use `Parameters<AccountsAdapter['initialize']>[0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3yVqXKPVGH5d5qnQQ3Mh9

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3yVqXKPVGH5d5qnQQ3Mh9)_