### PR TITLE
👷 ci(git): type check the test files of packages/git

### DIFF
--- a/packages/git/project.json
+++ b/packages/git/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/git/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Extends the shared definition with a second pass over tsconfig.spec.json: the lib project excludes specs and test/, and @swc/jest strips their types without checking them.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/git/tsconfig.lib.json && tsc --noEmit --project packages/git/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/git/src/application/GitProviderService.spec.ts
+++ b/packages/git/src/application/GitProviderService.spec.ts
@@ -11,8 +11,6 @@ import {
   createGitProviderId,
 } from '@packmind/types';
 import { createOrganizationId } from '@packmind/types';
-import { PackmindLogger } from '@packmind/logger';
-import { stubLogger } from '@packmind/test-utils';
 import {
   gitProviderFactory,
   gitlabProviderFactory,
@@ -24,7 +22,6 @@ describe('GitProviderService', () => {
   let mockGitProviderRepository: jest.Mocked<IGitProviderRepository>;
   let mockGitProviderFactory: jest.Mocked<IGitProviderFactory>;
   let mockGitRepoFactory: jest.Mocked<IGitRepoFactory>;
-  let stubbedLogger: jest.Mocked<PackmindLogger>;
   let mockGithubProviderInstance: jest.Mocked<IGitProvider>;
   let mockGitlabProviderInstance: jest.Mocked<IGitProvider>;
 
@@ -54,8 +51,6 @@ describe('GitProviderService', () => {
       list: jest.fn(),
       update: jest.fn(),
     } as unknown as jest.Mocked<IGitProviderRepository>;
-
-    stubbedLogger = stubLogger();
 
     mockGithubProviderInstance = {
       listAvailableRepositories: jest.fn(),
@@ -96,7 +91,6 @@ describe('GitProviderService', () => {
       mockGitProviderRepository,
       mockGitProviderFactory,
       mockGitRepoFactory,
-      stubbedLogger,
     );
   });
 
@@ -111,6 +105,7 @@ describe('GitProviderService', () => {
       organizationId: createOrganizationId('org-1'),
       url: 'https://api.github.com',
       authMethod: 'token' as const,
+      displayName: '',
     };
     let result: GitProvider;
 

--- a/packages/git/src/application/GitRepoService.spec.ts
+++ b/packages/git/src/application/GitRepoService.spec.ts
@@ -45,6 +45,8 @@ describe('GitRepoService', () => {
       branch: 'main',
       providerId: createGitProviderId('provider-1'),
       type: 'standard',
+      isTracked: false,
+      trackingRemovedAt: null,
     };
     let result: GitRepo;
 

--- a/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
+++ b/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
@@ -15,6 +15,7 @@ import {
   User,
   Organization,
 } from '@packmind/types';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { gitProviderFactory } from '../../../../test';
 import { stubLogger } from '@packmind/test-utils';
 
@@ -23,11 +24,10 @@ describe('AddGitProviderUseCase', () => {
   let mockGitProviderService: jest.Mocked<GitProviderService>;
   let accountsAdapter: jest.Mocked<IAccountsPort>;
   const organizationId = createOrganizationId('org-123');
-  const memberUser: User = {
+  const memberUser: User = userFactory({
     id: createUserId('user-123'),
     email: 'member@example.com',
     passwordHash: null,
-    active: true,
     memberships: [
       {
         userId: createUserId('user-123'),
@@ -35,12 +35,12 @@ describe('AddGitProviderUseCase', () => {
         role: 'member',
       },
     ],
-  };
-  const organization: Organization = {
+  });
+  const organization: Organization = organizationFactory({
     id: organizationId,
     name: 'Test Org',
     slug: 'test-org',
-  };
+  });
 
   beforeEach(() => {
     mockGitProviderService = {
@@ -71,6 +71,7 @@ describe('AddGitProviderUseCase', () => {
         url: 'https://github.com',
         token: 'test-token',
         authMethod: 'token' as const,
+        displayName: '',
       },
       organizationId: organizationId,
       userId: memberUser.id,
@@ -115,6 +116,7 @@ describe('AddGitProviderUseCase', () => {
         url: 'https://github.com',
         token: '',
         authMethod: 'token' as const,
+        displayName: '',
       },
       organizationId: organizationId,
       userId: memberUser.id,
@@ -147,6 +149,7 @@ describe('AddGitProviderUseCase', () => {
         url: 'https://github.com',
         token: 'test-token',
         authMethod: 'token' as const,
+        displayName: '',
       },
       organizationId: organizationId,
       userId: memberUser.id,
@@ -200,6 +203,7 @@ describe('AddGitProviderUseCase', () => {
               url: 'https://github.com',
               token: 'my-token',
               authMethod: 'token',
+              displayName: '',
             },
             organizationId,
             userId: memberUser.id,
@@ -220,6 +224,7 @@ describe('AddGitProviderUseCase', () => {
                 url: 'https://github.com',
                 token: '',
                 authMethod: 'token',
+                displayName: '',
               },
               organizationId,
               userId: memberUser.id,
@@ -255,6 +260,7 @@ describe('AddGitProviderUseCase', () => {
               token: null,
               authMethod: 'app',
               appInstallationId: 42,
+              displayName: '',
             },
             organizationId,
             userId: memberUser.id,
@@ -275,6 +281,7 @@ describe('AddGitProviderUseCase', () => {
                 url: 'https://github.com',
                 token: null,
                 authMethod: 'app',
+                displayName: '',
               },
               organizationId,
               userId: memberUser.id,
@@ -307,6 +314,7 @@ describe('AddGitProviderUseCase', () => {
               authMethod: 'app',
               appInstallationId: 42,
               organizationGitHubAppId: orgGitHubAppId,
+              displayName: '',
             },
             organizationId,
             userId: memberUser.id,
@@ -328,6 +336,7 @@ describe('AddGitProviderUseCase', () => {
                 token: null,
                 authMethod: 'app' as const,
                 organizationGitHubAppId: orgGitHubAppId,
+                displayName: '',
               },
               organizationId,
               userId: memberUser.id,
@@ -348,6 +357,7 @@ describe('AddGitProviderUseCase', () => {
                 token: null,
                 authMethod: 'app',
                 appInstallationId: 42,
+                displayName: '',
               },
               organizationId,
               userId: memberUser.id,
@@ -371,6 +381,7 @@ describe('AddGitProviderUseCase', () => {
                 authMethod: 'app',
                 appInstallationId: 42,
                 organizationGitHubAppId: orgGitHubAppId,
+                displayName: '',
               },
               organizationId,
               userId: memberUser.id,
@@ -389,6 +400,7 @@ describe('AddGitProviderUseCase', () => {
           url: 'https://github.com',
           token: null,
           authMethod: 'token' as const,
+          displayName: '',
         },
         organizationId: organizationId,
         userId: memberUser.id,
@@ -434,6 +446,7 @@ describe('AddGitProviderUseCase', () => {
           url: 'https://github.com',
           token: null,
           authMethod: 'token' as const,
+          displayName: '',
         },
         organizationId: organizationId,
         userId: memberUser.id,
@@ -467,6 +480,7 @@ describe('AddGitProviderUseCase', () => {
           url: 'https://github.com',
           token: null,
           authMethod: 'token' as const,
+          displayName: '',
         },
         organizationId: organizationId,
         userId: memberUser.id,
@@ -500,6 +514,10 @@ describe('AddGitProviderUseCase', () => {
         url: 'https://github.com',
         token: 'test-token',
         authMethod: 'token' as const,
+        // The route has no runtime DTO validation, so displayName can genuinely
+        // be absent even though the command type declares it - that absence is
+        // exactly what the cases below exercise.
+        displayName: undefined as unknown as string,
       },
       organizationId,
       userId: memberUser.id,

--- a/packages/git/src/application/useCases/addGitRepo/AddGitRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/addGitRepo/AddGitRepoUseCase.spec.ts
@@ -23,8 +23,10 @@ import {
   createUserId,
 } from '@packmind/types';
 
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { stubLogger } from '@packmind/test-utils';
 import { v4 as uuidv4 } from 'uuid';
+import { gitProviderFactory, gitRepoFactory } from '../../../../test';
 
 describe('AddGitRepoUseCase', () => {
   let useCase: AddGitRepoUseCase;
@@ -53,7 +55,7 @@ describe('AddGitRepoUseCase', () => {
       addTarget: jest.fn(),
     } as Partial<jest.Mocked<IDeploymentPort>> as jest.Mocked<IDeploymentPort>;
 
-    const adminUser: User = {
+    const adminUser: User = userFactory({
       id: userId,
       email: 'admin@example.com',
       displayName: 'admin',
@@ -66,13 +68,13 @@ describe('AddGitRepoUseCase', () => {
           role: 'admin',
         },
       ],
-    };
+    });
 
-    const organization: Organization = {
+    const organization: Organization = organizationFactory({
       id: organizationId,
       name: 'Test Org',
       slug: 'test-org',
-    };
+    });
 
     mockAccountsAdapter = {
       getUserById: jest.fn().mockResolvedValue(adminUser),
@@ -108,23 +110,23 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      mockProvider = {
+      mockProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: 'token',
         authMethod: 'token',
-      };
+      });
 
-      expectedResult = {
+      expectedResult = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -182,22 +184,22 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      mockProvider = {
+      mockProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: 'token',
-      };
+      });
 
-      expectedResult = {
+      expectedResult = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -235,23 +237,23 @@ describe('AddGitRepoUseCase', () => {
         branch: 'develop',
       };
 
-      mockProvider = {
+      mockProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: 'token',
         authMethod: 'token',
-      };
+      });
 
-      expectedResult = {
+      expectedResult = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'develop',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -306,23 +308,23 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      mockProvider = {
+      mockProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: 'token',
         authMethod: 'token',
-      };
+      });
 
-      expectedResult = {
+      expectedResult = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockTarget = {
         id: createTargetId(uuidv4()),
@@ -448,14 +450,14 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId: createOrganizationId(uuidv4()), // Different organization
         url: 'https://github.com',
         token: 'token',
         authMethod: 'token',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -476,14 +478,14 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: null,
         authMethod: 'token',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -506,7 +508,7 @@ describe('AddGitRepoUseCase', () => {
 
       // App-auth providers carry no token — the installation token is minted
       // on demand by GithubTokenResolverFactory downstream.
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
@@ -514,15 +516,15 @@ describe('AddGitRepoUseCase', () => {
         token: null,
         authMethod: 'app',
         appInstallationId: 12345,
-      };
+      });
 
-      const expectedResult: GitRepo = {
+      const expectedResult: GitRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -547,23 +549,23 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: 'token',
         authMethod: 'token',
-      };
+      });
 
-      const existingRepo: GitRepo = {
+      const existingRepo: GitRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -590,23 +592,23 @@ describe('AddGitRepoUseCase', () => {
         allowTokenlessProvider: true,
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: null,
         authMethod: 'token',
-      };
+      });
 
-      const expectedResult: GitRepo = {
+      const expectedResult: GitRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'testowner',
         repo: 'testrepo',
         branch: 'main',
         providerId: gitProviderId,
         type: 'standard',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -632,14 +634,14 @@ describe('AddGitRepoUseCase', () => {
         allowTokenlessProvider: false,
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: null,
         authMethod: 'token',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,
@@ -660,14 +662,14 @@ describe('AddGitRepoUseCase', () => {
         branch: 'main',
       };
 
-      const mockProvider: GitProvider = {
+      const mockProvider: GitProvider = gitProviderFactory({
         id: gitProviderId,
         source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         token: null,
         authMethod: 'token',
-      };
+      });
 
       mockGitProviderService.findGitProviderById.mockResolvedValue(
         mockProvider,

--- a/packages/git/src/application/useCases/checkDirectoryExistence/CheckDirectoryExistenceUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkDirectoryExistence/CheckDirectoryExistenceUseCase.spec.ts
@@ -55,7 +55,7 @@ describe('CheckDirectoryExistenceUseCase', () => {
       getFileOnRepo: jest.fn(),
       commitFiles: jest.fn(),
       listDirectoriesOnRepo: jest.fn(),
-    } as jest.Mocked<IGitRepo>;
+    } as unknown as jest.Mocked<IGitRepo>;
 
     // Mock IGitRepoFactory
     mockGitRepoFactory = {

--- a/packages/git/src/application/useCases/checkProviderAuth/CheckProviderAuthUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkProviderAuth/CheckProviderAuthUseCase.spec.ts
@@ -1,4 +1,5 @@
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   createOrganizationId,
   createUserId,
@@ -19,7 +20,7 @@ describe('CheckProviderAuthUseCase', () => {
   const organizationId = createOrganizationId('org-123');
   const userId = createUserId('user-123');
 
-  const user: User = {
+  const user: User = userFactory({
     id: userId,
     email: 'test@example.com',
     passwordHash: null,
@@ -31,13 +32,13 @@ describe('CheckProviderAuthUseCase', () => {
         role: 'member',
       },
     ],
-  };
+  });
 
-  const organization: Organization = {
+  const organization: Organization = organizationFactory({
     id: organizationId,
     name: 'Test Organization',
     slug: 'test-org',
-  };
+  });
 
   beforeEach(() => {
     mockGitProviderService = {

--- a/packages/git/src/application/useCases/commitToGit/CommitToGitUseCase.spec.ts
+++ b/packages/git/src/application/useCases/commitToGit/CommitToGitUseCase.spec.ts
@@ -12,7 +12,11 @@ import {
 } from '@packmind/types';
 import { IGitRepo } from '../../../domain/repositories/IGitRepo';
 import { IGitRepoFactory } from '../../../domain/repositories/IGitRepoFactory';
-import { gitCommitFactory } from '../../../../test/gitCommitFactory';
+import {
+  gitCommitFactory,
+  gitProviderFactory,
+  gitRepoFactory,
+} from '../../../../test';
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 import { createOrganizationId } from '@packmind/types';
@@ -78,22 +82,22 @@ describe('CommitToGitUseCase', () => {
   });
 
   describe('commitToGit', () => {
-    const mockGitProvider: GitProvider = {
+    const mockGitProvider: GitProvider = gitProviderFactory({
       id: createGitProviderId('provider-id'),
       source: GitProviderVendors.github,
       organizationId: createOrganizationId('org-id'),
       url: null,
       token: 'github-token',
       authMethod: 'token',
-    };
+    });
 
-    const mockGitRepo: GitRepo = {
+    const mockGitRepo: GitRepo = gitRepoFactory({
       id: createGitRepoId('repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       branch: 'main',
       providerId: createGitProviderId('provider-id'),
-    };
+    });
 
     describe('when committing multiple files to git', () => {
       const files = [

--- a/packages/git/src/application/useCases/findOrCreateGitRepo/FindOrCreateGitRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/findOrCreateGitRepo/FindOrCreateGitRepoUseCase.spec.ts
@@ -14,6 +14,7 @@ import {
   User,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { gitRepoFactory } from '../../../../test';
 import { FindOrCreateGitRepoUseCase } from './FindOrCreateGitRepoUseCase';
 
 describe('FindOrCreateGitRepoUseCase', () => {
@@ -78,14 +79,14 @@ describe('FindOrCreateGitRepoUseCase', () => {
 
     beforeEach(async () => {
       const tokenProviderId = createGitProviderId(uuidv4());
-      existingRepo = {
+      existingRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'dev',
         providerId: tokenProviderId,
         isTracked: false,
-      };
+      });
 
       mockGitPort.listProviders.mockResolvedValue({
         providers: [
@@ -135,14 +136,14 @@ describe('FindOrCreateGitRepoUseCase', () => {
         authMethod: 'token',
         displayName: '',
       };
-      createdRepo = {
+      createdRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'dev',
         providerId: newProviderId,
         isTracked: false,
-      };
+      });
 
       mockGitPort.listProviders.mockResolvedValue({ providers: [] });
       mockGitPort.addGitProvider.mockResolvedValue(createdProvider);

--- a/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
@@ -8,6 +8,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { createGitProviderId } from '@packmind/types';
 import { GitRepo, createGitRepoId } from '@packmind/types';
+import { gitRepoFactory } from '../../../../test';
 import { GitProviderService } from '../../GitProviderService';
 import { GetAvailableRemoteDirectoriesUseCase } from './GetAvailableRemoteDirectoriesUseCase';
 
@@ -64,13 +65,13 @@ describe('GetAvailableTargetsUseCase', () => {
   describe('execute', () => {
     const organizationId = createOrganizationId(uuidv4());
     const userId = createUserId(uuidv4());
-    const mockGitRepo: GitRepo = {
+    const mockGitRepo: GitRepo = gitRepoFactory({
       id: createGitRepoId(uuidv4()),
       owner: 'test-owner',
       repo: 'test-repo',
       branch: 'main',
       providerId: createGitProviderId(uuidv4()),
-    };
+    });
     const validCommand: GetAvailableRemoteDirectoriesCommand = {
       userId,
       organizationId,

--- a/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
@@ -41,7 +41,7 @@ describe('GetFileFromRepoUseCase', () => {
       commitFiles: jest.fn(),
       listDirectoriesOnRepo: jest.fn(),
       checkDirectoryExists: jest.fn(),
-    } as jest.Mocked<IGitRepo>;
+    } as unknown as jest.Mocked<IGitRepo>;
 
     gitRepoFactory = {
       createGitRepo: jest.fn().mockImplementation((_gitRepo, provider) => {

--- a/packages/git/src/application/useCases/getTrackedRepository/GetTrackedRepositoryUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getTrackedRepository/GetTrackedRepositoryUseCase.spec.ts
@@ -11,6 +11,7 @@ import {
   User,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { gitRepoFactory } from '../../../../test';
 import { GitRepoService } from '../../GitRepoService';
 import { GetTrackedRepositoryUseCase } from './GetTrackedRepositoryUseCase';
 
@@ -29,14 +30,14 @@ describe('GetTrackedRepositoryUseCase', () => {
     repo: 'widgets',
   };
 
-  const trackedRepo: GitRepo = {
+  const trackedRepo: GitRepo = gitRepoFactory({
     id: createGitRepoId(uuidv4()),
     owner: 'acme',
     repo: 'widgets',
     branch: 'main',
     providerId: createGitProviderId(uuidv4()),
     isTracked: true,
-  };
+  });
 
   beforeEach(() => {
     mockGitRepoService = {

--- a/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
+++ b/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
@@ -1,4 +1,5 @@
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   createOrganizationId,
   createUserId,
@@ -18,7 +19,7 @@ describe('ListProvidersUseCase', () => {
   const organizationId = createOrganizationId('org-123');
   const userId = createUserId('user-123');
 
-  const user: User = {
+  const user: User = userFactory({
     id: userId,
     email: 'test@example.com',
     passwordHash: null,
@@ -30,13 +31,13 @@ describe('ListProvidersUseCase', () => {
         role: 'member',
       },
     ],
-  };
+  });
 
-  const organization: Organization = {
+  const organization: Organization = organizationFactory({
     id: organizationId,
     name: 'Test Organization',
     slug: 'test-org',
-  };
+  });
 
   beforeEach(() => {
     mockGitProviderService = {

--- a/packages/git/src/application/useCases/setTrackedRepository/SetTrackedRepositoryUseCase.spec.ts
+++ b/packages/git/src/application/useCases/setTrackedRepository/SetTrackedRepositoryUseCase.spec.ts
@@ -17,6 +17,7 @@ import {
   UserOrganizationRole,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { gitRepoFactory } from '../../../../test';
 import { GitRepoService } from '../../GitRepoService';
 import { SetTrackedRepositoryUseCase } from './SetTrackedRepositoryUseCase';
 
@@ -98,14 +99,14 @@ describe('SetTrackedRepositoryUseCase', () => {
     let emittedEvent: RepositoryTrackingSetEvent;
 
     beforeEach(async () => {
-      createdRepo = {
+      createdRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'dev',
         providerId,
         isTracked: false,
-      };
+      });
       trackedRepo = { ...createdRepo, isTracked: true };
 
       mockGitRepoService.findTrackedByOwnerRepoInOrganization.mockResolvedValue(
@@ -171,14 +172,14 @@ describe('SetTrackedRepositoryUseCase', () => {
     let result: GitRepo;
 
     beforeEach(async () => {
-      existing = {
+      existing = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'dev',
         providerId,
         isTracked: true,
-      };
+      });
       mockGitRepoService.findTrackedByOwnerRepoInOrganization.mockResolvedValue(
         existing,
       );
@@ -202,14 +203,14 @@ describe('SetTrackedRepositoryUseCase', () => {
   describe('when a different branch is already tracked', () => {
     beforeEach(() => {
       mockGitRepoService.findTrackedByOwnerRepoInOrganization.mockResolvedValue(
-        {
+        gitRepoFactory({
           id: createGitRepoId(uuidv4()),
           owner: 'acme',
           repo: 'widgets',
           branch: 'main',
           providerId,
           isTracked: true,
-        },
+        }),
       );
     });
 

--- a/packages/git/src/application/useCases/updateGitProvider/UpdateGitProviderUseCase.spec.ts
+++ b/packages/git/src/application/useCases/updateGitProvider/UpdateGitProviderUseCase.spec.ts
@@ -1,4 +1,5 @@
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   GitProviderDisplayNameAlreadyUsedError,
   GitProviderDisplayNameNotEditableError,
@@ -24,7 +25,7 @@ describe('UpdateGitProviderUseCase', () => {
   let accountsAdapter: jest.Mocked<IAccountsPort>;
 
   const organizationId = createOrganizationId('org-123');
-  const adminUser: User = {
+  const adminUser: User = userFactory({
     id: createUserId('admin-123'),
     email: 'admin@example.com',
     passwordHash: null,
@@ -36,12 +37,12 @@ describe('UpdateGitProviderUseCase', () => {
         role: 'admin',
       },
     ],
-  };
-  const organization: Organization = {
+  });
+  const organization: Organization = organizationFactory({
     id: organizationId,
     name: 'Test Org',
     slug: 'test-org',
-  };
+  });
 
   const makeUseCase = (mode: 'shared' | 'on-prem' = 'on-prem') =>
     new UpdateGitProviderUseCase(

--- a/packages/git/src/application/useCases/updateTrackedBranch/UpdateTrackedBranchUseCase.spec.ts
+++ b/packages/git/src/application/useCases/updateTrackedBranch/UpdateTrackedBranchUseCase.spec.ts
@@ -22,6 +22,7 @@ import {
   UserOrganizationRole,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { gitRepoFactory } from '../../../../test';
 import { GitProviderService } from '../../GitProviderService';
 import { GitRepoService } from '../../GitRepoService';
 import { UpdateTrackedBranchUseCase } from './UpdateTrackedBranchUseCase';
@@ -131,14 +132,14 @@ describe('UpdateTrackedBranchUseCase', () => {
   describe('when the requested branch is already tracked', () => {
     beforeEach(() => {
       mockGitRepoService.findTrackedByOwnerRepoInOrganization.mockResolvedValue(
-        {
+        gitRepoFactory({
           id: createGitRepoId(uuidv4()),
           owner: 'acme',
           repo: 'widgets',
           branch: 'dev',
           providerId,
           isTracked: true,
-        },
+        }),
       );
     });
 
@@ -157,22 +158,22 @@ describe('UpdateTrackedBranchUseCase', () => {
     let emittedEvent: RepositoryTrackingSetEvent;
 
     beforeEach(async () => {
-      oldRepo = {
+      oldRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'main',
         providerId,
         isTracked: true,
-      };
-      newRepo = {
+      });
+      newRepo = gitRepoFactory({
         id: createGitRepoId(uuidv4()),
         owner: 'acme',
         repo: 'widgets',
         branch: 'dev',
         providerId,
         isTracked: false,
-      };
+      });
       trackedRepo = { ...newRepo, isTracked: true };
 
       mockGitRepoService.findTrackedByOwnerRepoInOrganization.mockResolvedValue(

--- a/packages/git/src/infra/repositories/github/auth/InstallStateSigner.spec.ts
+++ b/packages/git/src/infra/repositories/github/auth/InstallStateSigner.spec.ts
@@ -20,7 +20,11 @@ describe('InstallStateSigner', () => {
 
       beforeEach(() => {
         const signer = signerWithFixedNow();
-        const state = signer.sign({ orgId: 'org-123', userId: 'user-456' });
+        const state = signer.sign({
+          orgId: 'org-123',
+          userId: 'user-456',
+          kind: 'install',
+        });
         payload = signer.verify(state);
       });
 
@@ -39,8 +43,16 @@ describe('InstallStateSigner', () => {
 
       beforeEach(() => {
         const signer = signerWithFixedNow();
-        const state1 = signer.sign({ orgId: 'org-1', userId: 'user-1' });
-        const state2 = signer.sign({ orgId: 'org-1', userId: 'user-1' });
+        const state1 = signer.sign({
+          orgId: 'org-1',
+          userId: 'user-1',
+          kind: 'install',
+        });
+        const state2 = signer.sign({
+          orgId: 'org-1',
+          userId: 'user-1',
+          kind: 'install',
+        });
         payload1 = signer.verify(state1);
         payload2 = signer.verify(state2);
       });
@@ -63,7 +75,11 @@ describe('InstallStateSigner', () => {
 
       beforeEach(() => {
         const signer = signerWithFixedNow();
-        const state = signer.sign({ orgId: 'org-1', userId: 'user-1' });
+        const state = signer.sign({
+          orgId: 'org-1',
+          userId: 'user-1',
+          kind: 'install',
+        });
         payload = signer.verify(state);
       });
 
@@ -90,12 +106,14 @@ describe('InstallStateSigner', () => {
         userId: 'user-1',
         nonce: fixedNonce,
         exp: fixedExp,
+        kind: 'install',
       });
       const state2 = signer.sign({
         orgId: 'org-1',
         userId: 'user-1',
         nonce: fixedNonce,
         exp: fixedExp,
+        kind: 'install',
       });
 
       expect(state1).toBe(state2);
@@ -112,6 +130,7 @@ describe('InstallStateSigner', () => {
           orgId: 'org-1',
           userId: 'user-1',
           nonce: 'aabbccddeeff00112233445566778899',
+          kind: 'install',
         });
         const [payload, sig] = state.split('.');
         // Tamper a character in the middle of the payload (position 10) so the
@@ -142,6 +161,7 @@ describe('InstallStateSigner', () => {
           orgId: 'org-1',
           userId: 'user-1',
           exp: FIXED_NOW - 1,
+          kind: 'install',
         });
 
         // Verify using same "now" — exp is already past
@@ -356,7 +376,11 @@ describe('InstallStateSigner', () => {
           () => FIXED_NOW,
         );
 
-        const state = signerA.sign({ orgId: 'org-1', userId: 'user-1' });
+        const state = signerA.sign({
+          orgId: 'org-1',
+          userId: 'user-1',
+          kind: 'install',
+        });
         expect(() => signerB.verify(state)).toThrow(InvalidInstallStateError);
       });
     });

--- a/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
@@ -1230,8 +1230,8 @@ describe('GitlabRepository', () => {
 
           await gitlabRepository.commitFiles(files, 'Mixed test');
 
-          const commitCall = mockAxiosInstance.post.mock.calls[0];
-          actions = commitCall[1].actions;
+          const [, commitPayload] = mockAxiosInstance.post.mock.calls[0];
+          actions = (commitPayload as { actions: typeof actions }).actions;
         });
 
         it('uses update action for existing files', () => {

--- a/packages/git/tsconfig.spec.json
+++ b/packages/git/tsconfig.spec.json
@@ -10,6 +10,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Explanation

`packages/git`'s test files were never type checked: the shared `typecheck` target only runs `tsc` over `tsconfig.lib.json`, which excludes specs and `test/`, and `@swc/jest` strips their types without checking them. That had let 65 type errors accumulate. This fixes all of them in the fixtures and adds a `tsconfig.spec.json` pass to the target so the drift can't come back.

## Type of Change

- [x] Improvement/Enhancement

## Affected Components

- Domain packages affected: `git` (test files and `project.json` / `tsconfig.spec.json` only — no `src/` production code)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

**Drift categories:** missing required fields on entity literals (43: `displayName` on `GitProvider`/`User`, `type`/`isTracked`/`trackingRemovedAt` on `GitRepo`), missing `kind` on `InstallStateSigner.sign` payloads (9), a stale 4-arg `GitProviderService` constructor call (1), `as jest.Mocked<IGitRepo>` on partial mocks needing `as unknown as` (2), unknown-typed axios mock payload (1). Hand-patched literals were replaced with the existing factories (`gitProviderFactory`, `gitRepoFactory`, `userFactory`, `organizationFactory`).

**Bugs:** No production bug — all 65 were fixture drift, tests pass unchanged. One latent nit: `InstallStateSigner.sign`'s `kind?: InstallStateKind` is dead, because intersecting it with `Omit<InstallStatePayload, 'exp' | 'nonce'>` keeps `kind` required; the runtime default is unreachable from typed callers. Left as-is (src is out of scope here).

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:** `nx typecheck git`, `nx test git` (741 pass, 1 pre-existing env-gated skip), `nx lint git` (only the 2 pre-existing `src/` warnings), `prettier -c`, and `nx run-many -t typecheck -p packages/*` — verified failing after injecting a type error into a spec and, separately, into a `test/` helper no spec imports.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

`AddGitProviderUseCase.spec.ts` keeps `displayName: undefined as unknown as string` in the "displayName is omitted" block: that absence is the behaviour under test (the route has no runtime DTO validation), matching the file's existing `source: undefined as unknown as GitProviderVendor`.

`packages/git` is the first project to gate its specs; `project.json` extends the shared target rather than replacing it, so caching and inputs are inherited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xRzurH3QsyF9ALavxBmQn

---
_Generated by [Claude Code](https://claude.ai/code/session_015xRzurH3QsyF9ALavxBmQn)_