### PR TITLE
✅ test(standards): restore type checking on the package's tests

### DIFF
--- a/packages/standards/project.json
+++ b/packages/standards/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/standards/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Overrides the nx.json command instead of inheriting it with '{}': that one checks tsconfig.lib.json only, which excludes the specs and test/, so @swc/jest left them unchecked. Both projects are checked here.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/standards/tsconfig.lib.json && tsc --noEmit --project packages/standards/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/standards/src/application/services/StandardService.spec.ts
+++ b/packages/standards/src/application/services/StandardService.spec.ts
@@ -41,8 +41,10 @@ describe('StandardService', () => {
       findBySlug: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
       findBySpaceId: jest.fn(),
       findByUserId: jest.fn(),
+      countBySpaceIds: jest.fn(),
       markAsMoved: jest.fn(),
     };
 
@@ -52,9 +54,10 @@ describe('StandardService', () => {
       findById: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
-      list: jest.fn(),
+      hardDeleteById: jest.fn(),
       findByStandardId: jest.fn(),
       findLatestByStandardId: jest.fn(),
+      findLatestByStandardIds: jest.fn(),
       findByStandardIdAndVersion: jest.fn(),
     };
 
@@ -64,8 +67,10 @@ describe('StandardService', () => {
       findById: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
       findByStandardVersionId: jest.fn(),
       findByStandardVersionIds: jest.fn(),
+      findByIdInSpace: jest.fn(),
     };
 
     ruleExampleRepository = {
@@ -74,8 +79,10 @@ describe('StandardService', () => {
       findById: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
       findByRuleId: jest.fn(),
       findByRuleIds: jest.fn(),
+      findByIdInSpace: jest.fn(),
       updateById: jest.fn(),
     };
 

--- a/packages/standards/src/application/services/StandardVersionService.spec.ts
+++ b/packages/standards/src/application/services/StandardVersionService.spec.ts
@@ -31,10 +31,11 @@ describe('StandardVersionService', () => {
   beforeEach(() => {
     standardVersionRepository = {
       add: jest.fn(),
-      list: jest.fn(),
+      addMany: jest.fn(),
       findById: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
       findByStandardId: jest.fn(),
       findLatestByStandardId: jest.fn(),
       findLatestByStandardIds: jest.fn(),
@@ -43,11 +44,14 @@ describe('StandardVersionService', () => {
 
     ruleRepository = {
       add: jest.fn(),
+      addMany: jest.fn(),
       findById: jest.fn(),
       findByStandardVersionId: jest.fn(),
       findByStandardVersionIds: jest.fn(),
+      findByIdInSpace: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
+      hardDeleteById: jest.fn(),
     };
 
     stubbedLogger = stubLogger();

--- a/packages/standards/src/application/useCases/addRuleToStandard/AddRuleToStandardUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/addRuleToStandard/AddRuleToStandardUseCase.spec.ts
@@ -58,6 +58,7 @@ describe('AddRuleToStandardUseCase', () => {
     const user: User = {
       id: userId,
       email: 'test@example.com',
+      displayName: null,
       passwordHash: 'hashed_password',
       memberships: [{ organizationId, role: 'member', userId }],
       active: true,

--- a/packages/standards/src/application/useCases/createRuleExample/CreateRuleExampleUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/createRuleExample/CreateRuleExampleUseCase.spec.ts
@@ -44,6 +44,7 @@ describe('CreateRuleExampleUseCase', () => {
   const user: User = {
     id: userId,
     email: 'test@example.com',
+    displayName: null,
     passwordHash: 'hashed_password',
     memberships: [{ organizationId, role: 'member', userId }],
     active: true,

--- a/packages/standards/src/application/useCases/createStandard/CreateStandardUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/createStandard/CreateStandardUseCase.spec.ts
@@ -58,6 +58,7 @@ describe('CreateStandardUseCase', () => {
     const user: User = {
       id: testUserId,
       email: 'test@example.com',
+      displayName: null,
       passwordHash: 'hashed_password',
       memberships: [
         {

--- a/packages/standards/src/application/useCases/createStandardSamples/CreateStandardSamplesUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/createStandardSamples/CreateStandardSamplesUseCase.spec.ts
@@ -47,6 +47,7 @@ describe('CreateStandardSamplesUseCase', () => {
     const user: User = {
       id: testUserId,
       email: 'test@example.com',
+      displayName: null,
       passwordHash: 'hashed_password',
       memberships: [
         {
@@ -305,6 +306,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [{ type: 'language', id: 'nonexistent' }],
         };
 
@@ -347,6 +349,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [{ type: 'framework', id: 'broken' }],
         };
 
@@ -408,6 +411,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [{ type: 'language', id: 'java' }],
         };
 
@@ -471,6 +475,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [
             { type: 'language', id: 'java' },
             { type: 'framework', id: 'nonexistent' },
@@ -501,6 +506,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [],
         };
 
@@ -554,6 +560,7 @@ describe('CreateStandardSamplesUseCase', () => {
         command = {
           userId: testUserId.toString(),
           organizationId: testOrganizationId,
+          spaceId: testSpaceId,
           samples: [{ type: 'language', id: 'java' }],
         };
 

--- a/packages/standards/src/application/useCases/createStandardWithExamples/CreateStandardWithExamplesUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/createStandardWithExamples/CreateStandardWithExamplesUseCase.spec.ts
@@ -970,11 +970,9 @@ describe('CreateStandardWithExamplesUseCase', () => {
 
           mockRules = [
             ruleFactory({
-              id: uuidv4(),
               standardVersionId: mockStandardVersion.id,
             }),
             ruleFactory({
-              id: uuidv4(),
               standardVersionId: mockStandardVersion.id,
             }),
           ];
@@ -1062,7 +1060,6 @@ describe('CreateStandardWithExamplesUseCase', () => {
 
           mockRules = [
             ruleFactory({
-              id: uuidv4(),
               standardVersionId: mockStandardVersion.id,
             }),
           ];
@@ -1118,7 +1115,6 @@ describe('CreateStandardWithExamplesUseCase', () => {
           );
           ruleRepository.findByStandardVersionId.mockResolvedValue([
             ruleFactory({
-              id: uuidv4(),
               standardVersionId: mockStandardVersion.id,
             }),
           ]);
@@ -1161,7 +1157,6 @@ describe('CreateStandardWithExamplesUseCase', () => {
           );
           ruleRepository.findByStandardVersionId.mockResolvedValue([
             ruleFactory({
-              id: uuidv4(),
               standardVersionId: mockStandardVersion.id,
             }),
           ]);

--- a/packages/standards/src/application/useCases/deleteRuleExample/DeleteRuleExampleUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/deleteRuleExample/DeleteRuleExampleUseCase.spec.ts
@@ -44,6 +44,7 @@ describe('DeleteRuleExampleUseCase', () => {
   const user: User = {
     id: userId,
     email: 'test@example.com',
+    displayName: null,
     passwordHash: 'hashed_password',
     memberships: [{ organizationId, role: 'member', userId }],
     active: true,
@@ -75,10 +76,12 @@ describe('DeleteRuleExampleUseCase', () => {
 
     ruleExampleRepository = {
       add: jest.fn(),
+      addMany: jest.fn(),
       findById: jest.fn(),
       findByIdInSpace: jest.fn(),
       updateById: jest.fn(),
       findByRuleId: jest.fn(),
+      findByRuleIds: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
       hardDeleteById: jest.fn(),

--- a/packages/standards/src/application/useCases/getStandardById/GetStandardByIdUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/getStandardById/GetStandardByIdUseCase.spec.ts
@@ -13,6 +13,7 @@ import {
   User,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
 import { standardFactory } from '../../../../test/standardFactory';
 import { createStandardId } from '@packmind/types';
 import { StandardService } from '../../services/StandardService';
@@ -47,7 +48,7 @@ describe('GetStandardByIdUseCase', () => {
       createSpace: jest.fn(),
       listSpacesByOrganization: jest.fn(),
       getSpaceBySlug: jest.fn(),
-    } as jest.Mocked<ISpacesPort>;
+    } as unknown as jest.Mocked<ISpacesPort>;
 
     stubbedLogger = stubLogger();
 
@@ -81,6 +82,7 @@ describe('GetStandardByIdUseCase', () => {
         const user: User = {
           id: userId,
           email: 'test@example.com',
+          displayName: null,
           passwordHash: 'hashed_password',
           memberships: [{ organizationId, role: 'member', userId }],
           active: true,
@@ -90,12 +92,10 @@ describe('GetStandardByIdUseCase', () => {
           name: 'Test Org',
           slug: 'test-org',
         };
-        const space: Space = {
+        const space: Space = spaceFactory({
           id: spaceId,
-          name: 'Test Space',
-          slug: 'test-space',
           organizationId,
-        };
+        });
 
         const command: GetStandardByIdCommand = {
           userId,
@@ -156,6 +156,7 @@ describe('GetStandardByIdUseCase', () => {
         const user: User = {
           id: userId,
           email: 'test@example.com',
+          displayName: null,
           passwordHash: 'hashed_password',
           memberships: [{ organizationId, role: 'member', userId }],
           active: true,
@@ -165,12 +166,10 @@ describe('GetStandardByIdUseCase', () => {
           name: 'Test Org',
           slug: 'test-org',
         };
-        const space: Space = {
+        const space: Space = spaceFactory({
           id: spaceId,
-          name: 'Test Space',
-          slug: 'test-space',
           organizationId,
-        };
+        });
 
         const command: GetStandardByIdCommand = {
           userId,
@@ -207,6 +206,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -216,12 +216,10 @@ describe('GetStandardByIdUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: GetStandardByIdCommand = {
         userId,
@@ -257,6 +255,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -293,6 +292,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -302,12 +302,10 @@ describe('GetStandardByIdUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId: otherOrganizationId, // Different organization
-      };
+      });
 
       const command: GetStandardByIdCommand = {
         userId,
@@ -335,6 +333,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -345,12 +344,10 @@ describe('GetStandardByIdUseCase', () => {
         slug: 'test-org',
       };
       // Space belongs to a different organization
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId: otherOrganizationId,
-      };
+      });
 
       const command: GetStandardByIdCommand = {
         userId,
@@ -385,6 +382,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -394,12 +392,10 @@ describe('GetStandardByIdUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: GetStandardByIdCommand = {
         userId,
@@ -453,6 +449,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -483,6 +480,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [
           { organizationId: otherOrganizationId, role: 'member', userId },
@@ -525,6 +523,7 @@ describe('GetStandardByIdUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -534,12 +533,10 @@ describe('GetStandardByIdUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: GetStandardByIdCommand = {
         userId,

--- a/packages/standards/src/application/useCases/listStandardsBySpace/ListStandardsBySpaceUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/listStandardsBySpace/ListStandardsBySpaceUseCase.spec.ts
@@ -13,6 +13,7 @@ import {
   User,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
 import { standardFactory } from '../../../../test/standardFactory';
 import { StandardService } from '../../services/StandardService';
 import { ListStandardsBySpaceUseCase } from './ListStandardsBySpaceUseCase';
@@ -46,7 +47,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       createSpace: jest.fn(),
       listSpacesByOrganization: jest.fn(),
       getSpaceBySlug: jest.fn(),
-    } as jest.Mocked<ISpacesPort>;
+    } as unknown as jest.Mocked<ISpacesPort>;
 
     stubbedLogger = stubLogger();
 
@@ -76,6 +77,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -85,12 +87,10 @@ describe('ListStandardsBySpaceUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: ListStandardsBySpaceCommand = {
         userId,
@@ -145,6 +145,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -154,12 +155,10 @@ describe('ListStandardsBySpaceUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: ListStandardsBySpaceCommand = {
         userId,
@@ -187,6 +186,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -221,6 +221,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -230,12 +231,10 @@ describe('ListStandardsBySpaceUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId: otherOrganizationId, // Different organization
-      };
+      });
 
       const command: ListStandardsBySpaceCommand = {
         userId,
@@ -267,6 +266,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -276,12 +276,10 @@ describe('ListStandardsBySpaceUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: ListStandardsBySpaceCommand = {
         userId,
@@ -331,6 +329,7 @@ describe('ListStandardsBySpaceUseCase', () => {
       const user: User = {
         id: userId,
         email: 'test@example.com',
+        displayName: null,
         passwordHash: 'hashed_password',
         memberships: [{ organizationId, role: 'member', userId }],
         active: true,
@@ -340,12 +339,10 @@ describe('ListStandardsBySpaceUseCase', () => {
         name: 'Test Org',
         slug: 'test-org',
       };
-      const space: Space = {
+      const space: Space = spaceFactory({
         id: spaceId,
-        name: 'Test Space',
-        slug: 'test-space',
         organizationId,
-      };
+      });
 
       const command: ListStandardsBySpaceCommand = {
         userId,

--- a/packages/standards/src/application/useCases/updateRuleExample/UpdateRuleExampleUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/updateRuleExample/UpdateRuleExampleUseCase.spec.ts
@@ -45,6 +45,7 @@ describe('UpdateRuleExampleUseCase', () => {
   const user: User = {
     id: userId,
     email: 'test@example.com',
+    displayName: null,
     passwordHash: 'hashed_password',
     memberships: [{ organizationId, role: 'member', userId }],
     active: true,
@@ -79,10 +80,12 @@ describe('UpdateRuleExampleUseCase', () => {
 
     ruleExampleRepository = {
       add: jest.fn(),
+      addMany: jest.fn(),
       findById: jest.fn(),
       findByIdInSpace: jest.fn(),
       updateById: jest.fn(),
       findByRuleId: jest.fn(),
+      findByRuleIds: jest.fn(),
       deleteById: jest.fn(),
       restoreById: jest.fn(),
       hardDeleteById: jest.fn(),

--- a/packages/standards/src/application/useCases/updateStandard/UpdateStandardUseCase.spec.ts
+++ b/packages/standards/src/application/useCases/updateStandard/UpdateStandardUseCase.spec.ts
@@ -15,6 +15,7 @@ import {
   RuleAddedEvent,
   RuleDeletedEvent,
 } from '@packmind/types';
+import { spaceFactory } from '@packmind/spaces/test';
 import { standardFactory } from '../../../../test/standardFactory';
 import { standardVersionFactory } from '../../../../test/standardVersionFactory';
 import { ruleFactory } from '../../../../test/ruleFactory';
@@ -131,6 +132,7 @@ describe('UpdateStandardUseCase', () => {
     mockUser = {
       id: mockUserId,
       email: 'test@example.com',
+      displayName: null,
       passwordHash: 'hashed-password',
       active: true,
       memberships: [mockMembership],
@@ -142,12 +144,10 @@ describe('UpdateStandardUseCase', () => {
     } as unknown as jest.Mocked<IAccountsPort>;
 
     // Setup space mock
-    mockSpace = {
+    mockSpace = spaceFactory({
       id: createSpaceId(uuidv4()),
-      name: 'Test Space',
-      slug: 'test-space',
       organizationId: mockOrgId,
-    };
+    });
 
     spacesPort = {
       getSpaceById: jest.fn().mockResolvedValue(mockSpace),

--- a/packages/standards/src/infra/repositories/RuleExampleRepository.spec.ts
+++ b/packages/standards/src/infra/repositories/RuleExampleRepository.spec.ts
@@ -1,4 +1,4 @@
-import { GitCommitSchema } from '@packmind/git';
+import { GitCommitSchema } from '@packmind/git/schemas';
 import { PackmindLogger } from '@packmind/logger';
 import { createTestDatasourceFixture, stubLogger } from '@packmind/test-utils';
 import {

--- a/packages/standards/src/infra/repositories/RuleRepository.spec.ts
+++ b/packages/standards/src/infra/repositories/RuleRepository.spec.ts
@@ -1,4 +1,4 @@
-import { GitCommitSchema } from '@packmind/git';
+import { GitCommitSchema } from '@packmind/git/schemas';
 import { PackmindLogger } from '@packmind/logger';
 import { WithSoftDelete } from '@packmind/node-utils';
 import {

--- a/packages/standards/src/infra/repositories/StandardRepository.spec.ts
+++ b/packages/standards/src/infra/repositories/StandardRepository.spec.ts
@@ -1,4 +1,4 @@
-import { GitCommitSchema } from '@packmind/git';
+import { GitCommitSchema } from '@packmind/git/schemas';
 import { PackmindLogger } from '@packmind/logger';
 import { WithSoftDelete } from '@packmind/node-utils';
 import { SpaceSchema } from '@packmind/spaces';

--- a/packages/standards/src/infra/repositories/StandardVersionRepository.spec.ts
+++ b/packages/standards/src/infra/repositories/StandardVersionRepository.spec.ts
@@ -1,4 +1,4 @@
-import { GitCommitSchema } from '@packmind/git';
+import { GitCommitSchema } from '@packmind/git/schemas';
 import { PackmindLogger } from '@packmind/logger';
 import { WithSoftDelete } from '@packmind/node-utils';
 import {

--- a/packages/standards/tsconfig.spec.json
+++ b/packages/standards/tsconfig.spec.json
@@ -10,6 +10,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
## Explanation

`standards:typecheck` inherited the shared `nx.json` command, which checks `tsconfig.lib.json` only — that excludes `src/**/*.spec.ts`, and `test/` was in no project's `include`. With `@swc/jest` stripping types unchecked, 57 errors had accumulated in the specs. Fixed, and `tsconfig.spec.json` is now in the target so they cannot come back.

## Type of Change

- [x] Improvement/Enhancement

## Affected Components

- Domain packages affected: `standards` (specs and build config; no `src/` change)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

## Testing

`nx test standards` (396 pass, none skipped), `nx lint standards` (2 warnings, unchanged from `main`), `prettier -c`, and the pre-push `nx affected -t lint test build` across 7 projects / 21 tasks — all green on `e55c219`. Gate proven by injecting a type error into a spec and into an unimported `test/` helper, then reverting.

- [x] Unit tests added/updated
- [x] Test coverage maintained or improved

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

Drift: 20 `User` literals missing `displayName`, 13 `Space` literals now `spaceFactory`, 14 mock methods missing from interface mocks, 6 commands missing `spaceId`, 5 `id: uuidv4()` overrides discarding `ruleFactory`'s branded id, 2 stale `list` entries, 1 `as unknown as`. No production bug — all 57 were fixture drift, tests pass unchanged.

The four repository specs now take `GitCommitSchema` from `@packmind/git/schemas` rather than the barrel, following #476 — the barrel dragged all of git's `src` into the spec program, where standards' `noPropertyAccessFromIndexSignature` rejected `InstallStateSigner`'s dot access. `--listFiles` confirms the program is down to git's 5 schema files, so git keeps its own looser options and this gate no longer depends on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2G44mHyiVnLrYjotbqctJ