### PR TITLE
👷 ci(coding-agent): type check the specs and repair their fixture drift

### DIFF
--- a/packages/coding-agent/project.json
+++ b/packages/coding-agent/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/coding-agent/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Overrides the nx.json command to also check the specs: tsconfig.lib.json excludes them, so @swc/jest was the only thing reading those files and it strips types without checking them.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/coding-agent/tsconfig.lib.json && tsc --noEmit --project packages/coding-agent/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/coding-agent/src/application/services/DeployerService.spec.ts
+++ b/packages/coding-agent/src/application/services/DeployerService.spec.ts
@@ -1,7 +1,7 @@
 import { PackmindLogger } from '@packmind/logger';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
-import { stubLogger } from '@packmind/test-utils';
+import { gitRepoFactory, stubLogger } from '@packmind/test-utils';
 import {
   createSpaceId,
   FileUpdates,
@@ -21,6 +21,7 @@ import {
   TargetId,
   UserId,
   CodingAgent,
+  DeleteItemType,
 } from '@packmind/types';
 import { ICodingAgentRepositories } from '../../domain/repositories/ICodingAgentRepositories';
 import { ICodingAgentDeployer } from '../../domain/repository/ICodingAgentDeployer';
@@ -196,13 +197,13 @@ describe('DeployerService', () => {
       gitRepoId: createTestGitRepoId('repo-1'),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createTestGitRepoId('repo-1'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createTestGitProviderId('provider-1'),
       branch: 'main',
-    };
+    });
 
     const mockCommand: Command = commandFactory({
       id: createTestCommandId('recipe-1'),
@@ -258,7 +259,7 @@ describe('DeployerService', () => {
       beforeEach(async () => {
         const mockDeployer = new MockDeployer({
           createOrUpdate: [{ path: 'recipe1.md', content: 'content1' }],
-          delete: [{ path: 'old-recipe.md' }],
+          delete: [{ path: 'old-recipe.md', type: DeleteItemType.File }],
         });
 
         registry.registerDeployer('packmind', mockDeployer);
@@ -278,7 +279,9 @@ describe('DeployerService', () => {
       });
 
       it('returns one file to delete', () => {
-        expect(result.delete).toEqual([{ path: 'old-recipe.md' }]);
+        expect(result.delete).toEqual([
+          { path: 'old-recipe.md', type: DeleteItemType.File },
+        ]);
       });
     });
 
@@ -355,7 +358,10 @@ describe('DeployerService', () => {
       beforeEach(async () => {
         const deployer = new MockDeployer({
           createOrUpdate: [],
-          delete: [{ path: 'delete1.md' }, { path: 'delete2.md' }],
+          delete: [
+            { path: 'delete1.md', type: DeleteItemType.File },
+            { path: 'delete2.md', type: DeleteItemType.File },
+          ],
         });
 
         registry.registerDeployer('packmind', deployer);
@@ -402,23 +408,10 @@ describe('DeployerService', () => {
     });
 
     it('propagates deployer errors', async () => {
-      const errorDeployer = {
-        async deployCommands(): Promise<FileUpdates> {
-          throw new Error('Deployment failed');
-        },
-        async deployStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async deployArtifacts(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-      };
+      const errorDeployer = new MockDeployer();
+      jest
+        .spyOn(errorDeployer, 'deployCommands')
+        .mockRejectedValue(new Error('Deployment failed'));
 
       registry.registerDeployer('packmind', errorDeployer);
 
@@ -604,26 +597,13 @@ describe('DeployerService', () => {
     });
 
     it('uses correct existing content for each agent', async () => {
-      const deployArtifactsSpy = jest.fn().mockResolvedValue({
-        createOrUpdate: [{ path: 'CLAUDE.md', content: 'new content' }],
-        delete: [],
-      });
-
-      const claudeDeployer = {
-        async deployCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async deployStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        deployArtifacts: deployArtifactsSpy,
-      };
+      const claudeDeployer = new MockDeployer();
+      const deployArtifactsSpy = jest
+        .spyOn(claudeDeployer, 'deployArtifacts')
+        .mockResolvedValue({
+          createOrUpdate: [{ path: 'CLAUDE.md', content: 'new content' }],
+          delete: [],
+        });
 
       registry.registerDeployer('claude', claudeDeployer);
 
@@ -809,26 +789,13 @@ describe('DeployerService', () => {
     });
 
     it('handles missing existing content for new files', async () => {
-      const deployArtifactsSpy = jest.fn().mockResolvedValue({
-        createOrUpdate: [{ path: 'CLAUDE.md', content: 'new file content' }],
-        delete: [],
-      });
-
-      const claudeDeployer = {
-        async deployCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async deployStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        deployArtifacts: deployArtifactsSpy,
-      };
+      const claudeDeployer = new MockDeployer();
+      const deployArtifactsSpy = jest
+        .spyOn(claudeDeployer, 'deployArtifacts')
+        .mockResolvedValue({
+          createOrUpdate: [{ path: 'CLAUDE.md', content: 'new file content' }],
+          delete: [],
+        });
 
       registry.registerDeployer('claude', claudeDeployer);
 
@@ -850,23 +817,10 @@ describe('DeployerService', () => {
     });
 
     it('propagates deployer errors', async () => {
-      const errorDeployer = {
-        async deployCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async deployStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForCommands(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async generateFileUpdatesForStandards(): Promise<FileUpdates> {
-          return { createOrUpdate: [], delete: [] };
-        },
-        async deployArtifacts(): Promise<FileUpdates> {
-          throw new Error('Artifact deployment failed');
-        },
-      };
+      const errorDeployer = new MockDeployer();
+      jest
+        .spyOn(errorDeployer, 'deployArtifacts')
+        .mockRejectedValue(new Error('Artifact deployment failed'));
 
       registry.registerDeployer('claude', errorDeployer);
 

--- a/packages/coding-agent/src/application/useCases/PreviewArtifactRenderingUseCase.spec.ts
+++ b/packages/coding-agent/src/application/useCases/PreviewArtifactRenderingUseCase.spec.ts
@@ -9,11 +9,13 @@ import {
   StandardVersion,
   StandardVersionId,
   StandardId,
+  RuleId,
   SkillVersion,
   SkillVersionId,
   SkillId,
   UserId,
 } from '@packmind/types';
+import { ruleFactory } from '@packmind/standards/test';
 import { ICodingAgentDeployer } from '../../domain/repository/ICodingAgentDeployer';
 import { ICodingAgentDeployerRegistry } from '../../domain/repository/ICodingAgentDeployerRegistry';
 import { ICodingAgentRepositories } from '../../domain/repositories/ICodingAgentRepositories';
@@ -43,7 +45,13 @@ describe('PreviewArtifactRenderingUseCase', () => {
     description: 'A test standard',
     version: 1,
     scope: null,
-    rules: [{ id: 'r1', content: 'Rule 1', examples: [] }],
+    rules: [
+      ruleFactory({
+        id: 'r1' as RuleId,
+        content: 'Rule 1',
+        standardVersionId: 'sv-1' as StandardVersionId,
+      }),
+    ],
   };
 
   const skillVersion: SkillVersion = {
@@ -60,7 +68,7 @@ describe('PreviewArtifactRenderingUseCase', () => {
   beforeEach(() => {
     mockDeployer = {
       generateFileUpdatesForStandards: jest.fn(),
-      generateFileUpdatesForRecipes: jest.fn(),
+      generateFileUpdatesForCommands: jest.fn(),
       generateFileUpdatesForSkills: jest.fn(),
       deployCommands: jest.fn(),
       deployStandards: jest.fn(),
@@ -156,7 +164,7 @@ describe('PreviewArtifactRenderingUseCase', () => {
 
         describe('when slug is empty', () => {
           it('slugifies the artifact name', async () => {
-            const withEmptySlug: RecipeVersion = {
+            const withEmptySlug: CommandVersion = {
               ...recipeVersion,
               slug: '',
               name: 'My Cool Thing!',
@@ -175,7 +183,7 @@ describe('PreviewArtifactRenderingUseCase', () => {
 
         describe('when both slug and name are empty', () => {
           it('falls back to "preview"', async () => {
-            const emptyArtifact: RecipeVersion = {
+            const emptyArtifact: CommandVersion = {
               ...recipeVersion,
               slug: '',
               name: '',

--- a/packages/coding-agent/src/application/useCases/RenderArtifactsUseCase.spec.ts
+++ b/packages/coding-agent/src/application/useCases/RenderArtifactsUseCase.spec.ts
@@ -1,6 +1,7 @@
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 import {
+  DeleteItemType,
   FileUpdates,
   RenderArtifactsCommand,
   CommandVersion,
@@ -130,7 +131,7 @@ describe('RenderArtifactsUseCase', () => {
             { path: 'CLAUDE.md', content: 'content 1' },
             { path: 'AGENTS.md', content: 'content 2' },
           ],
-          delete: [{ path: 'old.md' }],
+          delete: [{ path: 'old.md', type: DeleteItemType.File }],
         };
 
         mockCodingAgentServices.renderArtifacts.mockResolvedValue(

--- a/packages/coding-agent/src/infra/repositories/agentsmd/AgentsMDDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/agentsmd/AgentsMDDeployer.spec.ts
@@ -15,6 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GenericStandardSectionWriter } from '../genericSectionWriter/GenericStandardSectionWriter';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 
 describe('AgentsMDDeployer', () => {
   let deployer: AgentsMDDeployer;
@@ -32,13 +33,13 @@ describe('AgentsMDDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {

--- a/packages/coding-agent/src/infra/repositories/claude/ClaudeDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/claude/ClaudeDeployer.spec.ts
@@ -16,13 +16,26 @@ import {
   createSkillVersionId,
   createSkillFileId,
   DeleteItemType,
+  FileModification,
   FileUpdates,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
-import { skillVersionFactory } from '@packmind/skills/test';
+import { skillFileFactory, skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
+
+/**
+ * Narrows a file update to the content-carrying variant of `FileModification`;
+ * the section-based variant has no `content`.
+ */
+const contentOf = (fileUpdate: FileModification): string => {
+  if (fileUpdate.content === undefined) {
+    throw new Error(`Expected ${fileUpdate.path} to carry content`);
+  }
+  return fileUpdate.content;
+};
 
 describe('ClaudeDeployer', () => {
   let deployer: ClaudeDeployer;
@@ -44,13 +57,13 @@ describe('ClaudeDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {
@@ -3217,21 +3230,21 @@ describe('ClaudeDeployer', () => {
           description: 'A skill with multiple files',
           prompt: 'See reference.md and forms.md for more information.',
           files: [
-            {
+            skillFileFactory({
               id: createSkillFileId('file-1'),
               skillVersionId: createSkillVersionId('skill-version-1'),
               path: 'reference.md',
               content:
                 '# Reference\n\nThis is additional reference documentation.',
               permissions: 'rw-r--r--',
-            },
-            {
+            }),
+            skillFileFactory({
               id: createSkillFileId('file-2'),
               skillVersionId: createSkillVersionId('skill-version-1'),
               path: 'forms.md',
               content: '# Forms\n\nInstructions for working with forms.',
               permissions: 'rw-r--r--',
-            },
+            }),
           ],
         });
       });
@@ -3370,20 +3383,20 @@ describe('ClaudeDeployer', () => {
           skillVersionsWithFiles = [
             skillVersionFactory({
               files: [
-                {
+                skillFileFactory({
                   id: createSkillFileId('file-1'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'helper.ts',
                   content: 'export const helper = () => {}',
                   permissions: '644',
-                },
-                {
+                }),
+                skillFileFactory({
                   id: createSkillFileId('file-2'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'utils/formatter.ts',
                   content: 'export const format = (s: string) => s',
                   permissions: '644',
-                },
+                }),
               ],
             }),
           ];
@@ -3523,7 +3536,7 @@ describe('ClaudeDeployer', () => {
           const imageFile = fileUpdates.createOrUpdate.find((file) =>
             file.path.includes('image.png'),
           );
-          expect(imageFile?.isBase64).toBe(true);
+          expect(imageFile).toMatchObject({ isBase64: true });
         });
       });
 
@@ -3551,7 +3564,7 @@ describe('ClaudeDeployer', () => {
           const helperFile = fileUpdates.createOrUpdate.find((file) =>
             file.path.includes('helper.ts'),
           );
-          expect(helperFile?.isBase64).toBe(false);
+          expect(helperFile).toMatchObject({ isBase64: false });
         });
       });
 
@@ -3562,20 +3575,20 @@ describe('ClaudeDeployer', () => {
           const skillVersionsWithFiles = [
             skillVersionFactory({
               files: [
-                {
+                skillFileFactory({
                   id: createSkillFileId('file-0'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'SKILL.md',
                   content: 'This should be ignored',
                   permissions: '644',
-                },
-                {
+                }),
+                skillFileFactory({
                   id: createSkillFileId('file-1'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'helper.ts',
                   content: 'export const helper = () => {}',
                   permissions: '644',
-                },
+                }),
               ],
             }),
           ];
@@ -3638,25 +3651,25 @@ describe('ClaudeDeployer', () => {
             skillVersionFactory({
               slug: 'first-skill',
               files: [
-                {
+                skillFileFactory({
                   id: createSkillFileId('file-1'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'helper1.ts',
                   content: 'export const helper1 = () => {}',
                   permissions: '644',
-                },
+                }),
               ],
             }),
             skillVersionFactory({
               slug: 'second-skill',
               files: [
-                {
+                skillFileFactory({
                   id: createSkillFileId('file-2'),
                   skillVersionId: createSkillVersionId('skill-version-2'),
                   path: 'helper2.ts',
                   content: 'export const helper2 = () => {}',
                   permissions: '644',
-                },
+                }),
               ],
             }),
           ];
@@ -3831,20 +3844,20 @@ describe('ClaudeDeployer', () => {
           const skillVersionsWithFiles = [
             skillVersionFactory({
               files: [
-                {
+                skillFileFactory({
                   id: createSkillFileId('file-1'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'helper.ts',
                   content: 'export const helper = () => {}',
                   permissions: '644',
-                },
-                {
+                }),
+                skillFileFactory({
                   id: createSkillFileId('file-2'),
                   skillVersionId: createSkillVersionId('skill-version-1'),
                   path: 'README.md',
                   content: '# Helper Documentation',
                   permissions: '644',
-                },
+                }),
               ],
             }),
           ];
@@ -4331,21 +4344,21 @@ describe('ClaudeDeployer', () => {
       });
 
       it('renders argument-hint before arguments', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('argument-hint:')).toBeLessThan(
           content.indexOf('arguments:'),
         );
       });
 
       it('renders arguments before model', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('arguments:')).toBeLessThan(
           content.indexOf('model:'),
         );
       });
 
       it('renders model before hooks', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('model:')).toBeLessThan(
           content.indexOf('hooks:'),
         );
@@ -4370,14 +4383,14 @@ describe('ClaudeDeployer', () => {
       });
 
       it('renders known properties before unknown ones', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('model:')).toBeLessThan(
           content.indexOf('alpha:'),
         );
       });
 
       it('renders unknown properties in alphabetical order', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('alpha:')).toBeLessThan(
           content.indexOf('zebra:'),
         );
@@ -4400,14 +4413,14 @@ describe('ClaudeDeployer', () => {
       });
 
       it('renders nested alpha before middle', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('alpha:')).toBeLessThan(
           content.indexOf('middle:'),
         );
       });
 
       it('renders nested middle before zebra', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('middle:')).toBeLessThan(
           content.indexOf('zebra:'),
         );

--- a/packages/coding-agent/src/infra/repositories/claude/ClaudeDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/claude/ClaudeDeployer.spec.ts
@@ -16,26 +16,14 @@ import {
   createSkillVersionId,
   createSkillFileId,
   DeleteItemType,
-  FileModification,
   FileUpdates,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
 import { skillFileFactory, skillVersionFactory } from '@packmind/skills/test';
-import { gitRepoFactory } from '@packmind/test-utils';
+import { contentOf, gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
-
-/**
- * Narrows a file update to the content-carrying variant of `FileModification`;
- * the section-based variant has no `content`.
- */
-const contentOf = (fileUpdate: FileModification): string => {
-  if (fileUpdate.content === undefined) {
-    throw new Error(`Expected ${fileUpdate.path} to carry content`);
-  }
-  return fileUpdate.content;
-};
 
 describe('ClaudeDeployer', () => {
   let deployer: ClaudeDeployer;

--- a/packages/coding-agent/src/infra/repositories/codex/CodexDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/codex/CodexDeployer.spec.ts
@@ -15,8 +15,12 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { GenericStandardSectionWriter } from '../genericSectionWriter/GenericStandardSectionWriter';
 import { commandFactory } from '@packmind/commands/test';
-import { standardFactory } from '@packmind/standards/test';
+import {
+  standardFactory,
+  standardVersionFactory,
+} from '@packmind/standards/test';
 import { skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
 
 describe('CodexDeployer', () => {
@@ -34,13 +38,13 @@ describe('CodexDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {
@@ -234,7 +238,7 @@ describe('CodexDeployer', () => {
           name: 'My Standard',
           slug: 'my-standard',
         });
-        const standardVersion: StandardVersion = {
+        const standardVersion = standardVersionFactory({
           id: createStandardVersionId('sv-1'),
           standardId: standard.id,
           name: standard.name,
@@ -242,7 +246,7 @@ describe('CodexDeployer', () => {
           description: 'Standard description',
           version: 1,
           userId: createUserId('user-1'),
-        };
+        });
 
         const skillVersion = skillVersionFactory({
           name: 'my-skill',

--- a/packages/coding-agent/src/infra/repositories/continue/ContinueDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/continue/ContinueDeployer.spec.ts
@@ -16,6 +16,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 
 describe('ContinueDeployer', () => {
   let deployer: ContinueDeployer;
@@ -37,13 +38,13 @@ describe('ContinueDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {

--- a/packages/coding-agent/src/infra/repositories/copilot/CopilotDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/copilot/CopilotDeployer.spec.ts
@@ -6,26 +6,14 @@ import {
   createSkillVersionId,
   createTargetId,
   DeleteItemType,
-  FileModification,
   GitRepo,
   IStandardsPort,
   SkillVersion,
   Target,
 } from '@packmind/types';
 import { skillVersionFactory } from '@packmind/skills/test';
-import { gitRepoFactory } from '@packmind/test-utils';
+import { contentOf, gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
-
-/**
- * Narrows a file update to the content-carrying variant of `FileModification`;
- * the section-based variant has no `content`.
- */
-const contentOf = (fileUpdate: FileModification): string => {
-  if (fileUpdate.content === undefined) {
-    throw new Error(`Expected ${fileUpdate.path} to carry content`);
-  }
-  return fileUpdate.content;
-};
 
 describe('CopilotDeployer', () => {
   let deployer: CopilotDeployer;

--- a/packages/coding-agent/src/infra/repositories/copilot/CopilotDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/copilot/CopilotDeployer.spec.ts
@@ -6,13 +6,26 @@ import {
   createSkillVersionId,
   createTargetId,
   DeleteItemType,
+  FileModification,
   GitRepo,
   IStandardsPort,
   SkillVersion,
   Target,
 } from '@packmind/types';
 import { skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
+
+/**
+ * Narrows a file update to the content-carrying variant of `FileModification`;
+ * the section-based variant has no `content`.
+ */
+const contentOf = (fileUpdate: FileModification): string => {
+  if (fileUpdate.content === undefined) {
+    throw new Error(`Expected ${fileUpdate.path} to carry content`);
+  }
+  return fileUpdate.content;
+};
 
 describe('CopilotDeployer', () => {
   let deployer: CopilotDeployer;
@@ -34,13 +47,13 @@ describe('CopilotDeployer', () => {
       gitRepoId: createGitRepoId('test-repo-id'),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {
@@ -78,7 +91,7 @@ describe('CopilotDeployer', () => {
         const binaryFile = fileUpdates.createOrUpdate.find((f) =>
           f.path.endsWith('image.png'),
         );
-        expect(binaryFile?.isBase64).toBe(true);
+        expect(binaryFile).toMatchObject({ isBase64: true });
       });
 
       it('propagates skillFileId for skill file', async () => {
@@ -145,7 +158,7 @@ describe('CopilotDeployer', () => {
         const textFile = fileUpdates.createOrUpdate.find((f) =>
           f.path.endsWith('reference.md'),
         );
-        expect(textFile?.isBase64).toBe(false);
+        expect(textFile).toMatchObject({ isBase64: false });
       });
     });
   });
@@ -183,7 +196,7 @@ describe('CopilotDeployer', () => {
         const binaryFile = fileUpdates.createOrUpdate.find((f) =>
           f.path.endsWith('image.png'),
         );
-        expect(binaryFile?.isBase64).toBe(true);
+        expect(binaryFile).toMatchObject({ isBase64: true });
       });
     });
 
@@ -219,7 +232,7 @@ describe('CopilotDeployer', () => {
         const textFile = fileUpdates.createOrUpdate.find((f) =>
           f.path.endsWith('reference.md'),
         );
-        expect(textFile?.isBase64).toBe(false);
+        expect(textFile).toMatchObject({ isBase64: false });
       });
     });
   });
@@ -524,14 +537,14 @@ describe('CopilotDeployer', () => {
       });
 
       it('renders argument-hint before disable-model-invocation', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('argument-hint:')).toBeLessThan(
           content.indexOf('disable-model-invocation:'),
         );
       });
 
       it('renders disable-model-invocation before user-invocable', () => {
-        const content = fileUpdates.createOrUpdate[0].content;
+        const content = contentOf(fileUpdates.createOrUpdate[0]);
         expect(content.indexOf('disable-model-invocation:')).toBeLessThan(
           content.indexOf('user-invocable:'),
         );

--- a/packages/coding-agent/src/infra/repositories/copilotPlugin/CopilotPluginDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/copilotPlugin/CopilotPluginDeployer.spec.ts
@@ -15,6 +15,7 @@ import {
   createUserId,
   FileUpdates,
 } from '@packmind/types';
+import { contentOf } from '@packmind/test-utils';
 
 function makeTarget(path: string): Target {
   return {
@@ -64,17 +65,12 @@ function makeSkill(overrides: Partial<SkillVersion> = {}): SkillVersion {
   };
 }
 
-/**
- * Parses the manifest emitted by `deployPluginManifest`, narrowing the file
- * update to the content-carrying variant of `FileModification`; the
- * section-based variant has no `content`.
- */
+/** Parses the manifest emitted by `deployPluginManifest`. */
 function manifestOf(updates: FileUpdates): Record<string, unknown> {
-  const [file] = updates.createOrUpdate;
-  if (file?.content === undefined) {
-    throw new Error('Expected the plugin manifest to carry content');
-  }
-  return JSON.parse(file.content) as Record<string, unknown>;
+  return JSON.parse(contentOf(updates.createOrUpdate[0])) as Record<
+    string,
+    unknown
+  >;
 }
 
 describe('CopilotPluginDeployer', () => {

--- a/packages/coding-agent/src/infra/repositories/copilotPlugin/CopilotPluginDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/copilotPlugin/CopilotPluginDeployer.spec.ts
@@ -13,6 +13,7 @@ import {
   createSkillVersionId,
   createTargetId,
   createUserId,
+  FileUpdates,
 } from '@packmind/types';
 
 function makeTarget(path: string): Target {
@@ -61,6 +62,19 @@ function makeSkill(overrides: Partial<SkillVersion> = {}): SkillVersion {
     prompt: '# prompt\n',
     ...overrides,
   };
+}
+
+/**
+ * Parses the manifest emitted by `deployPluginManifest`, narrowing the file
+ * update to the content-carrying variant of `FileModification`; the
+ * section-based variant has no `content`.
+ */
+function manifestOf(updates: FileUpdates): Record<string, unknown> {
+  const [file] = updates.createOrUpdate;
+  if (file?.content === undefined) {
+    throw new Error('Expected the plugin manifest to carry content');
+  }
+  return JSON.parse(file.content) as Record<string, unknown>;
 }
 
 describe('CopilotPluginDeployer', () => {
@@ -437,7 +451,7 @@ describe('CopilotPluginDeployer', () => {
           makeTarget('plugins/security'),
         );
 
-        expect(JSON.parse(updates.createOrUpdate[0].content)).toEqual({
+        expect(manifestOf(updates)).toEqual({
           name: 'security',
           version: '0.1.0',
           hooks: 'hooks/hooks.json',
@@ -454,9 +468,7 @@ describe('CopilotPluginDeployer', () => {
           makeTarget('plugins/security'),
         );
 
-        expect(
-          Object.keys(JSON.parse(updates.createOrUpdate[0].content)),
-        ).not.toContain('hooks');
+        expect(Object.keys(manifestOf(updates))).not.toContain('hooks');
       });
     });
   });

--- a/packages/coding-agent/src/infra/repositories/cursor/CursorDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/cursor/CursorDeployer.spec.ts
@@ -13,8 +13,9 @@ import {
   DeleteItemType,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
-import { skillVersionFactory } from '@packmind/skills/test';
+import { skillFileFactory, skillVersionFactory } from '@packmind/skills/test';
 import { commandVersionFactory } from '@packmind/commands/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
 
 describe('CursorDeployer', () => {
@@ -37,13 +38,13 @@ describe('CursorDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {
@@ -250,21 +251,21 @@ describe('CursorDeployer', () => {
           description: 'A skill with multiple files',
           prompt: 'See reference.md and forms.md for more information.',
           files: [
-            {
+            skillFileFactory({
               id: createSkillFileId('file-1'),
               skillVersionId: createSkillVersionId('skill-version-1'),
               path: 'reference.md',
               content:
                 '# Reference\n\nThis is additional reference documentation.',
               permissions: 'rw-r--r--',
-            },
-            {
+            }),
+            skillFileFactory({
               id: createSkillFileId('file-2'),
               skillVersionId: createSkillVersionId('skill-version-1'),
               path: 'forms.md',
               content: '# Forms\n\nInstructions for working with forms.',
               permissions: 'rw-r--r--',
-            },
+            }),
           ],
         });
       });
@@ -406,7 +407,7 @@ describe('CursorDeployer', () => {
         const imageFile = fileUpdates.createOrUpdate.find((f) =>
           f.path.endsWith('image.png'),
         );
-        expect(imageFile?.isBase64).toBe(true);
+        expect(imageFile).toMatchObject({ isBase64: true });
       });
     });
   });
@@ -476,13 +477,13 @@ describe('CursorDeployer', () => {
         const skillVersionsWithFiles = [
           skillVersionFactory({
             files: [
-              {
+              skillFileFactory({
                 id: createSkillFileId('file-1'),
                 skillVersionId: createSkillVersionId('skill-version-1'),
                 path: 'helper.ts',
                 content: 'export const helper = () => {}',
                 permissions: 'rw-r--r--',
-              },
+              }),
             ],
           }),
         ];
@@ -534,20 +535,20 @@ describe('CursorDeployer', () => {
         const skillVersionsWithFiles = [
           skillVersionFactory({
             files: [
-              {
+              skillFileFactory({
                 id: createSkillFileId('file-1'),
                 skillVersionId: createSkillVersionId('skill-version-1'),
                 path: 'SKILL.MD',
                 content: 'This should be ignored',
                 permissions: 'rw-r--r--',
-              },
-              {
+              }),
+              skillFileFactory({
                 id: createSkillFileId('file-2'),
                 skillVersionId: createSkillVersionId('skill-version-1'),
                 path: 'reference.md',
                 content: 'Reference content',
                 permissions: 'rw-r--r--',
-              },
+              }),
             ],
           }),
         ];
@@ -1022,13 +1023,13 @@ describe('CursorDeployer', () => {
         const skillVersionsWithFiles = [
           skillVersionFactory({
             files: [
-              {
+              skillFileFactory({
                 id: createSkillFileId('file-1'),
                 skillVersionId: createSkillVersionId('skill-version-1'),
                 path: 'helper.ts',
                 content: 'export const helper = () => {}',
                 permissions: 'rw-r--r--',
-              },
+              }),
             ],
           }),
         ];

--- a/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/OnboardDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/OnboardDeployer.spec.ts
@@ -1,5 +1,5 @@
 import { OnboardDeployer } from './OnboardDeployer';
-import { DeleteItemType, FileUpdates } from '@packmind/types';
+import { DeleteItemType, FileModification, FileUpdates } from '@packmind/types';
 
 /**
  * CLI versions that only expose the legacy `packmind-cli` executable. The
@@ -49,20 +49,33 @@ describe('OnboardDeployer', () => {
     options: { includeNext?: boolean; cliVersion?: string } = {},
   ): FileUpdates => deployer.deploy('TestAgent', '.test/skills/', options);
 
+  /**
+   * Narrows a file update to the content-carrying variant of
+   * `FileModification`; the section-based variant has no `content`.
+   */
+  const contentOf = (file: FileModification): string => {
+    if (file.content === undefined) {
+      throw new Error(`Emitted file carries no content: ${file.path}`);
+    }
+    return file.content;
+  };
+
   const contentAt = (result: FileUpdates, path: string): string => {
     const file = result.createOrUpdate.find((f) => f.path === path);
     if (!file) throw new Error(`Missing emitted file: ${path}`);
-    return file.content;
+    return contentOf(file);
   };
 
   /**
    * Files that reach every install at or above the skill's `minimumVersion`,
    * as opposed to the version-pinned ones under `packmind-versions/`.
    */
-  const unversionedFiles = (result: FileUpdates) =>
-    result.createOrUpdate.filter(
-      (file) => !file.path.includes('/packmind-versions/'),
-    );
+  const unversionedFiles = (
+    result: FileUpdates,
+  ): { path: string; content: string }[] =>
+    result.createOrUpdate
+      .filter((file) => !file.path.includes('/packmind-versions/'))
+      .map((file) => ({ path: file.path, content: contentOf(file) }));
 
   const versionedFileNames = [
     'create-items.md',

--- a/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/OnboardDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/OnboardDeployer.spec.ts
@@ -1,5 +1,6 @@
 import { OnboardDeployer } from './OnboardDeployer';
-import { DeleteItemType, FileModification, FileUpdates } from '@packmind/types';
+import { DeleteItemType, FileUpdates } from '@packmind/types';
+import { contentAt, contentOf } from '@packmind/test-utils';
 
 /**
  * CLI versions that only expose the legacy `packmind-cli` executable. The
@@ -48,23 +49,6 @@ describe('OnboardDeployer', () => {
   const deploy = (
     options: { includeNext?: boolean; cliVersion?: string } = {},
   ): FileUpdates => deployer.deploy('TestAgent', '.test/skills/', options);
-
-  /**
-   * Narrows a file update to the content-carrying variant of
-   * `FileModification`; the section-based variant has no `content`.
-   */
-  const contentOf = (file: FileModification): string => {
-    if (file.content === undefined) {
-      throw new Error(`Emitted file carries no content: ${file.path}`);
-    }
-    return file.content;
-  };
-
-  const contentAt = (result: FileUpdates, path: string): string => {
-    const file = result.createOrUpdate.find((f) => f.path === path);
-    if (!file) throw new Error(`Missing emitted file: ${path}`);
-    return contentOf(file);
-  };
 
   /**
    * Files that reach every install at or above the skill's `minimumVersion`,

--- a/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/UpdatePlaybookDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/UpdatePlaybookDeployer.spec.ts
@@ -1,5 +1,6 @@
 import { UpdatePlaybookDeployer } from './UpdatePlaybookDeployer';
-import { DeleteItemType, FileModification, FileUpdates } from '@packmind/types';
+import { DeleteItemType, FileUpdates } from '@packmind/types';
+import { contentAt, contentOf } from '@packmind/test-utils';
 
 /**
  * CLI versions that only expose the legacy `packmind-cli` executable. The
@@ -48,23 +49,6 @@ describe('UpdatePlaybookDeployer', () => {
   const deploy = (
     options: { includeNext?: boolean; cliVersion?: string } = {},
   ): FileUpdates => deployer.deploy('TestAgent', '.test/skills/', options);
-
-  /**
-   * Narrows a file update to the content-carrying variant of
-   * `FileModification`; the section-based variant has no `content`.
-   */
-  const contentOf = (file: FileModification): string => {
-    if (file.content === undefined) {
-      throw new Error(`Emitted file carries no content: ${file.path}`);
-    }
-    return file.content;
-  };
-
-  const contentAt = (result: FileUpdates, path: string): string => {
-    const file = result.createOrUpdate.find((f) => f.path === path);
-    if (!file) throw new Error(`Missing emitted file: ${path}`);
-    return contentOf(file);
-  };
 
   /**
    * Files that reach every install at or above the skill's `minimumVersion`,

--- a/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/UpdatePlaybookDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/defaultSkillsDeployer/UpdatePlaybookDeployer.spec.ts
@@ -1,5 +1,5 @@
 import { UpdatePlaybookDeployer } from './UpdatePlaybookDeployer';
-import { DeleteItemType, FileUpdates } from '@packmind/types';
+import { DeleteItemType, FileModification, FileUpdates } from '@packmind/types';
 
 /**
  * CLI versions that only expose the legacy `packmind-cli` executable. The
@@ -49,20 +49,33 @@ describe('UpdatePlaybookDeployer', () => {
     options: { includeNext?: boolean; cliVersion?: string } = {},
   ): FileUpdates => deployer.deploy('TestAgent', '.test/skills/', options);
 
+  /**
+   * Narrows a file update to the content-carrying variant of
+   * `FileModification`; the section-based variant has no `content`.
+   */
+  const contentOf = (file: FileModification): string => {
+    if (file.content === undefined) {
+      throw new Error(`Emitted file carries no content: ${file.path}`);
+    }
+    return file.content;
+  };
+
   const contentAt = (result: FileUpdates, path: string): string => {
     const file = result.createOrUpdate.find((f) => f.path === path);
     if (!file) throw new Error(`Missing emitted file: ${path}`);
-    return file.content;
+    return contentOf(file);
   };
 
   /**
    * Files that reach every install at or above the skill's `minimumVersion`,
    * as opposed to the version-pinned ones under `packmind-versions/`.
    */
-  const unversionedFiles = (result: FileUpdates) =>
-    result.createOrUpdate.filter(
-      (file) => !file.path.includes('/packmind-versions/'),
-    );
+  const unversionedFiles = (
+    result: FileUpdates,
+  ): { path: string; content: string }[] =>
+    result.createOrUpdate
+      .filter((file) => !file.path.includes('/packmind-versions/'))
+      .map((file) => ({ path: file.path, content: contentOf(file) }));
 
   const unversionedStepFiles = [
     'analyze-standards.md',

--- a/packages/coding-agent/src/infra/repositories/genericSectionWriter/SingleFileDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/genericSectionWriter/SingleFileDeployer.spec.ts
@@ -17,6 +17,7 @@ import {
 import { SingleFileDeployer, DeployerConfig } from './SingleFileDeployer';
 import { v4 as uuidv4 } from 'uuid';
 import { IStandardsPort, IGitPort } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/test-utils';
 
 // Create a concrete test implementation of the abstract SingleFileDeployer
 class TestSingleFileDeployer extends SingleFileDeployer {
@@ -42,13 +43,13 @@ describe('SingleFileDeployer', () => {
 
     deployer = new TestSingleFileDeployer(mockStandardsPort, mockGitPort);
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'testowner',
       repo: 'testrepo',
       branch: 'main',
       providerId: createGitProviderId('test-provider-id'),
-    };
+    });
 
     jetbrainsTarget = {
       id: createTargetId(uuidv4()),

--- a/packages/coding-agent/src/infra/repositories/gitlabDuo/GitlabDuoDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/gitlabDuo/GitlabDuoDeployer.spec.ts
@@ -20,6 +20,7 @@ import { GenericStandardSectionWriter } from '../genericSectionWriter/GenericSta
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
 import { skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
 
 describe('GitlabDuoDeployer', () => {
@@ -38,13 +39,13 @@ describe('GitlabDuoDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   describe('deployRecipes', () => {
@@ -498,7 +499,7 @@ describe('GitlabDuoDeployer', () => {
         const helperFile = result.createOrUpdate.find((f) =>
           f.path.includes('helper.py'),
         );
-        expect(helperFile?.isBase64).toBe(false);
+        expect(helperFile).toMatchObject({ isBase64: false });
       });
 
       it('includes skillFileId on additional files', () => {

--- a/packages/coding-agent/src/infra/repositories/junie/JunieDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/junie/JunieDeployer.spec.ts
@@ -15,6 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { GenericStandardSectionWriter } from '../genericSectionWriter/GenericStandardSectionWriter';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 
 describe('JunieDeployer', () => {
   let deployer: JunieDeployer;
@@ -32,13 +33,13 @@ describe('JunieDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   describe('deployRecipes', () => {

--- a/packages/coding-agent/src/infra/repositories/kiro/KiroDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/kiro/KiroDeployer.spec.ts
@@ -20,6 +20,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { commandFactory } from '@packmind/commands/test';
 import { standardFactory } from '@packmind/standards/test';
 import { skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
 
 const STEERING_DIR = '.kiro/steering/';
@@ -71,13 +72,13 @@ describe('KiroDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   afterEach(() => {
@@ -92,7 +93,7 @@ describe('KiroDeployer', () => {
 
   describe('deployStandards', () => {
     describe('when the standard has a scope', () => {
-      let content: string;
+      let content: string | undefined;
       let path: string;
 
       beforeEach(async () => {
@@ -143,7 +144,7 @@ describe('KiroDeployer', () => {
     });
 
     describe('when the standard has no scope', () => {
-      let content: string;
+      let content: string | undefined;
 
       beforeEach(async () => {
         const result = await deployer.deployStandards(

--- a/packages/coding-agent/src/infra/repositories/opencode/OpenCodeDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/opencode/OpenCodeDeployer.spec.ts
@@ -15,8 +15,12 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { GenericStandardSectionWriter } from '../genericSectionWriter/GenericStandardSectionWriter';
 import { commandFactory } from '@packmind/commands/test';
-import { standardFactory } from '@packmind/standards/test';
+import {
+  standardFactory,
+  standardVersionFactory,
+} from '@packmind/standards/test';
 import { skillVersionFactory } from '@packmind/skills/test';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { DefaultSkillsDeployer } from '../defaultSkillsDeployer/DefaultSkillsDeployer';
 
 describe('OpenCodeDeployer', () => {
@@ -34,13 +38,13 @@ describe('OpenCodeDeployer', () => {
       gitRepoId: createGitRepoId(uuidv4()),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   describe('deployRecipes', () => {
@@ -327,7 +331,7 @@ describe('OpenCodeDeployer', () => {
           name: 'My Standard',
           slug: 'my-standard',
         });
-        const standardVersion: StandardVersion = {
+        const standardVersion = standardVersionFactory({
           id: createStandardVersionId('sv-1'),
           standardId: standard.id,
           name: standard.name,
@@ -335,7 +339,7 @@ describe('OpenCodeDeployer', () => {
           description: 'Standard description',
           version: 1,
           userId: createUserId('user-1'),
-        };
+        });
 
         const skillVersion = skillVersionFactory({
           name: 'my-skill',

--- a/packages/coding-agent/src/infra/repositories/packmind/PackmindDeployer.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/packmind/PackmindDeployer.spec.ts
@@ -12,6 +12,7 @@ import {
   createTargetId,
   createUserId,
   DeleteItemType,
+  FileModification,
   FileUpdates,
   GitRepo,
   IStandardsPort,
@@ -22,6 +23,7 @@ import {
   StandardVersion,
   Target,
 } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { PackmindDeployer } from './PackmindDeployer';
 
 describe('PackmindDeployer', () => {
@@ -43,13 +45,13 @@ describe('PackmindDeployer', () => {
       gitRepoId: createGitRepoId('test-repo-id'),
     };
 
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'test-owner',
       repo: 'test-repo',
       providerId: createGitProviderId('provider-id'),
       branch: 'main',
-    };
+    });
   });
 
   describe('deployRecipes', () => {
@@ -309,7 +311,7 @@ describe('PackmindDeployer', () => {
     });
 
     describe('when deploying standard with rules', () => {
-      let standardFile: { path: string; content: string } | undefined;
+      let standardFile: FileModification | undefined;
 
       beforeEach(async () => {
         const standard: Standard = standardFactory({
@@ -513,7 +515,7 @@ describe('PackmindDeployer', () => {
       let localMockStandardsPort: { getRulesByStandardId: jest.Mock };
       let result: FileUpdates;
       let standard: Standard;
-      let standardFile: { path: string; content: string } | undefined;
+      let standardFile: FileModification | undefined;
 
       beforeEach(async () => {
         localMockStandardsPort = {

--- a/packages/coding-agent/src/infra/repositories/utils/FileUtils.spec.ts
+++ b/packages/coding-agent/src/infra/repositories/utils/FileUtils.spec.ts
@@ -5,6 +5,7 @@ import {
   createGitRepoId,
   createGitProviderId,
 } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { getTargetPrefixedPath } from './FileUtils';
 
@@ -16,13 +17,13 @@ describe('SingleFileDeployer', () => {
   let nestedTarget: Target;
 
   beforeEach(() => {
-    mockGitRepo = {
+    mockGitRepo = gitRepoFactory({
       id: createGitRepoId('test-repo-id'),
       owner: 'testowner',
       repo: 'testrepo',
       branch: 'main',
       providerId: createGitProviderId('test-provider-id'),
-    };
+    });
 
     // Create various test targets
     rootTarget = {

--- a/packages/skills/test/skillFactory.ts
+++ b/packages/skills/test/skillFactory.ts
@@ -22,6 +22,8 @@ export const skillFactory: Factory<Skill> = (skill?: Partial<Skill>) => {
     metadata: { category: 'test', tags: 'testing' },
     allowedTools: 'Read,Write,Bash',
     movedTo: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
     ...skill,
   };
 };

--- a/packages/skills/test/skillFileFactory.ts
+++ b/packages/skills/test/skillFileFactory.ts
@@ -15,6 +15,7 @@ export const skillFileFactory: Factory<SkillFile> = (
     path: 'SKILL.md',
     content: '---\nname: test-skill\ndescription: Test skill\n---\n\nContent',
     permissions: 'rw-r--r--',
+    isBase64: false,
     ...skillFile,
   };
 };

--- a/packages/test-utils/src/fileUpdates/contentOf.ts
+++ b/packages/test-utils/src/fileUpdates/contentOf.ts
@@ -1,0 +1,43 @@
+import { FileModification, FileUpdates } from '@packmind/types';
+
+export class MissingFileContentError extends Error {
+  constructor(path: string) {
+    super(`Expected the file update for '${path}' to carry inline content`);
+    this.name = 'MissingFileContentError';
+  }
+}
+
+export class MissingFileUpdateError extends Error {
+  constructor(path: string) {
+    super(`Expected a file update for '${path}'`);
+    this.name = 'MissingFileUpdateError';
+  }
+}
+
+/**
+ * Narrows a file update to the content-carrying variant of `FileModification`.
+ *
+ * `FileModification` is a union: one variant holds inline `content`, the other
+ * a list of `sections` and no content at all. Assertions that need the rendered
+ * text have to rule the section variant out, and a deployer that emitted
+ * sections where the spec expected content is a failure worth reporting rather
+ * than one to paper over with a default.
+ */
+export const contentOf = (fileUpdate: FileModification): string => {
+  if (fileUpdate.content === undefined) {
+    throw new MissingFileContentError(fileUpdate.path);
+  }
+  return fileUpdate.content;
+};
+
+/**
+ * The rendered content of the file emitted at `path`, for specs that assert on
+ * one file out of many.
+ */
+export const contentAt = (fileUpdates: FileUpdates, path: string): string => {
+  const fileUpdate = fileUpdates.createOrUpdate.find((f) => f.path === path);
+  if (!fileUpdate) {
+    throw new MissingFileUpdateError(path);
+  }
+  return contentOf(fileUpdate);
+};

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from './factories/git';
 export * from './factories/commands';
 export * from './factories/standards';
 export * from './factories/deployments';
+export * from './fileUpdates/contentOf';
 export * from './logger/stubLogger';
 export * from './skipWhenRoot';
 export * from './repository';


### PR DESCRIPTION
## Explanation

`packages/coding-agent`'s specs were never type checked: the shared `typecheck` in `nx.json` only reads `tsconfig.lib.json`, which excludes `src/**/*.spec.ts`, and @swc/jest strips types without checking them. Enabling `tsconfig.spec.json` surfaced 84 errors, all fixture drift. This repairs them and adds the second `tsc` invocation so the gate holds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: `coding-agent` (specs + `project.json`), `skills` (two `/test` factories), `test-utils` (new shared `contentOf`/`contentAt`)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

Drift: 14 incomplete `GitRepo` and 16 `SkillFile` literals (now factories), 26 `FileModification` narrowings, 4 `DeleteItem` and 2 `StandardVersion` missing fields, 4 partial `ICodingAgentDeployer` mocks, 3 stale `RecipeVersion` references, 3 missing factory defaults.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**
`nx run-many -t typecheck -p packages/*` (fails on an injected `const __c: number = "x";`), `nx test coding-agent` (1261 passed, 0 skipped), `nx lint coding-agent skills test-utils` (93 warnings, unchanged), `prettier -c`, and tests for the changed factories' consumers.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

No production bug — all 84 were fixture drift, and every test passes with its assertions unchanged.

`gitRepoFactory` comes from `@packmind/test-utils` (already a dependency) rather than `@packmind/git/test`, to avoid adding a `coding-agent` → `git` edge for a fixture.

Follow-up available: 14 pre-existing `throw new Error('expected content')` sites in the two `*PluginDeployer` specs can move onto the new shared `contentOf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01836uQtrc6DnZ1x5vh8hyWA