### PR TITLE
🔬 test(llm): restore type checking on the llm specs

### DIFF
--- a/packages/llm/project.json
+++ b/packages/llm/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/llm/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Overrides the nx.json command to also gate the specs: tsconfig.lib.json excludes them, so @swc/jest was the only thing reading those files and it strips types without checking them.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/llm/tsconfig.lib.json && tsc --noEmit --project packages/llm/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/llm/src/application/useCases/getAiServiceForOrganization/GetAiServiceForOrganizationUseCase.spec.ts
+++ b/packages/llm/src/application/useCases/getAiServiceForOrganization/GetAiServiceForOrganizationUseCase.spec.ts
@@ -70,7 +70,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
               model: 'gpt-4',
               fastestModel: 'gpt-4-mini',
             },
-            configuredAt: new Date(),
           });
         });
 
@@ -90,7 +89,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
               model: 'claude-3-opus-20240229',
               fastestModel: 'claude-3-haiku-20240307',
             },
-            configuredAt: new Date(),
           });
         });
 
@@ -107,7 +105,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
             config: {
               provider: LLMProvider.PACKMIND,
             },
-            configuredAt: new Date(),
           });
         });
 
@@ -153,7 +150,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
             config: {
               provider: LLMProvider.PACKMIND,
             },
-            configuredAt: new Date(),
           });
         });
 
@@ -173,7 +169,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
               model: 'gpt-4',
               fastestModel: 'gpt-4-mini',
             },
-            configuredAt: new Date(),
           });
         });
 
@@ -193,7 +188,6 @@ describe('GetAiServiceForOrganizationUseCase', () => {
               model: 'claude-3-opus-20240229',
               fastestModel: 'claude-3-haiku-20240307',
             },
-            configuredAt: new Date(),
           });
         });
 

--- a/packages/llm/src/application/useCases/getModels/GetModelsUseCase.spec.ts
+++ b/packages/llm/src/application/useCases/getModels/GetModelsUseCase.spec.ts
@@ -59,18 +59,17 @@ describe('GetModelsUseCase', () => {
     };
 
     const createValidCommand = (
-      configOverrides?: Partial<GetModelsCommand['config']>,
+      config: GetModelsCommand['config'] = {
+        provider: LLMProvider.OPENAI,
+        apiKey: 'test-key',
+      },
     ): GetModelsCommand & MemberContext => ({
       userId: String(userId),
       organizationId,
       user,
       organization,
       membership,
-      config: {
-        provider: LLMProvider.OPENAI,
-        apiKey: 'test-key',
-        ...configOverrides,
-      },
+      config,
     });
 
     describe('when models are successfully retrieved', () => {
@@ -117,7 +116,10 @@ describe('GetModelsUseCase', () => {
       beforeEach(async () => {
         mockGetModels.mockResolvedValue([]);
         result = await useCase.executeForMembers(
-          createValidCommand({ provider: LLMProvider.ANTHROPIC }),
+          createValidCommand({
+            provider: LLMProvider.ANTHROPIC,
+            apiKey: 'test-key',
+          }),
         );
       });
 
@@ -188,7 +190,10 @@ describe('GetModelsUseCase', () => {
 
       it('classifies error as rate limit', async () => {
         const result = await useCase.executeForMembers(
-          createValidCommand({ provider: LLMProvider.GEMINI }),
+          createValidCommand({
+            provider: LLMProvider.GEMINI,
+            apiKey: 'test-key',
+          }),
         );
 
         expect(result.error?.type).toBe('RATE_LIMIT');

--- a/packages/llm/src/application/useCases/saveLLMConfiguration/SaveLLMConfigurationUseCase.spec.ts
+++ b/packages/llm/src/application/useCases/saveLLMConfiguration/SaveLLMConfigurationUseCase.spec.ts
@@ -6,6 +6,7 @@ import {
   SaveLLMConfigurationCommand,
 } from '@packmind/types';
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { OrganizationAdminRequiredError } from '@packmind/node-utils';
 import { SaveLLMConfigurationUseCase } from './SaveLLMConfigurationUseCase';
 import { IAIProviderRepository } from '../../../domain/repositories/IAIProviderRepository';
@@ -18,39 +19,31 @@ describe('SaveLLMConfigurationUseCase', () => {
   let mockAccountsPort: jest.Mocked<IAccountsPort>;
   let mockConfigurationRepository: jest.Mocked<IAIProviderRepository>;
 
-  const adminUser = {
+  const adminUser = userFactory({
     id: userId,
     email: 'admin@example.com',
-    passwordHash: 'hashed-password',
-    active: true,
     memberships: [
       {
         userId,
         organizationId,
-        role: 'admin' as const,
+        role: 'admin',
       },
     ],
-  };
+  });
 
-  const memberUser = {
+  const memberUser = userFactory({
     id: userId,
     email: 'member@example.com',
-    passwordHash: 'hashed-password',
-    active: true,
     memberships: [
       {
         userId,
         organizationId,
-        role: 'member' as const,
+        role: 'member',
       },
     ],
-  };
+  });
 
-  const organization = {
-    id: organizationId,
-    name: 'Test Organization',
-    slug: 'test-org',
-  };
+  const organization = organizationFactory({ id: organizationId });
 
   beforeEach(() => {
     mockAccountsPort = {

--- a/packages/llm/src/application/useCases/testLLMConnection/TestLLMConnectionUseCase.spec.ts
+++ b/packages/llm/src/application/useCases/testLLMConnection/TestLLMConnectionUseCase.spec.ts
@@ -3,9 +3,11 @@ import {
   createUserId,
   IAccountsPort,
   LLMProvider,
+  UserOrganizationMembership,
 } from '@packmind/types';
 import { MemberContext } from '@packmind/node-utils';
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { TestLLMConnectionUseCase } from './TestLLMConnectionUseCase';
 import { createLLMService } from '../../../factories/createLLMService';
 
@@ -22,28 +24,19 @@ describe('TestLLMConnectionUseCase', () => {
 
   const userId = createUserId('user-123');
   const organizationId = createOrganizationId('org-456');
+  const membership: UserOrganizationMembership = {
+    userId,
+    organizationId,
+    role: 'member',
+  };
   const memberContext: MemberContext = {
-    user: {
+    user: userFactory({
       id: userId,
       email: 'test@example.com',
-      memberships: [
-        {
-          userId: String(userId),
-          organizationId,
-          role: 'member',
-        },
-      ],
-    },
-    organization: {
-      id: organizationId,
-      name: 'Test Organization',
-      slug: 'test-org',
-    },
-    membership: {
-      userId: String(userId),
-      organizationId,
-      role: 'member',
-    },
+      memberships: [membership],
+    }),
+    organization: organizationFactory({ id: organizationId }),
+    membership,
   };
 
   beforeEach(() => {
@@ -59,6 +52,7 @@ describe('TestLLMConnectionUseCase', () => {
       executePrompt: mockExecutePrompt,
       isConfigured: jest.fn().mockResolvedValue(true),
       executePromptWithHistory: jest.fn(),
+      getModels: jest.fn(),
     });
   });
 

--- a/packages/llm/src/application/useCases/testSavedLLMConfiguration/TestSavedLLMConfigurationUseCase.spec.ts
+++ b/packages/llm/src/application/useCases/testSavedLLMConfiguration/TestSavedLLMConfigurationUseCase.spec.ts
@@ -5,6 +5,7 @@ import {
   LLMProvider,
 } from '@packmind/types';
 import { stubLogger } from '@packmind/test-utils';
+import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { OrganizationAdminRequiredError } from '@packmind/node-utils';
 import { IAIProviderRepository } from '../../../domain/repositories/IAIProviderRepository';
 import { TestSavedLLMConfigurationUseCase } from './TestSavedLLMConfigurationUseCase';
@@ -30,39 +31,31 @@ describe('TestSavedLLMConfigurationUseCase', () => {
     typeof utils.isPackmindProviderAvailable
   >;
 
-  const adminUser = {
+  const adminUser = userFactory({
     id: userId,
     email: 'admin@example.com',
-    passwordHash: 'hashed-password',
-    active: true,
     memberships: [
       {
         userId,
         organizationId,
-        role: 'admin' as const,
+        role: 'admin',
       },
     ],
-  };
+  });
 
-  const memberUser = {
+  const memberUser = userFactory({
     id: userId,
     email: 'member@example.com',
-    passwordHash: 'hashed-password',
-    active: true,
     memberships: [
       {
         userId,
         organizationId,
-        role: 'member' as const,
+        role: 'member',
       },
     ],
-  };
+  });
 
-  const organization = {
-    id: organizationId,
-    name: 'Test Organization',
-    slug: 'test-org',
-  };
+  const organization = organizationFactory({ id: organizationId });
 
   beforeEach(() => {
     mockAccountsPort = {
@@ -224,8 +217,6 @@ describe('TestSavedLLMConfigurationUseCase', () => {
     });
 
     describe('when configuration exists', () => {
-      const configuredAt = new Date('2024-01-15T10:00:00Z');
-
       beforeEach(() => {
         mockConfigurationRepository.get.mockResolvedValue({
           config: {
@@ -234,7 +225,6 @@ describe('TestSavedLLMConfigurationUseCase', () => {
             model: 'gpt-4',
             fastestModel: 'gpt-4-mini',
           },
-          configuredAt,
         });
       });
 
@@ -358,7 +348,6 @@ describe('TestSavedLLMConfigurationUseCase', () => {
             model: 'gpt-4',
             fastestModel: 'gpt-4',
           },
-          configuredAt: new Date(),
         });
         mockExecutePrompt.mockResolvedValueOnce({
           success: true,

--- a/packages/llm/src/infra/services/PackmindService.spec.ts
+++ b/packages/llm/src/infra/services/PackmindService.spec.ts
@@ -40,11 +40,10 @@ describe('PackmindService', () => {
     describe('when PACKMIND_DEFAULT_PROVIDER is not set', () => {
       it('returns configured status', async () => {
         mockGetConfig.mockImplementation((key: string) => {
-          if (key === 'PACKMIND_DEFAULT_PROVIDER')
-            return Promise.resolve(undefined);
+          if (key === 'PACKMIND_DEFAULT_PROVIDER') return Promise.resolve(null);
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -66,11 +65,10 @@ describe('PackmindService', () => {
 
       it('uses OpenAI as default provider', async () => {
         mockGetConfig.mockImplementation((key: string) => {
-          if (key === 'PACKMIND_DEFAULT_PROVIDER')
-            return Promise.resolve(undefined);
+          if (key === 'PACKMIND_DEFAULT_PROVIDER') return Promise.resolve(null);
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -101,7 +99,7 @@ describe('PackmindService', () => {
             return Promise.resolve('openai');
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -132,7 +130,7 @@ describe('PackmindService', () => {
             return Promise.resolve('anthropic');
           if (key === 'ANTHROPIC_API_KEY')
             return Promise.resolve('test-anthropic-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockAnthropicService = {
@@ -163,7 +161,7 @@ describe('PackmindService', () => {
             return Promise.resolve('gemini');
           if (key === 'GEMINI_API_KEY')
             return Promise.resolve('test-gemini-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockGeminiService = {
@@ -194,7 +192,7 @@ describe('PackmindService', () => {
             return Promise.resolve('packmind');
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -225,7 +223,7 @@ describe('PackmindService', () => {
             return Promise.resolve('invalid-provider');
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -256,7 +254,7 @@ describe('PackmindService', () => {
             return Promise.reject(new Error('Config error'));
           if (key === 'OPENAI_API_KEY')
             return Promise.resolve('test-openai-key');
-          return Promise.resolve(undefined);
+          return Promise.resolve(null);
         });
 
         const mockOpenAIService = {
@@ -621,7 +619,7 @@ describe('PackmindService', () => {
         if (key === 'PACKMIND_DEFAULT_PROVIDER')
           return Promise.resolve('openai');
         if (key === 'OPENAI_API_KEY') return Promise.resolve('test-openai-key');
-        return Promise.resolve(undefined);
+        return Promise.resolve(null);
       });
 
       const mockOpenAIService = {
@@ -641,7 +639,7 @@ describe('PackmindService', () => {
         if (key === 'PACKMIND_DEFAULT_PROVIDER')
           return Promise.resolve('openai');
         if (key === 'OPENAI_API_KEY') return Promise.resolve('test-openai-key');
-        return Promise.resolve(undefined);
+        return Promise.resolve(null);
       });
 
       const mockOpenAIService = {


### PR DESCRIPTION
## Explanation

The shared `typecheck` target only runs `tsc -p <proj>/tsconfig.lib.json`, which excludes `src/**/*.spec.ts`, and @swc/jest strips types without checking them — so nothing type checked `packages/llm`'s specs. 26 errors had accumulated. Fixed all of them in the fixtures and extended the package's `typecheck` command with `tsconfig.spec.json` so drift fails CI from now on.

<!-- Reference any existing issue, drop the section otherwise -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: `llm` only (specs + `project.json`)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

Drift categories: 7 non-existent `configuredAt` fields on `StoredAIProvider`, 5 `User` literals missing `displayName` (now `userFactory`/`organizationFactory`), 2 membership ids widened to `string` instead of branded `UserId`, 1 `AIService` mock missing `getModels`, 12 `Configuration.getConfig` stubs resolving `undefined` against a `Promise<string | null>` contract, 1 partial-spread that widened the `LLMServiceConfig` discriminated union.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] Test coverage maintained or improved

**Test Details:**
`nx run-many -t test,lint,typecheck -p llm` (365 tests pass unchanged, none skipped), `nx run-many -t typecheck -p packages/*`, `prettier -c`; gate verified by injecting `const __c: number = "x";` into a spec and confirming the CI command fails.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

No production bug — all 26 were fixture drift, and no `src/` file changed. Worth confirming the `Promise.resolve(null)` switch in `PackmindService.spec.ts`: production guards with `if (!value)`, so `null` and `undefined` behave identically, and `null` is what the contract actually returns.

`packages/llm` has no `test/` folder, so no `tsconfig.spec.json` `include` change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yqU5j5VJd8hn28GzhoguT

---
_Generated by [Claude Code](https://claude.ai/code/session_017yqU5j5VJd8hn28GzhoguT)_