### PR TITLE
👷 ci(deployments): restore type checking on test files

### DIFF
--- a/packages/accounts/src/infra/repositories/InvitationRepository.ts
+++ b/packages/accounts/src/infra/repositories/InvitationRepository.ts
@@ -50,7 +50,7 @@ export class InvitationRepository
     return this.decryptInvitation(saved);
   }
 
-  async addMany(invitations: Invitation[]): Promise<Invitation[]> {
+  override async addMany(invitations: Invitation[]): Promise<Invitation[]> {
     if (invitations.length === 0) {
       this.logger.warn('No invitations provided for bulk insert');
       return [];

--- a/packages/deployments/project.json
+++ b/packages/deployments/project.json
@@ -4,8 +4,13 @@
   "sourceRoot": "packages/deployments/src",
   "projectType": "library",
   "tags": ["env:node"],
+  "// typecheck": "Extends the nx.json command so the spec program (specs plus test/ fixtures) is type-checked too; the shared one only covers tsconfig.lib.json.",
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/deployments/tsconfig.lib.json && tsc --noEmit --project packages/deployments/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/deployments/src/application/adapter/DeploymentsAdapter.spec.ts
+++ b/packages/deployments/src/application/adapter/DeploymentsAdapter.spec.ts
@@ -1,12 +1,13 @@
 import {
   RenderPackageAsPluginCommand,
+  RenderPackageAsPluginResponse,
   TrackPluginDeletedCommand,
 } from '@packmind/types';
 import { DeploymentsAdapter } from './DeploymentsAdapter';
 
 describe('DeploymentsAdapter', () => {
   describe('renderPackageAsPlugin', () => {
-    const response = {
+    const response: RenderPackageAsPluginResponse = {
       files: [],
       skippedStandardsCount: 0,
       pluginName: 'security',

--- a/packages/deployments/src/application/listeners/DeploymentsListener.spec.ts
+++ b/packages/deployments/src/application/listeners/DeploymentsListener.spec.ts
@@ -9,6 +9,7 @@ import {
   CommandDeletedEvent,
   SkillDeletedEvent,
   StandardDeletedEvent,
+  PackmindEventSource,
 } from '@packmind/types';
 import { DataSource } from 'typeorm';
 import { IPackageRepository } from '../../domain/repositories/IPackageRepository';
@@ -23,6 +24,7 @@ describe('DeploymentsListener', () => {
   const spaceId = createSpaceId('space-456');
   const organizationId = createOrganizationId('org-789');
   const userId = createUserId('user-abc');
+  const source: PackmindEventSource = 'ui';
 
   beforeEach(() => {
     mockDataSource = {
@@ -67,6 +69,7 @@ describe('DeploymentsListener', () => {
         spaceId,
         organizationId,
         userId,
+        source,
       });
 
       eventService.emit(event);
@@ -89,6 +92,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 
@@ -98,6 +102,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 
@@ -133,6 +138,7 @@ describe('DeploymentsListener', () => {
         spaceId,
         organizationId,
         userId,
+        source,
       });
 
       eventService.emit(event);
@@ -155,6 +161,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 
@@ -164,6 +171,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 
@@ -199,6 +207,7 @@ describe('DeploymentsListener', () => {
         spaceId,
         organizationId,
         userId,
+        source,
       });
 
       eventService.emit(event);
@@ -221,6 +230,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 
@@ -230,6 +240,7 @@ describe('DeploymentsListener', () => {
             spaceId,
             organizationId,
             userId,
+            source,
           }),
         );
 

--- a/packages/deployments/src/application/services/RenderModeConfigurationService.spec.ts
+++ b/packages/deployments/src/application/services/RenderModeConfigurationService.spec.ts
@@ -4,6 +4,7 @@ import { IRenderModeConfigurationRepository } from '../../domain/repositories/IR
 import { stubLogger } from '@packmind/test-utils';
 import { OrganizationId, createOrganizationId } from '@packmind/types';
 import {
+  CodingAgents,
   DEFAULT_ACTIVE_RENDER_MODES,
   RenderMode,
   RenderModeConfiguration,

--- a/packages/deployments/src/application/services/TargetResolutionService.spec.ts
+++ b/packages/deployments/src/application/services/TargetResolutionService.spec.ts
@@ -1,5 +1,7 @@
 import { stubLogger } from '@packmind/test-utils';
 import {
+  GitProviderListItem,
+  GitProviderVendors,
   IGitPort,
   Target,
   CommandVersion,
@@ -19,6 +21,11 @@ import {
   createPackageId,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { gitRepoFactory } from '@packmind/git/test';
+import { commandVersionFactory } from '@packmind/commands/test';
+import { standardVersionFactory } from '@packmind/standards/test';
+import { skillVersionFactory } from '@packmind/skills/test';
+import { targetFactory } from '../../../test';
 import { TargetResolutionService } from './TargetResolutionService';
 import { TargetService } from './TargetService';
 import { IDistributionRepository } from '../../domain/repositories/IDistributionRepository';
@@ -33,16 +40,26 @@ describe('TargetResolutionService', () => {
   const userId = uuidv4();
   const gitRemoteUrl = 'https://github.com/test-owner/test-repo.git';
   const gitBranch = 'main';
-  const providerId = uuidv4();
+  const providerId = createGitProviderId(uuidv4());
   const gitRepoId = createGitRepoId(uuidv4());
+  const githubProvider: GitProviderListItem = {
+    id: providerId,
+    source: GitProviderVendors.github,
+    organizationId,
+    url: 'https://github.com',
+    authMethod: 'token',
+    displayName: 'github-provider',
+    hasAuth: true,
+    lastDistributionAt: null,
+  };
   const targetId = createTargetId(uuidv4());
 
-  const target: Target = {
+  const target: Target = targetFactory({
     id: targetId,
     name: 'production',
     path: '/',
     gitRepoId,
-  };
+  });
 
   beforeEach(() => {
     gitPort = {
@@ -79,15 +96,15 @@ describe('TargetResolutionService', () => {
     describe('when matching repo and target exist', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'test-owner',
             repo: 'test-repo',
             branch: 'main',
-          },
+          }),
         ]);
         targetService.getTargetsByGitRepoId.mockResolvedValue([target]);
       });
@@ -108,15 +125,15 @@ describe('TargetResolutionService', () => {
     describe('when no matching repo exists', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'other-owner',
             repo: 'other-repo',
             branch: 'main',
-          },
+          }),
         ]);
       });
 
@@ -136,15 +153,15 @@ describe('TargetResolutionService', () => {
     describe('when repo exists but no matching target', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'test-owner',
             repo: 'test-repo',
             branch: 'main',
-          },
+          }),
         ]);
         targetService.getTargetsByGitRepoId.mockResolvedValue([
           { ...target, path: '/other-path/' },
@@ -167,15 +184,15 @@ describe('TargetResolutionService', () => {
     describe('when relativePath needs normalization', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'test-owner',
             repo: 'test-repo',
             branch: 'main',
-          },
+          }),
         ]);
       });
 
@@ -263,15 +280,15 @@ describe('TargetResolutionService', () => {
     describe('when target already exists', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'test-owner',
             repo: 'test-repo',
             branch: 'main',
-          },
+          }),
         ]);
         targetService.getTargetsByGitRepoId.mockResolvedValue([target]);
       });
@@ -326,13 +343,9 @@ describe('TargetResolutionService', () => {
         // findTargetFromGitInfo finds no matching repo -> returns null,
         // so findOrCreateTargetFromGitInfo delegates to findOrCreateGitRepo.
         gitPort.listProviders.mockResolvedValue({ providers: [] });
-        gitPort.findOrCreateGitRepo.mockResolvedValue({
-          id: newRepoId as unknown as string,
-          owner: 'test-owner',
-          repo: 'test-repo',
-          branch: 'main',
-          providerId: createGitProviderId(uuidv4()),
-        });
+        gitPort.findOrCreateGitRepo.mockResolvedValue(
+          gitRepoFactory({ id: newRepoId }),
+        );
         targetService.getTargetsByGitRepoId.mockResolvedValue([]);
         targetService.addTarget.mockResolvedValue(newTarget);
       });
@@ -419,7 +432,7 @@ describe('TargetResolutionService', () => {
   describe('findPreviouslyDeployedVersions', () => {
     const packageIds = [createPackageId(uuidv4())];
 
-    const standardVersion: StandardVersion = {
+    const standardVersion: StandardVersion = standardVersionFactory({
       id: createStandardVersionId(uuidv4()),
       standardId: createStandardId(uuidv4()),
       name: 'Test Standard',
@@ -427,18 +440,18 @@ describe('TargetResolutionService', () => {
       version: 1,
       rules: [],
       userId: createUserId(uuidv4()),
-    };
+    });
 
-    const recipeVersion: CommandVersion = {
+    const recipeVersion: CommandVersion = commandVersionFactory({
       id: createCommandVersionId(uuidv4()),
       recipeId: createCommandId(uuidv4()),
       name: 'Test Recipe',
       slug: 'test-recipe',
       version: 1,
       userId: createUserId(uuidv4()),
-    };
+    });
 
-    const skillVersion: SkillVersion = {
+    const skillVersion: SkillVersion = skillVersionFactory({
       id: createSkillVersionId(uuidv4()),
       skillId: createSkillId(uuidv4()),
       name: 'Test Skill',
@@ -447,20 +460,20 @@ describe('TargetResolutionService', () => {
       prompt: 'Test prompt',
       version: 1,
       userId: createUserId(uuidv4()),
-    };
+    });
 
     describe('when target exists', () => {
       beforeEach(() => {
         gitPort.listProviders.mockResolvedValue({
-          providers: [{ id: providerId, name: 'github', type: 'github' }],
+          providers: [githubProvider],
         });
         gitPort.listRepos.mockResolvedValue([
-          {
+          gitRepoFactory({
             id: gitRepoId,
             owner: 'test-owner',
             repo: 'test-repo',
             branch: 'main',
-          },
+          }),
         ]);
         targetService.getTargetsByGitRepoId.mockResolvedValue([target]);
         distributionRepository.findActiveStandardVersionsByTargetAndPackages.mockResolvedValue(

--- a/packages/deployments/src/application/useCases/AddTargetUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/AddTargetUseCase.spec.ts
@@ -3,7 +3,8 @@ import {
   AddTargetCommand,
   IGitPort,
   GitProviderMissingTokenError,
-  GitProviderWithoutToken,
+  GitProviderListItem,
+  GitProviderVendors,
   Target,
   createTargetId,
   createGitRepoId,
@@ -11,6 +12,7 @@ import {
   createUserId,
   createOrganizationId,
 } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/git/test';
 import { TargetService } from '../services/TargetService';
 
 describe('AddTargetUseCase', () => {
@@ -23,30 +25,34 @@ describe('AddTargetUseCase', () => {
   const gitRepoId = createGitRepoId('repo-123');
   const providerId = createGitProviderId('provider-123');
 
-  const mockRepo = {
+  const mockRepo = gitRepoFactory({
     id: gitRepoId,
     owner: 'owner',
     repo: 'repo',
     branch: 'main',
     providerId,
-  };
+  });
 
-  const mockProviderWithToken: GitProviderWithoutToken = {
+  const mockProviderWithToken: GitProviderListItem = {
     id: providerId,
-    source: 'github',
+    source: GitProviderVendors.github,
     organizationId,
     url: 'https://github.com',
     authMethod: 'token',
+    displayName: 'github-provider',
     hasAuth: true,
+    lastDistributionAt: null,
   };
 
-  const mockProviderWithoutToken: GitProviderWithoutToken = {
+  const mockProviderWithoutToken: GitProviderListItem = {
     id: providerId,
-    source: 'github',
+    source: GitProviderVendors.github,
     organizationId,
     url: 'https://github.com',
     authMethod: 'token',
+    displayName: 'github-provider',
     hasAuth: false,
+    lastDistributionAt: null,
   };
 
   beforeEach(() => {

--- a/packages/deployments/src/application/useCases/CreateRenderModeConfigurationUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/CreateRenderModeConfigurationUseCase.spec.ts
@@ -13,6 +13,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { renderModeConfigurationFactory } from '../../../test';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { CreateRenderModeConfigurationUseCase } from './CreateRenderModeConfigurationUseCase';
+import { userFactory } from '@packmind/accounts/test';
 
 const createMembership = (
   userId: string,
@@ -27,13 +28,14 @@ const createMembership = (
 const createUser = (
   userId: string,
   membership: UserOrganizationMembership,
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [membership],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [membership],
+  });
 
 describe('CreateRenderModeConfigurationUseCase', () => {
   let service: jest.Mocked<RenderModeConfigurationService>;

--- a/packages/deployments/src/application/useCases/DeleteTargetUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/DeleteTargetUseCase.spec.ts
@@ -3,7 +3,8 @@ import {
   DeleteTargetCommand,
   IGitPort,
   GitProviderMissingTokenError,
-  GitProviderWithoutToken,
+  GitProviderListItem,
+  GitProviderVendors,
   Target,
   createTargetId,
   createGitRepoId,
@@ -11,6 +12,7 @@ import {
   createUserId,
   createOrganizationId,
 } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/git/test';
 import { TargetService } from '../services/TargetService';
 
 describe('DeleteTargetUseCase', () => {
@@ -31,30 +33,34 @@ describe('DeleteTargetUseCase', () => {
     gitRepoId,
   };
 
-  const mockRepo = {
+  const mockRepo = gitRepoFactory({
     id: gitRepoId,
     owner: 'owner',
     repo: 'repo',
     branch: 'main',
     providerId,
-  };
+  });
 
-  const mockProviderWithToken: GitProviderWithoutToken = {
+  const mockProviderWithToken: GitProviderListItem = {
     id: providerId,
-    source: 'github',
+    source: GitProviderVendors.github,
     organizationId,
     url: 'https://github.com',
     authMethod: 'token',
+    displayName: 'github-provider',
     hasAuth: true,
+    lastDistributionAt: null,
   };
 
-  const mockProviderWithoutToken: GitProviderWithoutToken = {
+  const mockProviderWithoutToken: GitProviderListItem = {
     id: providerId,
-    source: 'github',
+    source: GitProviderVendors.github,
     organizationId,
     url: 'https://github.com',
     authMethod: 'token',
+    displayName: 'github-provider',
     hasAuth: false,
+    lastDistributionAt: null,
   };
 
   beforeEach(() => {

--- a/packages/deployments/src/application/useCases/DeployDefaultSkillsUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/DeployDefaultSkillsUseCase.spec.ts
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { getDefaultSkillId } from '../utils/defaultSkillIdUtils';
 import { DeployDefaultSkillsUseCase } from './DeployDefaultSkillsUseCase';
+import { userFactory } from '@packmind/accounts/test';
 
 const createMockDeployer = (
   overrides?: Partial<ICodingAgentDeployer>,
@@ -46,19 +47,20 @@ const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('DeployDefaultSkillsUseCase', () => {
   let renderModeConfigurationService: jest.Mocked<RenderModeConfigurationService>;

--- a/packages/deployments/src/application/useCases/FindActiveStandardVersionsByTargetUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/FindActiveStandardVersionsByTargetUseCase.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@packmind/types';
 import { IDistributionRepository } from '../../domain/repositories/IDistributionRepository';
 import { FindActiveStandardVersionsByTargetUseCase } from './FindActiveStandardVersionsByTargetUseCase';
+import { standardVersionFactory } from '@packmind/standards/test';
 
 describe('FindActiveStandardVersionsByTargetUseCase', () => {
   let useCase: FindActiveStandardVersionsByTargetUseCase;
@@ -51,19 +52,19 @@ describe('FindActiveStandardVersionsByTargetUseCase', () => {
 
     const createStandardVersion = (
       overrides?: Partial<StandardVersion>,
-    ): StandardVersion => ({
-      id: createStandardVersionId('sv-1'),
-      standardId: createStandardId('std-1'),
-      name: 'Test Standard',
-      slug: 'test-standard',
-      description: 'Test description',
-      version: 1,
-      summary: null,
-      gitCommit: undefined,
-      userId: createUserId('author-1'),
-      scope: null,
-      ...overrides,
-    });
+    ): StandardVersion =>
+      standardVersionFactory({
+        id: createStandardVersionId('sv-1'),
+        standardId: createStandardId('std-1'),
+        name: 'Test Standard',
+        slug: 'test-standard',
+        description: 'Test description',
+        version: 1,
+        gitCommit: undefined,
+        userId: createUserId('author-1'),
+        scope: null,
+        ...overrides,
+      });
 
     describe('when active standard versions exist', () => {
       let result: StandardVersion[];

--- a/packages/deployments/src/application/useCases/GetContentByVersionsUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/GetContentByVersionsUseCase.spec.ts
@@ -1,6 +1,7 @@
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 import {
+  CodingAgent,
   ArtifactVersionEntry,
   CodingAgents,
   FileUpdates,
@@ -34,24 +35,26 @@ import { v4 as uuidv4 } from 'uuid';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { getDefaultSkillId } from '../utils/defaultSkillIdUtils';
 import { GetContentByVersionsUseCase } from './GetContentByVersionsUseCase';
+import { userFactory } from '@packmind/accounts/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('GetContentByVersionsUseCase', () => {
   let codingAgentPort: jest.Mocked<ICodingAgentPort>;
@@ -266,7 +269,7 @@ describe('GetContentByVersionsUseCase', () => {
 
       codingAgentPort.deployArtifactsForAgents.mockResolvedValue(fileUpdates);
 
-      const skillFolderMap = new Map<string, string | undefined>();
+      const skillFolderMap = new Map<CodingAgent, string | undefined>();
       skillFolderMap.set('packmind', '.packmind/skills/');
       skillFolderMap.set('claude', '.claude/skills/');
       codingAgentPort.getSkillsFolderPathForAgents.mockReturnValue(

--- a/packages/deployments/src/application/useCases/GetDeployedContentUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/GetDeployedContentUseCase.spec.ts
@@ -1,5 +1,6 @@
 import { stubLogger } from '@packmind/test-utils';
 import {
+  CodingAgent,
   CodingAgents,
   FileUpdates,
   GetDeployedContentCommand,
@@ -37,24 +38,30 @@ import { RenderModeConfigurationService } from '../services/RenderModeConfigurat
 import { TargetResolutionService } from '../services/TargetResolutionService';
 import { IDistributionRepository } from '../../domain/repositories/IDistributionRepository';
 import { GetDeployedContentUseCase } from './GetDeployedContentUseCase';
+import { userFactory } from '@packmind/accounts/test';
+import { targetFactory } from '../../../test';
+import { commandFactory } from '@packmind/commands/test';
+import { standardFactory } from '@packmind/standards/test';
+import { skillFactory } from '@packmind/skills/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('GetDeployedContentUseCase', () => {
   let targetResolutionService: jest.Mocked<TargetResolutionService>;
@@ -161,11 +168,11 @@ describe('GetDeployedContentUseCase', () => {
     const standardId = createStandardId(uuidv4());
     const skillId = createSkillId(uuidv4());
 
-    const target: Target = {
+    const target: Target = targetFactory({
       id: targetId,
       name: 'Root',
       path: '/',
-    };
+    });
 
     const recipeVersion: CommandVersion = {
       id: createCommandVersionId(uuidv4()),
@@ -199,7 +206,7 @@ describe('GetDeployedContentUseCase', () => {
       userId: createUserId(uuidv4()),
     };
 
-    const recipe: Command = {
+    const recipe: Command = commandFactory({
       id: recipeId,
       name: 'test-recipe',
       slug: 'test-recipe',
@@ -207,9 +214,9 @@ describe('GetDeployedContentUseCase', () => {
       version: 1,
       userId: createUserId(uuidv4()),
       spaceId,
-    };
+    });
 
-    const standard: Standard = {
+    const standard: Standard = standardFactory({
       id: standardId,
       name: 'test-standard',
       slug: 'test-standard',
@@ -218,9 +225,9 @@ describe('GetDeployedContentUseCase', () => {
       userId: createUserId(uuidv4()),
       spaceId,
       scope: null,
-    };
+    });
 
-    const skill: Skill = {
+    const skill: Skill = skillFactory({
       id: skillId,
       name: 'test-skill',
       slug: 'test-skill',
@@ -229,7 +236,7 @@ describe('GetDeployedContentUseCase', () => {
       version: 1,
       userId: createUserId(uuidv4()),
       spaceId,
-    };
+    });
 
     const packageWithArtefacts: PackageWithArtefacts = {
       id: createPackageId(uuidv4()),
@@ -280,7 +287,7 @@ describe('GetDeployedContentUseCase', () => {
 
       codingAgentPort.deployArtifactsForAgents.mockResolvedValue(fileUpdates);
 
-      const skillFolderMap = new Map<string, string | undefined>();
+      const skillFolderMap = new Map<CodingAgent, string | undefined>();
       skillFolderMap.set('packmind', '.packmind/skills/');
       skillFolderMap.set('claude', '.claude/skills/');
       codingAgentPort.getSkillsFolderPathForAgents.mockReturnValue(
@@ -416,11 +423,11 @@ describe('GetDeployedContentUseCase', () => {
   });
 
   describe('when target exists but has no deployed versions', () => {
-    const target: Target = {
+    const target: Target = targetFactory({
       id: createTargetId(uuidv4()),
       name: 'Root',
       path: '/',
-    };
+    });
 
     beforeEach(() => {
       targetResolutionService.findTargetFromGitInfo.mockResolvedValue(target);

--- a/packages/deployments/src/application/useCases/GetRenderModeConfigurationUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/GetRenderModeConfigurationUseCase.spec.ts
@@ -15,24 +15,26 @@ import { v4 as uuidv4 } from 'uuid';
 import { renderModeConfigurationFactory } from '../../../test';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { GetRenderModeConfigurationUseCase } from './GetRenderModeConfigurationUseCase';
+import { userFactory } from '@packmind/accounts/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('GetRenderModeConfigurationUseCase', () => {
   let service: jest.Mocked<RenderModeConfigurationService>;

--- a/packages/deployments/src/application/useCases/GetTargetsByOrganizationUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/GetTargetsByOrganizationUseCase.spec.ts
@@ -1,6 +1,7 @@
 import { GetTargetsByOrganizationUseCase } from './GetTargetsByOrganizationUseCase';
 import { TargetService } from '../services/TargetService';
 import {
+  GitRepo,
   Target,
   TargetWithRepository,
   GetTargetsByOrganizationCommand,
@@ -11,6 +12,7 @@ import {
 } from '@packmind/types';
 import { stubLogger } from '@packmind/test-utils';
 import { createOrganizationId, createUserId } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/git/test';
 
 describe('GetTargetsByOrganizationUseCase', () => {
   let useCase: GetTargetsByOrganizationUseCase;
@@ -42,32 +44,26 @@ describe('GetTargetsByOrganizationUseCase', () => {
 
     describe('when organization has multiple repositories with targets', () => {
       let result: TargetWithRepository[];
-      let mockRepositories: {
-        id: ReturnType<typeof createGitRepoId>;
-        owner: string;
-        repo: string;
-        branch: string;
-        providerId: ReturnType<typeof createGitProviderId>;
-      }[];
+      let mockRepositories: GitRepo[];
       let mockTargetsRepo1: Target[];
       let mockTargetsRepo2: Target[];
 
       beforeEach(async () => {
         mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-1'),
             owner: 'owner1',
             repo: 'repo1',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
-          {
+          }),
+          gitRepoFactory({
             id: createGitRepoId('repo-2'),
             owner: 'owner2',
             repo: 'repo2',
             branch: 'main',
             providerId: createGitProviderId('provider-2'),
-          },
+          }),
         ];
 
         mockTargetsRepo1 = [
@@ -186,23 +182,17 @@ describe('GetTargetsByOrganizationUseCase', () => {
 
     describe('when repositories have no targets', () => {
       let result: TargetWithRepository[];
-      let mockRepositories: {
-        id: ReturnType<typeof createGitRepoId>;
-        owner: string;
-        repo: string;
-        branch: string;
-        providerId: ReturnType<typeof createGitProviderId>;
-      }[];
+      let mockRepositories: GitRepo[];
 
       beforeEach(async () => {
         mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-1'),
             owner: 'owner1',
             repo: 'repo1',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
+          }),
         ];
 
         mockGitPort.getOrganizationRepositories.mockResolvedValue(
@@ -252,23 +242,17 @@ describe('GetTargetsByOrganizationUseCase', () => {
     });
 
     describe('when target service errors occur', () => {
-      let mockRepositories: {
-        id: ReturnType<typeof createGitRepoId>;
-        owner: string;
-        repo: string;
-        branch: string;
-        providerId: ReturnType<typeof createGitProviderId>;
-      }[];
+      let mockRepositories: GitRepo[];
 
       beforeEach(() => {
         mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-1'),
             owner: 'owner1',
             repo: 'repo1',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
+          }),
         ];
 
         const error = new Error('Database connection failed');

--- a/packages/deployments/src/application/useCases/GetTargetsByRepositoryUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/GetTargetsByRepositoryUseCase.spec.ts
@@ -11,6 +11,7 @@ import {
 } from '@packmind/types';
 import { stubLogger } from '@packmind/test-utils';
 import { createOrganizationId, createUserId } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/git/test';
 
 describe('GetTargetsByRepositoryUseCase', () => {
   let useCase: GetTargetsByRepositoryUseCase;
@@ -49,27 +50,27 @@ describe('GetTargetsByRepositoryUseCase', () => {
 
       beforeEach(async () => {
         const mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-main'),
             owner: 'testowner',
             repo: 'testrepo',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
-          {
+          }),
+          gitRepoFactory({
             id: createGitRepoId('repo-develop'),
             owner: 'testowner',
             repo: 'testrepo',
             branch: 'develop',
             providerId: createGitProviderId('provider-1'),
-          },
-          {
+          }),
+          gitRepoFactory({
             id: createGitRepoId('repo-other'),
             owner: 'otherowner',
             repo: 'otherrepo',
             branch: 'main',
             providerId: createGitProviderId('provider-2'),
-          },
+          }),
         ];
 
         mockTargetsMain = [
@@ -153,13 +154,13 @@ describe('GetTargetsByRepositoryUseCase', () => {
 
       beforeEach(async () => {
         const mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-other'),
             owner: 'otherowner',
             repo: 'otherrepo',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
+          }),
         ];
 
         mockGitPort.getOrganizationRepositories.mockResolvedValue(
@@ -189,13 +190,13 @@ describe('GetTargetsByRepositoryUseCase', () => {
 
       beforeEach(async () => {
         const mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-main'),
             owner: 'testowner',
             repo: 'testrepo',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
+          }),
         ];
 
         mockGitPort.getOrganizationRepositories.mockResolvedValue(
@@ -239,13 +240,13 @@ describe('GetTargetsByRepositoryUseCase', () => {
 
       beforeEach(() => {
         const mockRepositories = [
-          {
+          gitRepoFactory({
             id: createGitRepoId('repo-main'),
             owner: 'testowner',
             repo: 'testrepo',
             branch: 'main',
             providerId: createGitProviderId('provider-1'),
-          },
+          }),
         ];
 
         const error = new Error('Target retrieval failed');

--- a/packages/deployments/src/application/useCases/InstallPackagesUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/InstallPackagesUseCase.spec.ts
@@ -12,6 +12,7 @@ import {
   OrganizationId,
   PackageWithArtefacts,
   PackmindLockFile,
+  PackmindLockFileEntry,
   Command,
   CommandVersion,
   Skill,
@@ -43,24 +44,27 @@ import { PackmindLockFileService } from '../services/PackmindLockFileService';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { InstallPackagesUseCase } from './InstallPackagesUseCase';
 import { PackagesNotFoundError } from '../../domain/errors/PackagesNotFoundError';
+import { userFactory } from '@packmind/accounts/test';
+import { spaceFactory } from '@packmind/spaces/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 const createSpaceMembership = (
   userId: string,
@@ -105,23 +109,23 @@ describe('InstallPackagesUseCase', () => {
       slug: 'test-org',
     };
 
-    publicSpace = {
+    publicSpace = spaceFactory({
       id: createSpaceId('public-space-id'),
       name: 'Public Space',
       slug: 'public',
       type: SpaceType.open,
       organizationId,
       isDefaultSpace: false,
-    };
+    });
 
-    privateSpace = {
+    privateSpace = spaceFactory({
       id: createSpaceId('private-space-id'),
       name: 'Private Space',
       slug: 'private',
       type: SpaceType.restricted,
       organizationId,
       isDefaultSpace: false,
-    };
+    });
 
     publicPackage = {
       id: createPackageId(uuidv4()),
@@ -419,6 +423,7 @@ describe('InstallPackagesUseCase', () => {
       spaceId: 'private-space-id',
       packageIds: ['private-pkg-id'],
       files: [],
+      source: 'user' as const,
     };
 
     const publicArtifactEntry = {
@@ -429,6 +434,7 @@ describe('InstallPackagesUseCase', () => {
       spaceId: 'public-space-id',
       packageIds: ['public-pkg-id'],
       files: [],
+      source: 'user' as const,
     };
 
     beforeEach(() => {
@@ -546,6 +552,7 @@ describe('InstallPackagesUseCase', () => {
               spaceId: 'private-space-id',
               packageIds: ['private-pkg-id'],
               files: [],
+              source: 'user',
             },
           },
         },
@@ -586,9 +593,9 @@ describe('InstallPackagesUseCase', () => {
   });
 
   describe('when a package is removed', () => {
-    const removedArtifactEntry = {
+    const removedArtifactEntry: PackmindLockFileEntry = {
       name: 'Removed Standard',
-      type: 'standard' as const,
+      type: 'standard',
       id: 'removed-standard-id',
       version: 1,
       spaceId: 'public-space-id',
@@ -596,9 +603,10 @@ describe('InstallPackagesUseCase', () => {
       files: [
         {
           path: '.cursor/rules/removed-standard.mdc',
-          agent: CodingAgents.cursor,
+          agent: 'cursor',
         },
       ],
+      source: 'user',
     };
 
     beforeEach(() => {
@@ -633,9 +641,9 @@ describe('InstallPackagesUseCase', () => {
     });
 
     describe('when user has no access to the removed package space', () => {
-      const inaccessibleRemovedArtifact = {
+      const inaccessibleRemovedArtifact: PackmindLockFileEntry = {
         name: 'Inaccessible Removed Standard',
-        type: 'standard' as const,
+        type: 'standard',
         id: 'inaccessible-removed-standard-id',
         version: 1,
         spaceId: 'private-space-id',
@@ -643,9 +651,10 @@ describe('InstallPackagesUseCase', () => {
         files: [
           {
             path: '.cursor/rules/inaccessible-removed-standard.mdc',
-            agent: CodingAgents.cursor,
+            agent: 'cursor',
           },
         ],
+        source: 'user',
       };
 
       beforeEach(() => {

--- a/packages/deployments/src/application/useCases/ListDeploymentsByPackageUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/ListDeploymentsByPackageUseCase.spec.ts
@@ -2,16 +2,17 @@ import { stubLogger } from '@packmind/test-utils';
 import {
   createDistributionId,
   createPackageId,
+  createGitRepoId,
   createTargetId,
   Distribution,
   DistributionStatus,
-  GitRepoId,
   ListDeploymentsByPackageCommand,
   OrganizationId,
   UserId,
 } from '@packmind/types';
 import { IDistributionRepository } from '../../domain/repositories/IDistributionRepository';
 import { ListDeploymentsByPackageUseCase } from './ListDeploymentsByPackageUseCase';
+import { distributionFactory, targetFactory } from '../../../test';
 
 describe('ListDeploymentsByPackageUseCase', () => {
   let useCase: ListDeploymentsByPackageUseCase;
@@ -42,21 +43,21 @@ describe('ListDeploymentsByPackageUseCase', () => {
         userId: 'user-789' as UserId,
       };
       const mockDistributions: Distribution[] = [
-        {
+        distributionFactory({
           id: createDistributionId('distribution-1'),
           organizationId: command.organizationId as OrganizationId,
           distributedPackages: [],
-          target: {
+          target: targetFactory({
             id: createTargetId('target-123'),
             name: 'Test Target',
             path: '/test',
-            gitRepoId: 'repo-123' as GitRepoId,
-          },
+            gitRepoId: createGitRepoId('repo-123'),
+          }),
           status: DistributionStatus.success,
           authorId: 'author-123' as UserId,
           createdAt: new Date().toISOString(),
           renderModes: [],
-        },
+        }),
       ];
       let result: Distribution[];
 

--- a/packages/deployments/src/application/useCases/PublishArtifactsUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/PublishArtifactsUseCase.spec.ts
@@ -20,8 +20,6 @@ import {
   createCommandId,
   createStandardId,
   createTargetId,
-  createGitRepoId,
-  createGitProviderId,
   createGitCommitId,
   createRuleId,
   GitRepo,
@@ -35,13 +33,16 @@ import {
   Rule,
   SkillFile,
   CodingAgents,
+  DeleteItemType,
   PackmindLockFile,
 } from '@packmind/types';
 import { PackmindLogger } from '@packmind/logger';
 import { PackmindEventEmitterService } from '@packmind/node-utils';
 import { commandVersionFactory } from '@packmind/commands/test/commandVersionFactory';
 import { standardVersionFactory } from '@packmind/standards/test/standardVersionFactory';
+import { skillFileFactory } from '@packmind/skills/test/skillFileFactory';
 import { skillVersionFactory } from '@packmind/skills/test/skillVersionFactory';
+import { gitRepoFactory } from '@packmind/git/test';
 import { targetFactory } from '../../../test/targetFactory';
 import { v4 as uuidv4 } from 'uuid';
 import { stubLogger } from '@packmind/test-utils';
@@ -210,13 +211,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -479,13 +474,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createCommandVersionId(uuidv4()),
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -564,13 +553,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createStandardVersionId(uuidv4()),
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -655,13 +638,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createStandardVersionId(uuidv4()),
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -755,13 +732,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createStandardVersionId(uuidv4()),
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -837,13 +808,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createStandardVersionId(uuidv4()),
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target1 = targetFactory({
         id: targetId1,
@@ -1000,13 +965,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -1135,13 +1094,7 @@ describe('PublishArtifactsUseCase', () => {
   describe('when recipe version does not exist', () => {
     it('throws error', async () => {
       const target = targetFactory({ id: targetId });
-      const gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      const gitRepo = gitRepoFactory();
 
       const command: PublishArtifactsCommand = {
         userId,
@@ -1167,13 +1120,7 @@ describe('PublishArtifactsUseCase', () => {
   describe('when standard version does not exist', () => {
     it('throws error', async () => {
       const target = targetFactory({ id: targetId });
-      const gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      const gitRepo = gitRepoFactory();
 
       const command: PublishArtifactsCommand = {
         userId,
@@ -1246,13 +1193,7 @@ describe('PublishArtifactsUseCase', () => {
         id: createCommandVersionId(uuidv4()),
       });
       const target = targetFactory({ id: targetId });
-      const gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      const gitRepo = gitRepoFactory();
 
       const command: PublishArtifactsCommand = {
         userId,
@@ -1358,13 +1299,7 @@ describe('PublishArtifactsUseCase', () => {
         rules: [],
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -1526,13 +1461,7 @@ describe('PublishArtifactsUseCase', () => {
         rules: [],
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -1627,13 +1556,7 @@ describe('PublishArtifactsUseCase', () => {
         rules: undefined, // Rules not populated from database
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -1732,12 +1655,12 @@ describe('PublishArtifactsUseCase', () => {
     const newSkillVersionId = createSkillVersionId(uuidv4());
     const previousSkillVersionId = createSkillVersionId(uuidv4());
     const mockFiles: SkillFile[] = [
-      {
+      skillFileFactory({
         id: createSkillFileId(uuidv4()),
         skillVersionId: previousSkillVersionId,
         path: 'references/guide.md',
         content: 'Reference guide content',
-      },
+      }),
     ];
 
     beforeEach(() => {
@@ -1760,13 +1683,7 @@ describe('PublishArtifactsUseCase', () => {
         files: undefined,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -1875,13 +1792,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2007,13 +1918,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2153,13 +2058,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2239,13 +2138,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2365,13 +2258,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2475,13 +2362,7 @@ describe('PublishArtifactsUseCase', () => {
         },
       ];
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2581,13 +2462,7 @@ describe('PublishArtifactsUseCase', () => {
   describe('when skill version does not exist', () => {
     it('throws error', async () => {
       const target = targetFactory({ id: targetId });
-      const gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      const gitRepo = gitRepoFactory();
 
       const command: PublishArtifactsCommand = {
         userId,
@@ -2639,13 +2514,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -2753,13 +2622,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2788,6 +2651,8 @@ describe('PublishArtifactsUseCase', () => {
           ],
           delete: [],
         },
+        skippedSkillsCount: 0,
+        lockFileSlice: {},
       });
 
       mockCommandsPort.getCommandVersionById.mockResolvedValue(recipeVersion);
@@ -2885,13 +2750,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -2920,6 +2779,8 @@ describe('PublishArtifactsUseCase', () => {
           ],
           delete: [],
         },
+        skippedSkillsCount: 0,
+        lockFileSlice: {},
       });
 
       mockCommandsPort.getCommandVersionById.mockResolvedValue(recipeVersion);
@@ -3054,13 +2915,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -3089,6 +2944,8 @@ describe('PublishArtifactsUseCase', () => {
           ],
           delete: [],
         },
+        skippedSkillsCount: 0,
+        lockFileSlice: {},
       });
 
       mockCommandsPort.getCommandVersionById.mockResolvedValue(recipeVersion);
@@ -3212,13 +3069,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -3312,13 +3163,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -3412,13 +3257,7 @@ describe('PublishArtifactsUseCase', () => {
         rules: [],
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({ id: targetId, gitRepoId: gitRepo.id });
 
@@ -3506,13 +3345,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -3592,13 +3425,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -3787,13 +3614,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -3857,8 +3678,9 @@ describe('PublishArtifactsUseCase', () => {
     describe('when per-target agents override org-level agents', () => {
       beforeEach(() => {
         mockGitPort.getFileFromRepo.mockResolvedValue({
+          sha: 'packmind-json-sha',
           content: JSON.stringify({ agents: [CodingAgents.claude] }),
-        } as GitCommit);
+        });
       });
 
       it('generates cleanup only for removed agents', async () => {
@@ -3882,7 +3704,7 @@ describe('PublishArtifactsUseCase', () => {
             delete: [
               {
                 path: '.cursor/rules/packmind/recipes-index.mdc',
-                type: 'file',
+                type: DeleteItemType.File,
               },
             ],
           },
@@ -3915,13 +3737,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -4094,13 +3910,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 2,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,
@@ -4301,13 +4111,7 @@ describe('PublishArtifactsUseCase', () => {
         version: 1,
       });
 
-      gitRepo = {
-        id: createGitRepoId(uuidv4()),
-        owner: 'test-owner',
-        repo: 'test-repo',
-        branch: 'main',
-        providerId: createGitProviderId(uuidv4()),
-      };
+      gitRepo = gitRepoFactory();
 
       target = targetFactory({
         id: targetId,

--- a/packages/deployments/src/application/useCases/PublishPackagesUseCase.integration.spec.ts
+++ b/packages/deployments/src/application/useCases/PublishPackagesUseCase.integration.spec.ts
@@ -23,6 +23,7 @@ import {
 import { PackmindLogger } from '@packmind/logger';
 import { spaceFactory } from '@packmind/spaces/test';
 import { packageFactory } from '../../../test/packageFactory';
+import { distributionFactory } from '../../../test/distributionFactory';
 import { targetFactory } from '../../../test/targetFactory';
 import { v4 as uuidv4 } from 'uuid';
 import { stubLogger } from '@packmind/test-utils';
@@ -117,7 +118,7 @@ describe('PublishPackagesUseCase - Integration behavior', () => {
         standards: [standardId],
       });
 
-      const distribution: Distribution = {
+      const distribution: Distribution = distributionFactory({
         id: createDistributionId(uuidv4()),
         distributedPackages: [],
         createdAt: new Date().toISOString(),
@@ -126,7 +127,7 @@ describe('PublishPackagesUseCase - Integration behavior', () => {
         target,
         status: DistributionStatus.no_changes,
         renderModes: [],
-      };
+      });
 
       mockPackageService.findById.mockResolvedValue(pkg);
       mockCommandsPort.listCommandVersions.mockResolvedValue([

--- a/packages/deployments/src/application/useCases/PublishPackagesUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/PublishPackagesUseCase.spec.ts
@@ -1,6 +1,7 @@
 import { PublishPackagesUseCase } from './PublishPackagesUseCase';
 import { PackageService } from '../services/PackageService';
 import {
+  PackagesDeployment,
   createUserId,
   createOrganizationId,
   createPackageId,
@@ -28,6 +29,7 @@ import { standardVersionFactory } from '@packmind/standards/test/standardVersion
 import { spaceFactory } from '@packmind/spaces/test';
 import { packageFactory } from '../../../test/packageFactory';
 import { targetFactory } from '../../../test/targetFactory';
+import { distributionFactory } from '../../../test/distributionFactory';
 import { v4 as uuidv4 } from 'uuid';
 import { stubLogger } from '@packmind/test-utils';
 import { IDistributedPackageRepository } from '../../domain/repositories/IDistributedPackageRepository';
@@ -53,20 +55,18 @@ describe('PublishPackagesUseCase', () => {
 
   const createMockDistribution = (
     overrides: Partial<Distribution> = {},
-  ): Distribution => {
-    const target = targetFactory({ id: targetId });
-    return {
+  ): Distribution =>
+    distributionFactory({
       id: createDistributionId(uuidv4()),
       distributedPackages: [],
       createdAt: new Date().toISOString(),
       authorId: userId,
       organizationId,
-      target,
+      target: targetFactory({ id: targetId }),
       status: DistributionStatus.success,
       renderModes: [],
       ...overrides,
-    };
-  };
+    });
 
   beforeEach(() => {
     mockLogger = stubLogger();
@@ -175,7 +175,7 @@ describe('PublishPackagesUseCase', () => {
     });
 
     describe('when publishing artifacts', () => {
-      let result: Distribution[];
+      let result: PackagesDeployment[];
 
       beforeEach(async () => {
         const mockDistributions = [createMockDistribution()];
@@ -506,7 +506,7 @@ describe('PublishPackagesUseCase', () => {
     let uniqueCommandVersion: CommandVersion;
     let sharedStandardVersion: StandardVersion;
     let uniqueStandardVersion: StandardVersion;
-    let result: Distribution[];
+    let result: PackagesDeployment[];
 
     beforeEach(async () => {
       sharedCommandId = createCommandId(uuidv4());

--- a/packages/deployments/src/application/useCases/PullContentUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/PullContentUseCase.spec.ts
@@ -35,8 +35,15 @@ import {
   createTargetId,
   createUserId,
   CodingAgents,
+  DeleteItemType,
 } from '@packmind/types';
 import { v4 as uuidv4 } from 'uuid';
+import { userFactory } from '@packmind/accounts/test';
+import { spaceFactory } from '@packmind/spaces/test';
+import { commandFactory } from '@packmind/commands/test';
+import { standardFactory } from '@packmind/standards/test';
+import { skillFactory } from '@packmind/skills/test';
+import { targetFactory } from '../../../test';
 import { PackageService } from '../services/PackageService';
 import { PackmindConfigService } from '../services/PackmindConfigService';
 import { PackmindLockFileService } from '../services/PackmindLockFileService';
@@ -49,19 +56,20 @@ const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('PullContentUseCase', () => {
   let packageService: jest.Mocked<PackageService>;
@@ -212,14 +220,14 @@ describe('PullContentUseCase', () => {
       slug: 'packmind',
     };
 
-    defaultSpace = {
+    defaultSpace = spaceFactory({
       id: createSpaceId('default-space'),
       name: 'Default Space',
       slug: 'default',
       type: SpaceType.open,
       organizationId,
       isDefaultSpace: true,
-    };
+    });
 
     spacesPort = {
       listSpacesByOrganization: jest.fn().mockResolvedValue([defaultSpace]),
@@ -499,7 +507,7 @@ describe('PullContentUseCase', () => {
       let skillVersion: SkillVersion;
 
       beforeEach(() => {
-        skill = {
+        skill = skillFactory({
           id: createSkillId('skill-1'),
           name: 'Test Skill',
           slug: 'test-skill',
@@ -508,7 +516,7 @@ describe('PullContentUseCase', () => {
           version: 1,
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
-        };
+        });
 
         skillVersion = {
           id: createSkillVersionId('skill-version-1'),
@@ -884,7 +892,7 @@ describe('PullContentUseCase', () => {
         let recipeVersion: CommandVersion;
 
         beforeEach(() => {
-          recipe = {
+          recipe = commandFactory({
             id: createCommandId('recipe-1'),
             name: 'Test Recipe',
             slug: 'test-recipe',
@@ -892,7 +900,7 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
           recipeVersion = {
             id: createCommandVersionId('rv-1'),
@@ -940,13 +948,7 @@ describe('PullContentUseCase', () => {
           };
 
           targetResolutionService.findOrCreateTargetFromGitInfo.mockResolvedValue(
-            {
-              id: targetId,
-              organizationId: organization.id,
-              gitRemoteUrl: 'https://github.com/owner/repo.git',
-              gitBranch: 'main',
-              relativePath: '/',
-            },
+            targetFactory({ id: targetId }),
           );
         });
 
@@ -989,7 +991,7 @@ describe('PullContentUseCase', () => {
       let skillVersion: SkillVersion;
 
       beforeEach(() => {
-        skill = {
+        skill = skillFactory({
           id: createSkillId('skill-1'),
           name: 'Test Skill',
           slug: 'test-skill',
@@ -998,7 +1000,7 @@ describe('PullContentUseCase', () => {
           version: 1,
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
-        };
+        });
 
         skillVersion = {
           id: createSkillVersionId('skill-version-1'),
@@ -1107,7 +1109,7 @@ describe('PullContentUseCase', () => {
         let skillVersionB: SkillVersion;
 
         beforeEach(() => {
-          skillA = {
+          skillA = skillFactory({
             id: createSkillId('skill-a'),
             name: 'Skill A',
             slug: 'skill-a',
@@ -1116,9 +1118,9 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
-          skillB = {
+          skillB = skillFactory({
             id: createSkillId('skill-b'),
             name: 'Skill B',
             slug: 'skill-b',
@@ -1127,7 +1129,7 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
           skillVersionA = {
             id: createSkillVersionId('skill-version-a'),
@@ -1192,7 +1194,7 @@ describe('PullContentUseCase', () => {
         let previousPackage: PackageWithArtefacts;
 
         beforeEach(() => {
-          installedSkill = {
+          installedSkill = skillFactory({
             id: createSkillId('installed-skill'),
             name: 'Installed Skill',
             slug: 'installed-skill',
@@ -1201,9 +1203,9 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
-          removedSkill = {
+          removedSkill = skillFactory({
             id: createSkillId('removed-skill'),
             name: 'Removed Skill',
             slug: 'removed-skill',
@@ -1212,7 +1214,7 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
           installedSkillVersion = {
             id: createSkillVersionId('installed-skill-version'),
@@ -1286,7 +1288,12 @@ describe('PullContentUseCase', () => {
 
           codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
             createOrUpdate: [],
-            delete: [{ path: '.claude/skills/removed-skill/SKILL.md' }],
+            delete: [
+              {
+                path: '.claude/skills/removed-skill/SKILL.md',
+                type: DeleteItemType.File,
+              },
+            ],
           });
         });
 
@@ -1313,7 +1320,7 @@ describe('PullContentUseCase', () => {
         let previouslyDeployedSkillVersion: SkillVersion;
 
         beforeEach(() => {
-          currentSkill = {
+          currentSkill = skillFactory({
             id: createSkillId('current-skill'),
             name: 'Current Skill',
             slug: 'current-skill',
@@ -1322,9 +1329,9 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
-          previouslyDeployedSkill = {
+          previouslyDeployedSkill = skillFactory({
             id: createSkillId('previously-deployed-skill'),
             name: 'Previously Deployed Skill',
             slug: 'previously-deployed-skill',
@@ -1333,7 +1340,7 @@ describe('PullContentUseCase', () => {
             version: 1,
             userId: createUserId('user-1'),
             spaceId: createSpaceId('space-1'),
-          };
+          });
 
           currentSkillVersion = {
             id: createSkillVersionId('current-skill-version'),
@@ -1409,7 +1416,10 @@ describe('PullContentUseCase', () => {
             codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
               createOrUpdate: [],
               delete: [
-                { path: '.claude/skills/previously-deployed-skill/SKILL.md' },
+                {
+                  path: '.claude/skills/previously-deployed-skill/SKILL.md',
+                  type: DeleteItemType.File,
+                },
               ],
             });
           });
@@ -1497,7 +1507,7 @@ describe('PullContentUseCase', () => {
       let previouslyDeployedStandardVersion: StandardVersion;
 
       beforeEach(() => {
-        currentStandard = {
+        currentStandard = standardFactory({
           id: createStandardId('current-standard'),
           name: 'Current Standard',
           slug: 'current-standard',
@@ -1506,9 +1516,9 @@ describe('PullContentUseCase', () => {
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
           scope: null,
-        };
+        });
 
-        previouslyDeployedStandard = {
+        previouslyDeployedStandard = standardFactory({
           id: createStandardId('previously-deployed-standard'),
           name: 'Previously Deployed Standard',
           slug: 'previously-deployed-standard',
@@ -1517,7 +1527,7 @@ describe('PullContentUseCase', () => {
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
           scope: null,
-        };
+        });
 
         currentStandardVersion = {
           id: createStandardVersionId('current-standard-version'),
@@ -1588,7 +1598,10 @@ describe('PullContentUseCase', () => {
           codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
             createOrUpdate: [],
             delete: [
-              { path: '.packmind/standards/previously-deployed-standard.md' },
+              {
+                path: '.packmind/standards/previously-deployed-standard.md',
+                type: DeleteItemType.File,
+              },
             ],
           });
         });
@@ -1646,7 +1659,7 @@ describe('PullContentUseCase', () => {
       let previouslyDeployedCommandVersion: CommandVersion;
 
       beforeEach(() => {
-        currentCommand = {
+        currentCommand = commandFactory({
           id: createCommandId('current-recipe'),
           name: 'Current Recipe',
           slug: 'current-recipe',
@@ -1654,9 +1667,9 @@ describe('PullContentUseCase', () => {
           version: 1,
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
-        };
+        });
 
-        previouslyDeployedCommand = {
+        previouslyDeployedCommand = commandFactory({
           id: createCommandId('previously-deployed-recipe'),
           name: 'Previously Deployed Recipe',
           slug: 'previously-deployed-recipe',
@@ -1664,7 +1677,7 @@ describe('PullContentUseCase', () => {
           version: 1,
           userId: createUserId('user-1'),
           spaceId: createSpaceId('space-1'),
-        };
+        });
 
         currentCommandVersion = {
           id: createCommandVersionId('current-recipe-version'),
@@ -1735,7 +1748,10 @@ describe('PullContentUseCase', () => {
           codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
             createOrUpdate: [],
             delete: [
-              { path: '.packmind/commands/previously-deployed-recipe.md' },
+              {
+                path: '.packmind/commands/previously-deployed-recipe.md',
+                type: DeleteItemType.File,
+              },
             ],
           });
         });
@@ -1804,6 +1820,7 @@ describe('PullContentUseCase', () => {
     let mockDeployer: {
       generateFileUpdatesForRecipes: jest.Mock;
       generateFileUpdatesForStandards: jest.Mock;
+      generateFileUpdatesForSkills: jest.Mock;
       deployArtifacts: jest.Mock;
       generateRemovalFileUpdates: jest.Mock;
     };
@@ -1813,7 +1830,7 @@ describe('PullContentUseCase', () => {
       const spaceId = createSpaceId('space-1');
       const userId = createUserId('user-1');
 
-      sharedCommand = {
+      sharedCommand = commandFactory({
         id: createCommandId('shared-recipe-id'),
         name: 'Shared Recipe',
         slug: 'shared-recipe',
@@ -1821,9 +1838,9 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
-      uniqueCommand = {
+      uniqueCommand = commandFactory({
         id: createCommandId('unique-recipe-id'),
         name: 'Unique Recipe',
         slug: 'unique-recipe',
@@ -1831,9 +1848,9 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
-      sharedStandard = {
+      sharedStandard = standardFactory({
         id: createStandardId('shared-standard-id'),
         name: 'Shared Standard',
         slug: 'shared-standard',
@@ -1842,9 +1859,9 @@ describe('PullContentUseCase', () => {
         userId,
         spaceId,
         scope: null,
-      };
+      });
 
-      uniqueStandard = {
+      uniqueStandard = standardFactory({
         id: createStandardId('unique-standard-id'),
         name: 'Unique Standard',
         slug: 'unique-standard',
@@ -1853,9 +1870,9 @@ describe('PullContentUseCase', () => {
         userId,
         spaceId,
         scope: null,
-      };
+      });
 
-      sharedSkill = {
+      sharedSkill = skillFactory({
         id: createSkillId('shared-skill-id'),
         name: 'Shared Skill',
         slug: 'shared-skill',
@@ -1864,9 +1881,9 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
-      uniqueSkill = {
+      uniqueSkill = skillFactory({
         id: createSkillId('unique-skill-id'),
         name: 'Unique Skill',
         slug: 'unique-skill',
@@ -1875,7 +1892,7 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
       sharedCommandVersion = {
         id: createCommandVersionId('rv-shared'),
@@ -2027,9 +2044,18 @@ describe('PullContentUseCase', () => {
         codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
           createOrUpdate: [],
           delete: [
-            { path: '.packmind/commands/unique-recipe.md' },
-            { path: '.packmind/standards/unique-standard.md' },
-            { path: '.packmind/skills/unique-skill.md' },
+            {
+              path: '.packmind/commands/unique-recipe.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/standards/unique-standard.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/skills/unique-skill.md',
+              type: DeleteItemType.File,
+            },
           ],
         });
       });
@@ -2165,9 +2191,18 @@ describe('PullContentUseCase', () => {
         codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
           createOrUpdate: [],
           delete: [
-            { path: '.packmind/commands/unique-recipe.md' },
-            { path: '.packmind/standards/unique-standard.md' },
-            { path: '.packmind/skills/unique-skill.md' },
+            {
+              path: '.packmind/commands/unique-recipe.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/standards/unique-standard.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/skills/unique-skill.md',
+              type: DeleteItemType.File,
+            },
           ],
         });
       });
@@ -2223,12 +2258,30 @@ describe('PullContentUseCase', () => {
         codingAgentPort.generateRemovalUpdatesForAgents.mockResolvedValue({
           createOrUpdate: [],
           delete: [
-            { path: '.packmind/commands/shared-recipe.md' },
-            { path: '.packmind/commands/unique-recipe.md' },
-            { path: '.packmind/standards/shared-standard.md' },
-            { path: '.packmind/standards/unique-standard.md' },
-            { path: '.packmind/skills/shared-skill.md' },
-            { path: '.packmind/skills/unique-skill.md' },
+            {
+              path: '.packmind/commands/shared-recipe.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/commands/unique-recipe.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/standards/shared-standard.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/standards/unique-standard.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/skills/shared-skill.md',
+              type: DeleteItemType.File,
+            },
+            {
+              path: '.packmind/skills/unique-skill.md',
+              type: DeleteItemType.File,
+            },
           ],
         });
       });
@@ -2486,7 +2539,7 @@ describe('PullContentUseCase', () => {
       const spaceId = createSpaceId('space-enrichment');
       const userId = createUserId('user-1');
 
-      recipe = {
+      recipe = commandFactory({
         id: createCommandId('recipe-enrich'),
         name: 'Enriched Recipe',
         slug: 'enriched-recipe',
@@ -2494,9 +2547,9 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
-      standard = {
+      standard = standardFactory({
         id: createStandardId('standard-enrich'),
         name: 'Enriched Standard',
         slug: 'enriched-standard',
@@ -2505,9 +2558,9 @@ describe('PullContentUseCase', () => {
         userId,
         spaceId,
         scope: null,
-      };
+      });
 
-      skill = {
+      skill = skillFactory({
         id: createSkillId('skill-enrich'),
         name: 'Enriched Skill',
         slug: 'enriched-skill',
@@ -2516,7 +2569,7 @@ describe('PullContentUseCase', () => {
         version: 1,
         userId,
         spaceId,
-      };
+      });
 
       recipeVersion = {
         id: createCommandVersionId('rv-enrich'),
@@ -2780,14 +2833,16 @@ describe('PullContentUseCase', () => {
           ...command,
           packagesSlugs: ['@my-space/test-package'],
         };
-        spacesPort.getSpaceBySlug.mockResolvedValue({
-          id: explicitSpaceId,
-          name: 'My Space',
-          slug: 'my-space',
-          type: SpaceType.open,
-          organizationId,
-          isDefaultSpace: false,
-        });
+        spacesPort.getSpaceBySlug.mockResolvedValue(
+          spaceFactory({
+            id: explicitSpaceId,
+            name: 'My Space',
+            slug: 'my-space',
+            type: SpaceType.open,
+            organizationId,
+            isDefaultSpace: false,
+          }),
+        );
         packageService.getPackagesBySlugsAndSpaceWithArtefacts.mockResolvedValue(
           [testPackage],
         );
@@ -2920,7 +2975,7 @@ describe('PullContentUseCase', () => {
           delete: [
             {
               path: '.claude/commands/packmind/',
-              type: 'directory',
+              type: DeleteItemType.Directory,
             },
           ],
         });
@@ -2931,7 +2986,7 @@ describe('PullContentUseCase', () => {
 
         expect(result.fileUpdates.delete).toContainEqual({
           path: '.claude/commands/packmind/',
-          type: 'directory',
+          type: DeleteItemType.Directory,
         });
       });
 
@@ -2965,10 +3020,10 @@ describe('PullContentUseCase', () => {
       });
     });
 
-    describe('when target is not found', () => {
+    describe('when target resolution fails', () => {
       beforeEach(() => {
-        targetResolutionService.findOrCreateTargetFromGitInfo.mockResolvedValue(
-          null,
+        targetResolutionService.findOrCreateTargetFromGitInfo.mockRejectedValue(
+          new Error('git repository is unreachable'),
         );
       });
 

--- a/packages/deployments/src/application/useCases/RemovePackageFromTargetsUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/RemovePackageFromTargetsUseCase.spec.ts
@@ -8,6 +8,8 @@ import { PackmindConfigService } from '../services/PackmindConfigService';
 import { PackageNotFoundError } from '../../domain/errors/PackageNotFoundError';
 import { TargetNotFoundError } from '../../domain/errors/TargetNotFoundError';
 import { stubLogger } from '@packmind/test-utils';
+import { gitRepoFactory } from '@packmind/git/test';
+import { packageFactory } from '../../../test';
 import {
   createPackageId,
   createTargetId,
@@ -24,6 +26,7 @@ import {
   createStandardId,
   createSkillId,
   RemovePackageFromTargetsCommand,
+  DeleteItemType,
   Package,
   Target,
   Distribution,
@@ -61,7 +64,7 @@ describe('RemovePackageFromTargetsUseCase', () => {
   const spaceId = createSpaceId('space-123');
   const gitRepoId = createGitRepoId('repo-123');
 
-  const mockPackage: Package = {
+  const mockPackage: Package = packageFactory({
     id: packageId,
     name: 'Test Package',
     slug: 'test-package',
@@ -70,7 +73,7 @@ describe('RemovePackageFromTargetsUseCase', () => {
     createdBy: userId,
     recipes: [],
     standards: [],
-  };
+  });
 
   const mockTarget: Target = {
     id: targetIds[0],
@@ -86,13 +89,13 @@ describe('RemovePackageFromTargetsUseCase', () => {
     gitRepoId,
   };
 
-  const mockGitRepo: GitRepo = {
+  const mockGitRepo: GitRepo = gitRepoFactory({
     branch: '',
     id: gitRepoId,
     owner: 'test-owner',
     repo: 'test-repo',
     providerId: createGitProviderId('provider-123'),
-  };
+  });
 
   beforeEach(() => {
     mockPackageService = {
@@ -355,7 +358,12 @@ describe('RemovePackageFromTargetsUseCase', () => {
         });
 
         describe('when there are files to delete', () => {
-          const deleteFiles = [{ path: '.packmind/recipes/deleted-recipe.md' }];
+          const deleteFiles = [
+            {
+              path: '.packmind/recipes/deleted-recipe.md',
+              type: DeleteItemType.File,
+            },
+          ];
 
           beforeEach(() => {
             mockCodingAgentPort.renderArtifacts.mockResolvedValue({
@@ -372,7 +380,12 @@ describe('RemovePackageFromTargetsUseCase', () => {
               mockGitRepo,
               expect.any(Array),
               expect.any(String),
-              [{ path: 'src/.packmind/recipes/deleted-recipe.md' }],
+              [
+                {
+                  path: 'src/.packmind/recipes/deleted-recipe.md',
+                  type: DeleteItemType.File,
+                },
+              ],
             );
           });
         });

--- a/packages/deployments/src/application/useCases/UpdateRenderModeConfigurationUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/UpdateRenderModeConfigurationUseCase.spec.ts
@@ -15,24 +15,26 @@ import { v4 as uuidv4 } from 'uuid';
 import { renderModeConfigurationFactory } from '../../../test';
 import { RenderModeConfigurationService } from '../services/RenderModeConfigurationService';
 import { UpdateRenderModeConfigurationUseCase } from './UpdateRenderModeConfigurationUseCase';
+import { userFactory } from '@packmind/accounts/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('UpdateRenderModeConfigurationUseCase', () => {
   let service: jest.Mocked<RenderModeConfigurationService>;

--- a/packages/deployments/src/application/useCases/UpdateTargetUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/UpdateTargetUseCase.spec.ts
@@ -10,8 +10,10 @@ import {
   createUserId,
   IGitPort,
   TargetPathUpdateForbiddenError,
-  GitProviderWithoutToken,
+  GitProviderListItem,
+  GitProviderVendors,
 } from '@packmind/types';
+import { gitRepoFactory } from '@packmind/git/test';
 
 describe('UpdateTargetUseCase', () => {
   let useCase: UpdateTargetUseCase;
@@ -106,21 +108,23 @@ describe('UpdateTargetUseCase', () => {
         organizationId,
       };
 
-      const mockRepo = {
+      const mockRepo = gitRepoFactory({
         id: gitRepoId,
         owner: 'owner',
         repo: 'repo',
         branch: 'main',
         providerId,
-      };
+      });
 
-      const mockProviderWithToken: GitProviderWithoutToken = {
+      const mockProviderWithToken: GitProviderListItem = {
         id: providerId,
-        source: 'github',
+        source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         authMethod: 'token',
+        displayName: 'github-provider',
         hasAuth: true,
+        lastDistributionAt: null,
       };
 
       const updatedTarget: Target = {
@@ -173,21 +177,23 @@ describe('UpdateTargetUseCase', () => {
         organizationId,
       };
 
-      const mockRepo = {
+      const mockRepo = gitRepoFactory({
         id: gitRepoId,
         owner: 'owner',
         repo: 'repo',
         branch: 'main',
         providerId,
-      };
+      });
 
-      const mockProviderWithoutToken: GitProviderWithoutToken = {
+      const mockProviderWithoutToken: GitProviderListItem = {
         id: providerId,
-        source: 'github',
+        source: GitProviderVendors.github,
         organizationId,
         url: 'https://github.com',
         authMethod: 'token',
+        displayName: 'github-provider',
         hasAuth: false,
+        lastDistributionAt: null,
       };
 
       let thrownError: Error;
@@ -401,22 +407,26 @@ describe('UpdateTargetUseCase', () => {
 
         beforeEach(async () => {
           mockTargetService.findById.mockResolvedValue(existingTarget);
-          mockGitPort.getRepositoryById.mockResolvedValue({
-            id: createGitRepoId('some-git-repo-id'),
-            owner: 'some-company',
-            repo: 'my-repo',
-            branch: 'main',
-            providerId: localProviderId,
-          });
+          mockGitPort.getRepositoryById.mockResolvedValue(
+            gitRepoFactory({
+              id: createGitRepoId('some-git-repo-id'),
+              owner: 'some-company',
+              repo: 'my-repo',
+              branch: 'main',
+              providerId: localProviderId,
+            }),
+          );
           mockGitPort.listProviders.mockResolvedValue({
             providers: [
               {
                 id: localProviderId,
-                source: 'github',
+                source: GitProviderVendors.github,
                 authMethod: 'token',
+                displayName: 'github-provider',
                 hasAuth: false,
                 organizationId,
                 url: 'https://github.com',
+                lastDistributionAt: null,
               },
             ],
           });
@@ -450,21 +460,23 @@ describe('UpdateTargetUseCase', () => {
       organizationId,
     };
 
-    const mockRepo = {
+    const mockRepo = gitRepoFactory({
       id: gitRepoId,
       owner: 'owner',
       repo: 'repo',
       branch: 'main',
       providerId,
-    };
+    });
 
-    const mockProviderWithToken: GitProviderWithoutToken = {
+    const mockProviderWithToken: GitProviderListItem = {
       id: providerId,
-      source: 'github',
+      source: GitProviderVendors.github,
       organizationId,
       url: 'https://github.com',
       authMethod: 'token',
+      displayName: 'github-provider',
       hasAuth: true,
+      lastDistributionAt: null,
     };
 
     const updatedTarget: Target = {

--- a/packages/deployments/src/application/useCases/addArtefactsToPackage/AddArtefactsToPackageUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/addArtefactsToPackage/AddArtefactsToPackageUseCase.spec.ts
@@ -31,6 +31,7 @@ import { DeploymentsServices } from '../../services/DeploymentsServices';
 import { PackageService } from '../../services/PackageService';
 import { PackageRepository } from '../../../infra/repositories/PackageRepository';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
 
 describe('AddArtefactsToPackageUseCase', () => {
   let useCase: AddArtefactsToPackageUseCase;
@@ -75,14 +76,15 @@ describe('AddArtefactsToPackageUseCase', () => {
     slug: 'test-org',
   });
 
-  const buildSpace = (): Space => ({
-    id: spaceId,
-    slug: 'test-space',
-    name: 'Test Space',
-    organizationId,
-    type: SpaceType.open,
-    isDefaultSpace: true,
-  });
+  const buildSpace = (): Space =>
+    spaceFactory({
+      id: spaceId,
+      slug: 'test-space',
+      name: 'Test Space',
+      organizationId,
+      type: SpaceType.open,
+      isDefaultSpace: true,
+    });
 
   const buildCommand = (id: CommandId, spaceIdParam: SpaceId): Command => ({
     id,
@@ -599,14 +601,14 @@ describe('AddArtefactsToPackageUseCase', () => {
       const differentOrgId = createOrganizationId(uuidv4());
 
       beforeEach(() => {
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId: differentOrgId,
           type: SpaceType.open,
           isDefaultSpace: true,
-        };
+        });
 
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);
 

--- a/packages/deployments/src/application/useCases/createPackage/CreatePackageUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/createPackage/CreatePackageUseCase.spec.ts
@@ -29,6 +29,10 @@ import { packageFactory } from '../../../../test';
 import { DeploymentsServices } from '../../services/DeploymentsServices';
 import { PackageService } from '../../services/PackageService';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
+import { commandFactory } from '@packmind/commands/test';
+import { standardFactory } from '@packmind/standards/test';
+import { skillFactory } from '@packmind/skills/test';
 
 describe('CreatePackageUseCase', () => {
   let useCase: CreatePackageUseCase;
@@ -70,46 +74,50 @@ describe('CreatePackageUseCase', () => {
     slug: 'test-org',
   });
 
-  const buildSpace = (): Space => ({
-    id: spaceId,
-    slug: 'test-space',
-    name: 'Test Space',
-    organizationId,
-  });
+  const buildSpace = (): Space =>
+    spaceFactory({
+      id: spaceId,
+      slug: 'test-space',
+      name: 'Test Space',
+      organizationId,
+    });
 
-  const buildCommand = (id: CommandId, spaceIdParam: SpaceId): Command => ({
-    id,
-    name: `Recipe ${id}`,
-    slug: `recipe-${id}`,
-    content: 'Test recipe content',
-    version: 1,
-    userId,
-    spaceId: spaceIdParam,
-  });
+  const buildCommand = (id: CommandId, spaceIdParam: SpaceId): Command =>
+    commandFactory({
+      id,
+      name: `Recipe ${id}`,
+      slug: `recipe-${id}`,
+      content: 'Test recipe content',
+      version: 1,
+      userId,
+      spaceId: spaceIdParam,
+    });
 
-  const buildStandard = (id: StandardId, spaceIdParam: SpaceId): Standard => ({
-    id,
-    name: `Standard ${id}`,
-    slug: `standard-${id}`,
-    description: 'Test standard',
-    version: 1,
-    userId,
-    scope: null,
-    spaceId: spaceIdParam,
-  });
+  const buildStandard = (id: StandardId, spaceIdParam: SpaceId): Standard =>
+    standardFactory({
+      id,
+      name: `Standard ${id}`,
+      slug: `standard-${id}`,
+      description: 'Test standard',
+      version: 1,
+      userId,
+      scope: null,
+      spaceId: spaceIdParam,
+    });
 
-  const buildSkill = (id: SkillId, spaceIdParam: SpaceId): Skill => ({
-    id,
-    name: `Skill ${id}`,
-    prompt: 'Test skill content',
-    userId,
-    spaceId: spaceIdParam,
-    slug: '',
-    version: 0,
-    description: '',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  });
+  const buildSkill = (id: SkillId, spaceIdParam: SpaceId): Skill =>
+    skillFactory({
+      id,
+      name: `Skill ${id}`,
+      prompt: 'Test skill content',
+      userId,
+      spaceId: spaceIdParam,
+      slug: '',
+      version: 0,
+      description: '',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
 
   beforeEach(() => {
     mockPackageService = {
@@ -587,12 +595,12 @@ describe('CreatePackageUseCase', () => {
       const differentOrgId = createOrganizationId(uuidv4());
 
       beforeEach(() => {
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId: differentOrgId,
-        };
+        });
 
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);
 

--- a/packages/deployments/src/application/useCases/deletePackage/DeletePackagesBatchUseCase.test.ts
+++ b/packages/deployments/src/application/useCases/deletePackage/DeletePackagesBatchUseCase.test.ts
@@ -10,7 +10,7 @@ import {
   createOrganizationId,
   PackagesDeletedEvent,
   DeletePackagesBatchCommand,
-  PackagesDeletedEvent,
+  DeletePackagesBatchResponse,
 } from '@packmind/types';
 
 describe('DeletePackagesBatchUseCase', () => {
@@ -114,7 +114,7 @@ describe('DeletePackagesBatchUseCase', () => {
       const spaceId = createSpaceId('space-456');
       const userId = createUserId('user-789');
       const organizationId = createOrganizationId('org-999');
-      let result: Record<string, never>;
+      let result: DeletePackagesBatchResponse;
 
       beforeEach(async () => {
         const existingPackage = packageFactory({ id: packageId, spaceId });
@@ -154,7 +154,7 @@ describe('DeletePackagesBatchUseCase', () => {
       const spaceId = createSpaceId('space-456');
       const userId = createUserId('user-789');
       const organizationId = createOrganizationId('org-999');
-      let executePromise: Promise<Record<string, never>>;
+      let executePromise: Promise<DeletePackagesBatchResponse>;
 
       beforeEach(() => {
         const package1 = packageFactory({ id: packageId1, spaceId });
@@ -201,7 +201,7 @@ describe('DeletePackagesBatchUseCase', () => {
       const wrongSpaceId = createSpaceId('space-wrong');
       const userId = createUserId('user-789');
       const organizationId = createOrganizationId('org-999');
-      let executePromise: Promise<Record<string, never>>;
+      let executePromise: Promise<DeletePackagesBatchResponse>;
 
       beforeEach(() => {
         const package1 = packageFactory({
@@ -254,7 +254,7 @@ describe('DeletePackagesBatchUseCase', () => {
       const spaceId = createSpaceId('space-999');
       const userId = createUserId('user-111');
       const organizationId = createOrganizationId('org-222');
-      let executePromise: Promise<Record<string, never>>;
+      let executePromise: Promise<DeletePackagesBatchResponse>;
 
       beforeEach(() => {
         const package1 = packageFactory({ id: packageId1, spaceId });
@@ -314,7 +314,7 @@ describe('DeletePackagesBatchUseCase', () => {
       const spaceId = createSpaceId('space-999');
       const userId = createUserId('user-111');
       const organizationId = createOrganizationId('org-222');
-      let executePromise: Promise<Record<string, never>>;
+      let executePromise: Promise<DeletePackagesBatchResponse>;
 
       beforeEach(() => {
         const package1 = packageFactory({ id: packageId1, spaceId });

--- a/packages/deployments/src/application/useCases/getPackageSummary/GetPackageSummaryUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/getPackageSummary/GetPackageSummaryUseCase.spec.ts
@@ -9,6 +9,7 @@ import {
   createSpaceId,
   createUserId,
 } from '@packmind/types';
+import { userFactory } from '@packmind/accounts/test';
 import { skillFactory } from '@packmind/skills/test';
 import { v4 as uuidv4 } from 'uuid';
 import { packageFactory } from '../../../../test';
@@ -36,12 +37,24 @@ function makeMembership(userId: string): UserOrganizationMembership {
 }
 
 function makeUser(userId: string): User {
-  return {
+  return userFactory({
     id: createUserId(userId),
     email: `${userId}@test.com`,
     passwordHash: null,
     active: true,
     memberships: [makeMembership(userId)],
+  });
+}
+
+function makePackageWithArtefacts(
+  overrides: Partial<PackageWithArtefacts> = {},
+): PackageWithArtefacts {
+  return {
+    ...packageFactory(),
+    recipes: [],
+    standards: [],
+    skills: [],
+    ...overrides,
   };
 }
 
@@ -91,7 +104,7 @@ describe('GetPackageSummaryUseCase', () => {
   describe('when spaceId is not provided', () => {
     beforeEach(() => {
       packageService.getPackagesBySlugsWithArtefacts.mockResolvedValue([
-        packageFactory({ slug: 'backend', spaceId: SPACE_ID }),
+        makePackageWithArtefacts({ slug: 'backend', spaceId: SPACE_ID }),
       ]);
     });
 
@@ -150,7 +163,7 @@ describe('GetPackageSummaryUseCase', () => {
   describe('when spaceId is provided', () => {
     beforeEach(() => {
       packageService.getPackagesBySlugsAndSpaceWithArtefacts.mockResolvedValue([
-        packageFactory({ slug: 'backend', spaceId: SPACE_ID }),
+        makePackageWithArtefacts({ slug: 'backend', spaceId: SPACE_ID }),
       ]);
     });
 

--- a/packages/deployments/src/application/useCases/listPackagesBySpace/ListPackagesBySpaceUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/listPackagesBySpace/ListPackagesBySpaceUseCase.spec.ts
@@ -15,6 +15,7 @@ import { packageFactory } from '../../../../test';
 import { DeploymentsServices } from '../../services/DeploymentsServices';
 import { PackageService } from '../../services/PackageService';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
 
 describe('ListPackagesBySpaceUseCase', () => {
   let useCase: ListPackagesBySpaceUseCase;
@@ -101,12 +102,12 @@ describe('ListPackagesBySpaceUseCase', () => {
       let package2: ReturnType<typeof packageFactory>;
 
       beforeEach(async () => {
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId,
-        };
+        });
 
         package1 = packageFactory({
           spaceId,
@@ -151,12 +152,12 @@ describe('ListPackagesBySpaceUseCase', () => {
       let result: { packages: ReturnType<typeof packageFactory>[] };
 
       beforeEach(async () => {
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId,
-        };
+        });
 
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);
         mockPackageService.getPackagesBySpaceId.mockResolvedValue([]);
@@ -226,12 +227,12 @@ describe('ListPackagesBySpaceUseCase', () => {
 
       beforeEach(() => {
         const differentOrgId = createOrganizationId(uuidv4());
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId: differentOrgId,
-        };
+        });
 
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);
 
@@ -267,12 +268,12 @@ describe('ListPackagesBySpaceUseCase', () => {
 
     describe('when service operations fail', () => {
       it('throws the error from service', async () => {
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId,
-        };
+        });
 
         const error = new Error('Database connection failed');
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);

--- a/packages/deployments/src/application/useCases/notifyArtefactsDistribution/NotifyArtefactsDistributionUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/notifyArtefactsDistribution/NotifyArtefactsDistributionUseCase.spec.ts
@@ -31,6 +31,9 @@ import { IDistributedPackageRepository } from '../../../domain/repositories/IDis
 import { RenderModeConfigurationService } from '../../services/RenderModeConfigurationService';
 import { TargetResolutionService } from '../../services/TargetResolutionService';
 import { v4 as uuidv4 } from 'uuid';
+import { commandVersionFactory } from '@packmind/commands/test';
+import { standardVersionFactory } from '@packmind/standards/test';
+import { skillVersionFactory } from '@packmind/skills/test';
 
 describe('NotifyArtefactsDistributionUseCase', () => {
   let useCase: NotifyArtefactsDistributionUseCase;
@@ -76,39 +79,40 @@ describe('NotifyArtefactsDistributionUseCase', () => {
     gitRepoId,
   });
 
-  const buildStandardVersion = (): StandardVersion => ({
-    id: createStandardVersionId(uuidv4()),
-    standardId,
-    version: 1,
-    description: 'Test standard description',
-    name: 'Test Standard',
-    summary: 'Test summary',
-    rules: [],
-    slug: 'test-standard',
-    scope: null,
-  });
+  const buildStandardVersion = (): StandardVersion =>
+    standardVersionFactory({
+      id: createStandardVersionId(uuidv4()),
+      standardId,
+      version: 1,
+      description: 'Test standard description',
+      name: 'Test Standard',
+      rules: [],
+      slug: 'test-standard',
+      scope: null,
+    });
 
-  const buildCommandVersion = (): CommandVersion => ({
-    id: createCommandVersionId(uuidv4()),
-    recipeId,
-    version: 1,
-    name: 'Test Recipe',
-    slug: 'test-recipe',
-    summary: 'Test summary',
-    content: 'Test step',
-    userId,
-  });
+  const buildCommandVersion = (): CommandVersion =>
+    commandVersionFactory({
+      id: createCommandVersionId(uuidv4()),
+      recipeId,
+      version: 1,
+      name: 'Test Recipe',
+      slug: 'test-recipe',
+      content: 'Test step',
+      userId,
+    });
 
-  const buildSkillVersion = (): SkillVersion => ({
-    id: createSkillVersionId(uuidv4()),
-    skillId,
-    version: 1,
-    name: 'Test Skill',
-    slug: 'test-skill',
-    description: 'Test skill description',
-    prompt: 'Test prompt',
-    userId,
-  });
+  const buildSkillVersion = (): SkillVersion =>
+    skillVersionFactory({
+      id: createSkillVersionId(uuidv4()),
+      skillId,
+      version: 1,
+      name: 'Test Skill',
+      slug: 'test-skill',
+      description: 'Test skill description',
+      prompt: 'Test prompt',
+      userId,
+    });
 
   const buildLockFile = (
     overrides: Partial<PackmindLockFile> = {},
@@ -126,6 +130,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
         spaceId: String(spaceId),
         packageIds: [String(packageId)],
         files: [],
+        source: 'user',
       },
       [`command:test-recipe`]: {
         name: 'Test Recipe',
@@ -135,6 +140,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
         spaceId: String(spaceId),
         packageIds: [String(packageId)],
         files: [],
+        source: 'user',
       },
       [`skill:test-skill`]: {
         name: 'Test Skill',
@@ -144,6 +150,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
         spaceId: String(spaceId),
         packageIds: [String(packageId)],
         files: [],
+        source: 'user',
       },
     },
     ...overrides,
@@ -309,7 +316,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
         await useCase.execute(
           buildCommand({
             packmindLockFile: buildLockFile({
-              agents: ['cursor', 'claude-code'],
+              agents: ['cursor', 'claude'],
             }),
           }),
         );
@@ -318,7 +325,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
       it('maps lock file agents to render modes', () => {
         expect(
           mockRenderModeConfigurationService.mapCodingAgentsToRenderModes,
-        ).toHaveBeenCalledWith(['cursor', 'claude-code']);
+        ).toHaveBeenCalledWith(['cursor', 'claude']);
       });
     });
 
@@ -392,6 +399,7 @@ describe('NotifyArtefactsDistributionUseCase', () => {
               spaceId: String(spaceId),
               packageIds: [String(packageId), String(secondPackageId)],
               files: [],
+              source: 'user',
             },
           },
         });

--- a/packages/deployments/src/application/useCases/notifyDistribution/NotifyDistributionUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/notifyDistribution/NotifyDistributionUseCase.spec.ts
@@ -37,6 +37,9 @@ import { IDistributedPackageRepository } from '../../../domain/repositories/IDis
 import { RenderModeConfigurationService } from '../../services/RenderModeConfigurationService';
 import { TargetResolutionService } from '../../services/TargetResolutionService';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
+import { commandVersionFactory } from '@packmind/commands/test';
+import { standardVersionFactory } from '@packmind/standards/test';
 
 describe('NotifyDistributionUseCase', () => {
   let useCase: NotifyDistributionUseCase;
@@ -82,24 +85,26 @@ describe('NotifyDistributionUseCase', () => {
 
   const globalSpaceId = createSpaceId(uuidv4());
 
-  const buildGlobalSpace = (): Space => ({
-    id: globalSpaceId,
-    name: 'Global',
-    slug: 'global',
-    type: SpaceType.open,
-    organizationId,
-    isDefaultSpace: true,
-  });
+  const buildGlobalSpace = (): Space =>
+    spaceFactory({
+      id: globalSpaceId,
+      name: 'Global',
+      slug: 'global',
+      type: SpaceType.open,
+      organizationId,
+      isDefaultSpace: true,
+    });
 
-  const buildSpace = (overrides: Partial<Space> = {}): Space => ({
-    id: createSpaceId(uuidv4()),
-    name: 'Custom Space',
-    slug: 'custom-space',
-    type: SpaceType.open,
-    organizationId,
-    isDefaultSpace: false,
-    ...overrides,
-  });
+  const buildSpace = (overrides: Partial<Space> = {}): Space =>
+    spaceFactory({
+      id: createSpaceId(uuidv4()),
+      name: 'Custom Space',
+      slug: 'custom-space',
+      type: SpaceType.open,
+      organizationId,
+      isDefaultSpace: false,
+      ...overrides,
+    });
 
   const buildPackage = (
     slug = 'my-package',
@@ -123,28 +128,28 @@ describe('NotifyDistributionUseCase', () => {
     gitRepoId,
   });
 
-  const buildCommandVersion = (): CommandVersion => ({
-    id: createCommandVersionId(uuidv4()),
-    recipeId,
-    version: 1,
-    name: 'Test Recipe',
-    slug: 'test-recipe',
-    summary: 'Test summary',
-    content: 'Test step',
-    userId,
-  });
+  const buildCommandVersion = (): CommandVersion =>
+    commandVersionFactory({
+      id: createCommandVersionId(uuidv4()),
+      recipeId,
+      version: 1,
+      name: 'Test Recipe',
+      slug: 'test-recipe',
+      content: 'Test step',
+      userId,
+    });
 
-  const buildStandardVersion = (): StandardVersion => ({
-    id: createStandardVersionId(uuidv4()),
-    standardId,
-    version: 1,
-    description: 'Test standard description',
-    name: 'Test Standard',
-    summary: 'Test summary',
-    rules: [],
-    slug: 'test-standard',
-    scope: null,
-  });
+  const buildStandardVersion = (): StandardVersion =>
+    standardVersionFactory({
+      id: createStandardVersionId(uuidv4()),
+      standardId,
+      version: 1,
+      description: 'Test standard description',
+      name: 'Test Standard',
+      rules: [],
+      slug: 'test-standard',
+      scope: null,
+    });
 
   const buildSkillVersion = (): SkillVersion => ({
     id: createSkillVersionId(uuidv4()),

--- a/packages/deployments/src/application/useCases/removeArtefactsFromPackage/RemoveArtefactsFromPackageUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/removeArtefactsFromPackage/RemoveArtefactsFromPackageUseCase.spec.ts
@@ -25,6 +25,7 @@ import { DeploymentsServices } from '../../services/DeploymentsServices';
 import { PackageService } from '../../services/PackageService';
 import { PackageRepository } from '../../../infra/repositories/PackageRepository';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
 
 describe('RemoveArtefactsFromPackageUseCase', () => {
   let useCase: RemoveArtefactsFromPackageUseCase;
@@ -65,14 +66,15 @@ describe('RemoveArtefactsFromPackageUseCase', () => {
     slug: 'test-org',
   });
 
-  const buildSpace = (): Space => ({
-    id: spaceId,
-    slug: 'test-space',
-    name: 'Test Space',
-    organizationId,
-    type: SpaceType.open,
-    isDefaultSpace: true,
-  });
+  const buildSpace = (): Space =>
+    spaceFactory({
+      id: spaceId,
+      slug: 'test-space',
+      name: 'Test Space',
+      organizationId,
+      type: SpaceType.open,
+      isDefaultSpace: true,
+    });
 
   beforeEach(() => {
     mockPackageRepository = {

--- a/packages/deployments/src/application/useCases/renderPackageAsPlugin/RenderPackageAsPluginUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/renderPackageAsPlugin/RenderPackageAsPluginUseCase.spec.ts
@@ -46,24 +46,27 @@ import { IDistributionRepository } from '../../../domain/repositories/IDistribut
 import { IDistributedPackageRepository } from '../../../domain/repositories/IDistributedPackageRepository';
 import { PackagesNotFoundError } from '../../../domain/errors/PackagesNotFoundError';
 import { RenderPackageAsPluginUseCase } from './RenderPackageAsPluginUseCase';
+import { userFactory } from '@packmind/accounts/test';
+import { spaceFactory } from '@packmind/spaces/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('RenderPackageAsPluginUseCase', () => {
   let packageService: jest.Mocked<PackageService>;
@@ -189,14 +192,14 @@ describe('RenderPackageAsPluginUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    defaultSpace = {
+    defaultSpace = spaceFactory({
       id: createSpaceId('default-space-id'),
       name: 'Default Space',
       slug: 'default',
       type: SpaceType.open,
       organizationId,
       isDefaultSpace: true,
-    };
+    });
 
     packageService = {
       getPackagesBySlugsAndSpaceWithArtefacts: jest.fn().mockResolvedValue([]),

--- a/packages/deployments/src/application/useCases/trackPluginDeleted/TrackPluginDeletedUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/trackPluginDeleted/TrackPluginDeletedUseCase.spec.ts
@@ -21,24 +21,27 @@ import { v4 as uuidv4 } from 'uuid';
 import { PackageService } from '../../services/PackageService';
 import { PackagesNotFoundError } from '../../../domain/errors/PackagesNotFoundError';
 import { TrackPluginDeletedUseCase } from './TrackPluginDeletedUseCase';
+import { userFactory } from '@packmind/accounts/test';
+import { spaceFactory } from '@packmind/spaces/test';
 
 const createUserWithMembership = (
   userId: string,
   organization: Organization,
   role: UserOrganizationMembership['role'],
-): User => ({
-  id: createUserId(userId),
-  email: `${userId}@packmind.test`,
-  passwordHash: null,
-  active: true,
-  memberships: [
-    {
-      userId: createUserId(userId),
-      organizationId: organization.id,
-      role,
-    },
-  ],
-});
+): User =>
+  userFactory({
+    id: createUserId(userId),
+    email: `${userId}@packmind.test`,
+    passwordHash: null,
+    active: true,
+    memberships: [
+      {
+        userId: createUserId(userId),
+        organizationId: organization.id,
+        role,
+      },
+    ],
+  });
 
 describe('TrackPluginDeletedUseCase', () => {
   let packageService: jest.Mocked<PackageService>;
@@ -85,14 +88,14 @@ describe('TrackPluginDeletedUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    defaultSpace = {
+    defaultSpace = spaceFactory({
       id: createSpaceId('default-space-id'),
       name: 'Default Space',
       slug: 'default',
       type: SpaceType.open,
       organizationId,
       isDefaultSpace: true,
-    };
+    });
     pkg = buildPackage();
 
     packageService = {

--- a/packages/deployments/src/application/useCases/updatePackage/UpdatePackageUseCase.spec.ts
+++ b/packages/deployments/src/application/useCases/updatePackage/UpdatePackageUseCase.spec.ts
@@ -34,6 +34,10 @@ import { packageFactory } from '../../../../test';
 import { DeploymentsServices } from '../../services/DeploymentsServices';
 import { PackageService } from '../../services/PackageService';
 import { v4 as uuidv4 } from 'uuid';
+import { spaceFactory } from '@packmind/spaces/test';
+import { commandFactory } from '@packmind/commands/test';
+import { standardFactory } from '@packmind/standards/test';
+import { skillFactory } from '@packmind/skills/test';
 
 describe('UpdatePackageUseCase', () => {
   let useCase: UpdatePackageUseCase;
@@ -75,44 +79,48 @@ describe('UpdatePackageUseCase', () => {
     slug: 'test-org',
   });
 
-  const buildSpace = (): Space => ({
-    id: spaceId,
-    slug: 'test-space',
-    name: 'Test Space',
-    organizationId,
-  });
+  const buildSpace = (): Space =>
+    spaceFactory({
+      id: spaceId,
+      slug: 'test-space',
+      name: 'Test Space',
+      organizationId,
+    });
 
-  const buildCommand = (id: CommandId, spaceIdParam: SpaceId): Command => ({
-    id,
-    name: `Recipe ${id}`,
-    slug: `recipe-${id}`,
-    content: 'Test recipe content',
-    version: 1,
-    userId,
-    spaceId: spaceIdParam,
-  });
+  const buildCommand = (id: CommandId, spaceIdParam: SpaceId): Command =>
+    commandFactory({
+      id,
+      name: `Recipe ${id}`,
+      slug: `recipe-${id}`,
+      content: 'Test recipe content',
+      version: 1,
+      userId,
+      spaceId: spaceIdParam,
+    });
 
-  const buildStandard = (id: StandardId, spaceIdParam: SpaceId): Standard => ({
-    id,
-    name: `Standard ${id}`,
-    slug: `standard-${id}`,
-    description: 'Test standard',
-    version: 1,
-    userId,
-    scope: null,
-    spaceId: spaceIdParam,
-  });
+  const buildStandard = (id: StandardId, spaceIdParam: SpaceId): Standard =>
+    standardFactory({
+      id,
+      name: `Standard ${id}`,
+      slug: `standard-${id}`,
+      description: 'Test standard',
+      version: 1,
+      userId,
+      scope: null,
+      spaceId: spaceIdParam,
+    });
 
-  const buildSkill = (id: SkillId, spaceIdParam: SpaceId): Skill => ({
-    id,
-    name: `Skill ${id}`,
-    slug: `skill-${id}`,
-    description: 'Test skill',
-    prompt: 'Test prompt',
-    version: 1,
-    userId,
-    spaceId: spaceIdParam,
-  });
+  const buildSkill = (id: SkillId, spaceIdParam: SpaceId): Skill =>
+    skillFactory({
+      id,
+      name: `Skill ${id}`,
+      slug: `skill-${id}`,
+      description: 'Test skill',
+      prompt: 'Test prompt',
+      version: 1,
+      userId,
+      spaceId: spaceIdParam,
+    });
 
   const buildExistingPackage = (pkgId: PackageId, pkgSpaceId: SpaceId) =>
     packageFactory({
@@ -356,12 +364,12 @@ describe('UpdatePackageUseCase', () => {
       it('throws error', async () => {
         const differentOrgId = createOrganizationId(uuidv4());
         const existingPackage = buildExistingPackage(packageId, spaceId);
-        const mockSpace: Space = {
+        const mockSpace: Space = spaceFactory({
           id: spaceId,
           slug: 'test-space',
           name: 'Test Space',
           organizationId: differentOrgId,
-        };
+        });
 
         mockPackageService.findById.mockResolvedValue(existingPackage);
         mockSpacesPort.getSpaceById.mockResolvedValue(mockSpace);

--- a/packages/deployments/src/infra/repositories/DistributionRepository.spec.ts
+++ b/packages/deployments/src/infra/repositories/DistributionRepository.spec.ts
@@ -21,10 +21,20 @@ import {
   StandardId,
   CommandId,
   SkillId,
+  SkillVersion,
 } from '@packmind/types';
+import { skillVersionFactory } from '@packmind/skills/test';
 import { Repository, SelectQueryBuilder } from 'typeorm';
 import { DistributionRepository } from './DistributionRepository';
 import { OutdatedDeploymentsByTarget } from '../../domain/repositories/IDistributionRepository';
+
+/**
+ * Shape the repository reads through `isSkillVersionOrphaned`: a skill version
+ * row with its parent skill joined in, so the soft-delete flag is visible.
+ */
+type SkillVersionWithParentSkill = SkillVersion & {
+  skill?: { deletedAt?: Date | null } | null;
+};
 
 describe('DistributionRepository', () => {
   let repository: DistributionRepository;
@@ -263,7 +273,6 @@ describe('DistributionRepository', () => {
       slug: name.toLowerCase().replace(/ /g, '-'),
       description: `Description for ${name}`,
       version: 1,
-      summary: null,
       gitCommit: undefined,
       userId: createUserId('author-1'),
       scope: null,
@@ -604,7 +613,6 @@ describe('DistributionRepository', () => {
       slug: name.toLowerCase().replace(/ /g, '-'),
       content: `Content for ${name}`,
       version: 1,
-      summary: null,
       userId: null,
     });
 
@@ -937,8 +945,8 @@ describe('DistributionRepository', () => {
       skillId: string,
       name: string,
       opts: { parentDeletedAt?: Date | null } = {},
-    ) =>
-      ({
+    ): SkillVersionWithParentSkill => ({
+      ...skillVersionFactory({
         id: createSkillVersionId(id),
         skillId: createSkillId(skillId),
         name,
@@ -947,8 +955,9 @@ describe('DistributionRepository', () => {
         version: 1,
         prompt: '',
         userId: createUserId('author-1'),
-        skill: { deletedAt: opts.parentDeletedAt ?? null },
-      }) as never;
+      }),
+      skill: { deletedAt: opts.parentDeletedAt ?? null },
+    });
 
     const createDistribution = (
       id: string,
@@ -1075,8 +1084,8 @@ describe('DistributionRepository', () => {
       skillId: string,
       name: string,
       opts: { parentDeletedAt?: Date | null } = {},
-    ) =>
-      ({
+    ): SkillVersionWithParentSkill => ({
+      ...skillVersionFactory({
         id: createSkillVersionId(id),
         skillId: createSkillId(skillId),
         name,
@@ -1085,8 +1094,9 @@ describe('DistributionRepository', () => {
         version: 1,
         prompt: '',
         userId: createUserId('author-1'),
-        skill: { deletedAt: opts.parentDeletedAt ?? null },
-      }) as never;
+      }),
+      skill: { deletedAt: opts.parentDeletedAt ?? null },
+    });
 
     const createDistribution = (
       id: string,
@@ -1269,7 +1279,7 @@ describe('DistributionRepository', () => {
       const standardId1 = createStandardId('std-1');
       const standardId2 = createStandardId('std-2');
       const commandId1 = createCommandId('recipe-1');
-      const skillId1 = 'skill-1' as never;
+      const skillId1 = createSkillId('skill-1');
 
       let result: Awaited<
         ReturnType<typeof repository.listDeployedArtifactIdsBySpace>
@@ -1293,7 +1303,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-one',
                   description: 'desc',
                   version: 1,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,
@@ -1305,7 +1314,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-two',
                   description: 'desc',
                   version: 1,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,
@@ -1319,21 +1327,18 @@ describe('DistributionRepository', () => {
                   slug: 'recipe-one',
                   content: 'content',
                   version: 1,
-                  summary: null,
                   userId: null,
                 },
               ],
               skillVersions: [
-                {
-                  id: 'skv-1' as never,
+                skillVersionFactory({
+                  id: createSkillVersionId('skv-1'),
                   skillId: skillId1,
                   name: 'Skill One',
                   slug: 'skill-one',
-                  content: 'content',
+                  prompt: 'content',
                   version: 1,
-                  summary: null,
-                  userId: null,
-                },
+                }),
               ],
             },
           ],
@@ -1386,7 +1391,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-one',
                   description: 'desc',
                   version: 1,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,
@@ -1431,7 +1435,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-two',
                   description: 'desc',
                   version: 1,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,
@@ -1517,7 +1520,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-one',
                   description: 'desc',
                   version: 1,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,
@@ -1544,7 +1546,6 @@ describe('DistributionRepository', () => {
                   slug: 'standard-one',
                   description: 'desc',
                   version: 2,
-                  summary: null,
                   gitCommit: undefined,
                   userId: createUserId('author-1'),
                   scope: null,

--- a/packages/deployments/tsconfig.spec.json
+++ b/packages/deployments/tsconfig.spec.json
@@ -10,6 +10,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.ts"
   ]
 }

--- a/packages/git/src/infra/repositories/github/auth/InstallStateSigner.ts
+++ b/packages/git/src/infra/repositories/github/auth/InstallStateSigner.ts
@@ -69,15 +69,15 @@ export class InstallStateSigner {
     };
 
     if (payload.organizationGitHubAppId !== undefined) {
-      fullPayload.organizationGitHubAppId = payload.organizationGitHubAppId;
+      fullPayload['organizationGitHubAppId'] = payload.organizationGitHubAppId;
     }
 
     if (payload.gitProviderId !== undefined) {
-      fullPayload.gitProviderId = payload.gitProviderId;
+      fullPayload['gitProviderId'] = payload.gitProviderId;
     }
 
     if (payload.displayName !== undefined) {
-      fullPayload.displayName = payload.displayName;
+      fullPayload['displayName'] = payload.displayName;
     }
 
     const json = JSON.stringify(fullPayload);
@@ -137,44 +137,45 @@ export class InstallStateSigner {
     if (
       typeof parsed !== 'object' ||
       parsed === null ||
-      typeof record.orgId !== 'string' ||
-      !record.orgId ||
-      typeof record.userId !== 'string' ||
-      !record.userId ||
-      typeof record.nonce !== 'string' ||
-      !record.nonce ||
-      typeof record.exp !== 'number' ||
-      !isFinite(record.exp as number)
+      typeof record['orgId'] !== 'string' ||
+      !record['orgId'] ||
+      typeof record['userId'] !== 'string' ||
+      !record['userId'] ||
+      typeof record['nonce'] !== 'string' ||
+      !record['nonce'] ||
+      typeof record['exp'] !== 'number' ||
+      !isFinite(record['exp'] as number)
     ) {
       throw new InvalidInstallStateError();
     }
 
     // kind defaults to 'install' for tokens signed before the discriminator was introduced
     const kind: InstallStateKind =
-      record.kind === 'manifest' ? 'manifest' : 'install';
+      record['kind'] === 'manifest' ? 'manifest' : 'install';
 
     const organizationGitHubAppId =
-      typeof record.organizationGitHubAppId === 'string' &&
-      record.organizationGitHubAppId.length > 0
-        ? (record.organizationGitHubAppId as string)
+      typeof record['organizationGitHubAppId'] === 'string' &&
+      record['organizationGitHubAppId'].length > 0
+        ? (record['organizationGitHubAppId'] as string)
         : undefined;
 
     const gitProviderId =
-      typeof record.gitProviderId === 'string' &&
-      record.gitProviderId.length > 0
-        ? (record.gitProviderId as string)
+      typeof record['gitProviderId'] === 'string' &&
+      record['gitProviderId'].length > 0
+        ? (record['gitProviderId'] as string)
         : undefined;
 
     const displayName =
-      typeof record.displayName === 'string' && record.displayName.length > 0
-        ? (record.displayName as string)
+      typeof record['displayName'] === 'string' &&
+      record['displayName'].length > 0
+        ? (record['displayName'] as string)
         : undefined;
 
     const payload: InstallStatePayload = {
-      orgId: record.orgId as string,
-      userId: record.userId as string,
-      nonce: record.nonce as string,
-      exp: record.exp as number,
+      orgId: record['orgId'] as string,
+      userId: record['userId'] as string,
+      nonce: record['nonce'] as string,
+      exp: record['exp'] as number,
       kind,
       organizationGitHubAppId,
       gitProviderId,

--- a/packages/skills/test/skillFactory.ts
+++ b/packages/skills/test/skillFactory.ts
@@ -22,6 +22,8 @@ export const skillFactory: Factory<Skill> = (skill?: Partial<Skill>) => {
     metadata: { category: 'test', tags: 'testing' },
     allowedTools: 'Read,Write,Bash',
     movedTo: null,
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-01T00:00:00.000Z'),
     ...skill,
   };
 };

--- a/packages/skills/test/skillFileFactory.ts
+++ b/packages/skills/test/skillFileFactory.ts
@@ -15,6 +15,7 @@ export const skillFileFactory: Factory<SkillFile> = (
     path: 'SKILL.md',
     content: '---\nname: test-skill\ndescription: Test skill\n---\n\nContent',
     permissions: 'rw-r--r--',
+    isBase64: false,
     ...skillFile,
   };
 };


### PR DESCRIPTION
## Explanation

`packages/deployments` spec files were never type-checked: the shared `typecheck` target only compiles `tsconfig.lib.json` (which excludes specs), and @swc/jest strips types without checking them. Turning the gate on surfaced 260 errors; all were fixed in the fixtures, then the gate was wired so it stays on.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Improvement/Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Breaking change

## Affected Components

- Domain packages affected: `deployments` (specs + gate), `skills/test` (2 factories), `git` and `accounts` (1 file each, see Reviewer Notes)
- Frontend / Backend / Both: Backend
- Breaking changes (if any): none

**Drift categories:** missing required fields 118, fields removed from the entity (`summary`, `source`) 24, wrong/over-wide types incl. `as never` ids 45, partial or stale mocks 23, cross-package strictness 26, other 24.

## Testing

`nx run-many -t typecheck -p packages/*` (proved failing on an injected error in a spec and in a `test/` helper, then reverted), `nx test deployments` (1260 passed, none skipped), `nx lint deployments` (31 warnings, same as before), `prettier -c`, plus `nx test` for `git accounts skills coding-agent` as consumers of the changed skill factories.

## TODO List

- [ ] CHANGELOG Updated — n/a
- [ ] Documentation Updated — n/a

## Reviewer Notes

No production bug — the fixtures were stale, and every test passes unchanged.

Two things worth a look:

- Two dependency files needed edits to compile under `deployments`' stricter options, which its specs now pull in: bracket access in `InstallStateSigner.ts` (`noPropertyAccessFromIndexSignature`) and an `override` in `InvitationRepository.ts` (`noImplicitOverride`). Both are no-ops at runtime; the packages themselves don't set those flags.
- `PullContentUseCase`'s "when target is not found" case stubbed `findOrCreateTargetFromGitInfo` with `null`, but that method returns `Promise<Target>` and never yields null, so the `if (target)` guard around it is dead. The test now stubs a rejection, exercising the reachable `catch`; the guard could be dropped in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qcr22epyHqwcKf3UEYs9WN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qcr22epyHqwcKf3UEYs9WN)_