### PR TITLE
Add mockPort utility for typed interface mocking

### DIFF
--- a/packages/git/src/application/GitProviderService.spec.ts
+++ b/packages/git/src/application/GitProviderService.spec.ts
@@ -1,3 +1,4 @@
+import { mockPort } from '@packmind/test-utils';
 import { GitProviderService } from './GitProviderService';
 import { IGitProviderRepository } from '../domain/repositories/IGitProviderRepository';
 import { IGitProviderFactory } from '../domain/repositories/IGitProviderFactory';
@@ -42,15 +43,7 @@ describe('GitProviderService', () => {
   });
 
   beforeEach(() => {
-    mockGitProviderRepository = {
-      findById: jest.fn(),
-      add: jest.fn(),
-      deleteById: jest.fn(),
-      restoreById: jest.fn(),
-      findByOrganizationId: jest.fn(),
-      list: jest.fn(),
-      update: jest.fn(),
-    } as unknown as jest.Mocked<IGitProviderRepository>;
+    mockGitProviderRepository = mockPort<IGitProviderRepository>();
 
     mockGithubProviderInstance = {
       listAvailableRepositories: jest.fn(),

--- a/packages/git/src/application/GitRepoService.spec.ts
+++ b/packages/git/src/application/GitRepoService.spec.ts
@@ -1,3 +1,4 @@
+import { mockPort } from '@packmind/test-utils';
 import { GitRepoService } from './GitRepoService';
 import { IGitRepoRepository } from '../domain/repositories/IGitRepoRepository';
 import { createOrganizationId, createUserId } from '@packmind/types';
@@ -18,18 +19,7 @@ describe('GitRepoService', () => {
   });
 
   beforeEach(() => {
-    mockGitRepoRepository = {
-      add: jest.fn(),
-      findById: jest.fn(),
-      deleteById: jest.fn(),
-      restoreById: jest.fn(),
-      findByOwnerAndRepo: jest.fn(),
-      findByOwnerAndRepoInOrganization: jest.fn(),
-      findByProviderId: jest.fn(),
-      findByOrganizationId: jest.fn(),
-      list: jest.fn(),
-      findByOwnerRepoAndBranchInOrganization: jest.fn(),
-    } as unknown as jest.Mocked<IGitRepoRepository>;
+    mockGitRepoRepository = mockPort<IGitRepoRepository>();
 
     gitRepoService = new GitRepoService(mockGitRepoRepository);
   });

--- a/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
+++ b/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@packmind/types';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { gitProviderFactory } from '../../../../test';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 
 describe('AddGitProviderUseCase', () => {
   let useCase: AddGitProviderUseCase;
@@ -51,10 +51,9 @@ describe('AddGitProviderUseCase', () => {
       jest.Mocked<GitProviderService>
     > as jest.Mocked<GitProviderService>;
 
-    accountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(memberUser),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    accountsAdapter = mockPort<IAccountsPort>();
+    accountsAdapter.getUserById.mockResolvedValue(memberUser);
+    accountsAdapter.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new AddGitProviderUseCase(
       mockGitProviderService,

--- a/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
+++ b/packages/git/src/application/useCases/addGitProvider/AddGitProviderUseCase.spec.ts
@@ -17,7 +17,7 @@ import {
 } from '@packmind/types';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import { gitProviderFactory } from '../../../../test';
-import { stubLogger, mockPort } from '@packmind/test-utils';
+import { invalidInput, mockPort, stubLogger } from '@packmind/test-utils';
 
 describe('AddGitProviderUseCase', () => {
   let useCase: AddGitProviderUseCase;
@@ -144,7 +144,7 @@ describe('AddGitProviderUseCase', () => {
   describe('when git provider source is missing', () => {
     const input = {
       gitProvider: {
-        source: undefined as unknown as GitProviderVendor,
+        source: invalidInput<GitProviderVendor>(undefined),
         url: 'https://github.com',
         token: 'test-token',
         authMethod: 'token' as const,
@@ -516,7 +516,7 @@ describe('AddGitProviderUseCase', () => {
         // The route has no runtime DTO validation, so displayName can genuinely
         // be absent even though the command type declares it - that absence is
         // exactly what the cases below exercise.
-        displayName: undefined as unknown as string,
+        displayName: invalidInput<string>(undefined),
       },
       organizationId,
       userId: memberUser.id,
@@ -677,12 +677,12 @@ describe('AddGitProviderUseCase', () => {
           gitProviderFactory(),
         );
         await useCase.execute({
-          gitProvider: {
+          gitProvider: invalidInput<(typeof tokenInput)['gitProvider']>({
             source: GitProviderVendors.github,
             url: 'https://github.com',
             token: 'ghp_candidate',
             displayName: '',
-          } as unknown as (typeof tokenInput)['gitProvider'],
+          }),
           organizationId,
           userId: memberUser.id,
           verifyCredentials: true,

--- a/packages/git/src/application/useCases/addGitRepo/AddGitRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/addGitRepo/AddGitRepoUseCase.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '@packmind/types';
 
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { v4 as uuidv4 } from 'uuid';
 import { gitProviderFactory, gitRepoFactory } from '../../../../test';
 
@@ -76,10 +76,9 @@ describe('AddGitRepoUseCase', () => {
       slug: 'test-org',
     });
 
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(adminUser),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(adminUser);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new AddGitRepoUseCase(
       mockGitProviderService,

--- a/packages/git/src/application/useCases/checkBranchExists/CheckBranchExistsUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkBranchExists/CheckBranchExistsUseCase.spec.ts
@@ -5,14 +5,13 @@ import {
   createGitProviderId,
   createOrganizationId,
 } from '@packmind/types';
+import { invalidInput, mockPort } from '@packmind/test-utils';
 import { GitProviderService } from '../../GitProviderService';
 import { CheckBranchExistsUseCase } from './CheckBranchExistsUseCase';
 
 describe('CheckBranchExistsUseCase', () => {
   let useCase: CheckBranchExistsUseCase;
-  let mockGitProviderService: jest.Mocked<
-    Pick<GitProviderService, 'findGitProviderById' | 'checkBranchExists'>
-  >;
+  let mockGitProviderService: jest.Mocked<GitProviderService>;
 
   const providerId: GitProviderId = createGitProviderId(
     'de754fed-7659-4816-95c6-12e3a0b9e3c9',
@@ -43,14 +42,9 @@ describe('CheckBranchExistsUseCase', () => {
   const args = { owner: 'acme', repo: 'repo-a', branch: 'main' };
 
   beforeEach(() => {
-    mockGitProviderService = {
-      findGitProviderById: jest.fn(),
-      checkBranchExists: jest.fn(),
-    };
+    mockGitProviderService = mockPort<GitProviderService>();
 
-    useCase = new CheckBranchExistsUseCase(
-      mockGitProviderService as unknown as GitProviderService,
-    );
+    useCase = new CheckBranchExistsUseCase(mockGitProviderService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -144,7 +138,7 @@ describe('CheckBranchExistsUseCase', () => {
       it('rejects', async () => {
         await expect(
           useCase.execute({
-            gitProviderId: undefined as unknown as GitProviderId,
+            gitProviderId: invalidInput<GitProviderId>(undefined),
             ...args,
           }),
         ).rejects.toThrow('Git provider ID is required');

--- a/packages/git/src/application/useCases/checkDirectoryExistence/CheckDirectoryExistenceUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkDirectoryExistence/CheckDirectoryExistenceUseCase.spec.ts
@@ -12,7 +12,7 @@ import { GitRepoService } from '../../GitRepoService';
 import { GitProviderService } from '../../GitProviderService';
 import { IGitRepoFactory } from '../../../domain/repositories/IGitRepoFactory';
 import { IGitRepo } from '../../../domain/repositories/IGitRepo';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { PackmindLogger } from '@packmind/logger';
 import { gitRepoFactory, gitProviderFactory } from '../../../../test';
 
@@ -26,36 +26,13 @@ describe('CheckDirectoryExistenceUseCase', () => {
 
   beforeEach(() => {
     // Mock GitRepoService with its required methods
-    mockGitRepoService = {
-      findGitRepoById: jest.fn(),
-      addGitRepo: jest.fn(),
-      findGitRepoByOwnerAndRepo: jest.fn(),
-      findGitRepoByOwnerRepoAndBranchInOrganization: jest.fn(),
-      findGitReposByProviderId: jest.fn(),
-      findGitReposByOrganizationId: jest.fn(),
-      updateGitRepo: jest.fn(),
-      deleteGitRepo: jest.fn(),
-    } as unknown as jest.Mocked<GitRepoService>;
+    mockGitRepoService = mockPort<GitRepoService>();
 
     // Mock GitProviderService with its required methods
-    mockGitProviderService = {
-      findGitProviderById: jest.fn(),
-      addGitProvider: jest.fn(),
-      updateGitProvider: jest.fn(),
-      deleteGitProvider: jest.fn(),
-      listProviders: jest.fn(),
-      listAvailableRepositories: jest.fn(),
-      checkBranchExists: jest.fn(),
-      listAvailableTargets: jest.fn(),
-    } as unknown as jest.Mocked<GitProviderService>;
+    mockGitProviderService = mockPort<GitProviderService>();
 
     // Mock IGitRepo instance with checkDirectoryExists method
-    mockGitRepoInstance = {
-      checkDirectoryExists: jest.fn(),
-      getFileOnRepo: jest.fn(),
-      commitFiles: jest.fn(),
-      listDirectoriesOnRepo: jest.fn(),
-    } as unknown as jest.Mocked<IGitRepo>;
+    mockGitRepoInstance = mockPort<IGitRepo>();
 
     // Mock IGitRepoFactory
     mockGitRepoFactory = {

--- a/packages/git/src/application/useCases/checkProviderAuth/CheckProviderAuthUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkProviderAuth/CheckProviderAuthUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   createOrganizationId,
@@ -48,10 +48,9 @@ describe('CheckProviderAuthUseCase', () => {
       jest.Mocked<GitProviderService>
     > as jest.Mocked<GitProviderService>;
 
-    mockAccountsPort = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsPort = mockPort<IAccountsPort>();
+    mockAccountsPort.getUserById.mockResolvedValue(user);
+    mockAccountsPort.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new CheckProviderAuthUseCase(
       mockAccountsPort,

--- a/packages/git/src/application/useCases/checkTrackedBranchExists/CheckTrackedBranchExistsUseCase.spec.ts
+++ b/packages/git/src/application/useCases/checkTrackedBranchExists/CheckTrackedBranchExistsUseCase.spec.ts
@@ -1,5 +1,5 @@
 import { Cache } from '@packmind/node-utils';
-import { stubLogger } from '@packmind/test-utils';
+import { mockPort, stubLogger } from '@packmind/test-utils';
 import {
   GitRepo,
   createGitProviderId,
@@ -18,11 +18,7 @@ jest.mock('@packmind/node-utils', () => ({
   },
 }));
 
-const mockCacheInstance = {
-  get: jest.fn(),
-  set: jest.fn(),
-  invalidate: jest.fn(),
-} as jest.Mocked<Pick<Cache, 'get' | 'set' | 'invalidate'>>;
+const mockCacheInstance = mockPort<Cache>();
 const MockedCache = Cache as jest.Mocked<typeof Cache>;
 
 const repositoryId = createGitRepoId('repo-1');
@@ -42,22 +38,22 @@ const gitRepo = {
 
 describe('CheckTrackedBranchExistsUseCase', () => {
   let useCase: CheckTrackedBranchExistsUseCase;
-  let gitRepoService: jest.Mocked<Pick<GitRepoService, 'findGitRepoById'>>;
-  let checkBranchExists: jest.Mocked<Pick<CheckBranchExistsUseCase, 'execute'>>;
+  let gitRepoService: jest.Mocked<GitRepoService>;
+  let checkBranchExists: jest.Mocked<CheckBranchExistsUseCase>;
 
   beforeEach(() => {
-    gitRepoService = { findGitRepoById: jest.fn().mockResolvedValue(gitRepo) };
-    checkBranchExists = { execute: jest.fn().mockResolvedValue(true) };
+    gitRepoService = mockPort<GitRepoService>();
+    gitRepoService.findGitRepoById.mockResolvedValue(gitRepo);
+    checkBranchExists = mockPort<CheckBranchExistsUseCase>();
+    checkBranchExists.execute.mockResolvedValue(true);
 
-    MockedCache.getInstance.mockReturnValue(
-      mockCacheInstance as unknown as Cache,
-    );
+    MockedCache.getInstance.mockReturnValue(mockCacheInstance);
     mockCacheInstance.get.mockResolvedValue(null);
     mockCacheInstance.set.mockResolvedValue(undefined);
 
     useCase = new CheckTrackedBranchExistsUseCase(
-      gitRepoService as unknown as GitRepoService,
-      checkBranchExists as unknown as CheckBranchExistsUseCase,
+      gitRepoService,
+      checkBranchExists,
       stubLogger(),
     );
   });

--- a/packages/git/src/application/useCases/commitToGit/CommitToGitUseCase.spec.ts
+++ b/packages/git/src/application/useCases/commitToGit/CommitToGitUseCase.spec.ts
@@ -18,7 +18,7 @@ import {
   gitRepoFactory,
 } from '../../../../test';
 import { PackmindLogger } from '@packmind/logger';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { createOrganizationId } from '@packmind/types';
 
 describe('CommitToGitUseCase', () => {
@@ -30,30 +30,14 @@ describe('CommitToGitUseCase', () => {
   let mockGithubRepository: jest.Mocked<IGitRepo>;
 
   beforeEach(() => {
-    mockGitCommitService = {
-      addCommit: jest.fn(),
-      getCommit: jest.fn(),
-    } as unknown as jest.Mocked<GitCommitService>;
+    mockGitCommitService = mockPort<GitCommitService>();
 
-    mockGitProviderService = {
-      findGitProviderById: jest.fn(),
-      addGitProvider: jest.fn(),
-      findGitProvidersByOrganizationId: jest.fn(),
-      updateGitProvider: jest.fn(),
-      deleteGitProvider: jest.fn(),
-      getAvailableRepos: jest.fn(),
-      checkBranchExists: jest.fn(),
-    } as unknown as jest.Mocked<GitProviderService>;
+    mockGitProviderService = mockPort<GitProviderService>();
 
     mockLogger = stubLogger();
 
-    mockGithubRepository = {
-      commitFiles: jest.fn(),
-      getFileOnRepo: jest.fn(),
-      listDirectoriesOnRepo: jest.fn(),
-      checkDirectoryExists: jest.fn(),
-      listFilesInDirectories: jest.fn().mockResolvedValue([]),
-    } as unknown as jest.Mocked<IGitRepo>;
+    mockGithubRepository = mockPort<IGitRepo>();
+    mockGithubRepository.listFilesInDirectories.mockResolvedValue([]);
 
     mockGitRepoFactory = {
       createGitRepo: jest.fn().mockImplementation((gitRepo, provider) => {

--- a/packages/git/src/application/useCases/findOrCreateGitRepo/FindOrCreateGitRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/findOrCreateGitRepo/FindOrCreateGitRepoUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   createGitProviderId,
   createGitRepoId,
@@ -36,13 +36,7 @@ describe('FindOrCreateGitRepoUseCase', () => {
   };
 
   beforeEach(() => {
-    mockGitPort = {
-      listProviders: jest.fn(),
-      listRepos: jest.fn(),
-      listAvailableRepos: jest.fn(),
-      addGitProvider: jest.fn(),
-      addGitRepo: jest.fn(),
-    } as unknown as jest.Mocked<IGitPort>;
+    mockGitPort = mockPort<IGitPort>();
 
     const user: User = {
       id: userId,
@@ -57,10 +51,9 @@ describe('FindOrCreateGitRepoUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(user);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new FindOrCreateGitRepoUseCase(
       mockGitPort,

--- a/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
@@ -21,11 +21,7 @@ jest.mock('@packmind/node-utils', () => ({
 }));
 
 // Get the mocked Cache after the mock
-const mockCacheInstance = {
-  get: jest.fn(),
-  set: jest.fn(),
-  invalidate: jest.fn(),
-} as jest.Mocked<Pick<Cache, 'get' | 'set' | 'invalidate'>>;
+const mockCacheInstance = mockPort<Cache>();
 const MockedCache = Cache as jest.Mocked<typeof Cache>;
 
 describe('GetAvailableTargetsUseCase', () => {
@@ -36,9 +32,7 @@ describe('GetAvailableTargetsUseCase', () => {
     mockGitProviderService = mockPort<GitProviderService>();
 
     // Setup cache mock
-    MockedCache.getInstance.mockReturnValue(
-      mockCacheInstance as unknown as Cache,
-    );
+    MockedCache.getInstance.mockReturnValue(mockCacheInstance);
     mockCacheInstance.get.mockResolvedValue(null); // Default to cache miss
     mockCacheInstance.set.mockResolvedValue(undefined);
     mockCacheInstance.invalidate.mockResolvedValue(undefined);

--- a/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getAvailableRemoteDirectories/GetAvailableRemoteDirectoriesUseCase.spec.ts
@@ -1,5 +1,5 @@
 import { Cache } from '@packmind/node-utils';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   GetAvailableRemoteDirectoriesCommand,
   createOrganizationId,
@@ -33,16 +33,7 @@ describe('GetAvailableTargetsUseCase', () => {
   let mockGitProviderService: jest.Mocked<GitProviderService>;
 
   beforeEach(() => {
-    mockGitProviderService = {
-      addGitProvider: jest.fn(),
-      findGitProviderById: jest.fn(),
-      findGitProvidersByOrganizationId: jest.fn(),
-      updateGitProvider: jest.fn(),
-      deleteGitProvider: jest.fn(),
-      getAvailableRepos: jest.fn(),
-      checkBranchExists: jest.fn(),
-      listAvailableTargets: jest.fn(),
-    } as unknown as jest.Mocked<GitProviderService>;
+    mockGitProviderService = mockPort<GitProviderService>();
 
     // Setup cache mock
     MockedCache.getInstance.mockReturnValue(

--- a/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
@@ -10,6 +10,10 @@ import {
   GitProviderVendors,
 } from '@packmind/types';
 import { stubLogger, mockPort } from '@packmind/test-utils';
+import {
+  gitProviderFactory,
+  gitRepoFactory as gitRepoEntityFactory,
+} from '../../../../test';
 
 describe('GetFileFromRepoUseCase', () => {
   let useCase: GetFileFromRepoUseCase;
@@ -17,20 +21,17 @@ describe('GetFileFromRepoUseCase', () => {
   let gitRepoFactory: jest.Mocked<IGitRepoFactory>;
   let mockGitRepoInstance: jest.Mocked<IGitRepo>;
 
-  const mockGitRepoEntity: GitRepo = {
-    id: 'repo-123',
+  const mockGitRepoEntity: GitRepo = gitRepoEntityFactory({
     owner: 'test-owner',
     repo: 'test-repo',
     branch: 'main',
-    providerId: 'provider-123',
-  } as unknown as GitRepo;
+  });
 
-  const mockProvider: GitProvider = {
-    id: 'provider-123',
+  const mockProvider: GitProvider = gitProviderFactory({
     source: GitProviderVendors.github,
     token: 'test-token',
     authMethod: 'token',
-  } as unknown as GitProvider;
+  });
 
   beforeEach(() => {
     gitProviderRepository = mockPort<IGitProviderRepository>();
@@ -144,10 +145,8 @@ describe('GetFileFromRepoUseCase', () => {
 
   describe('when git provider token is not configured', () => {
     it('throws error', async () => {
-      const providerWithoutToken = { ...mockProvider, token: undefined };
-      gitProviderRepository.findById.mockResolvedValue(
-        providerWithoutToken as unknown as GitProvider,
-      );
+      const providerWithoutToken = gitProviderFactory({ token: null });
+      gitProviderRepository.findById.mockResolvedValue(providerWithoutToken);
 
       await expect(
         useCase.getFileFromRepo(mockGitRepoEntity, 'test-file.txt'),

--- a/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getFileFromRepo/GetFileFromRepoUseCase.spec.ts
@@ -8,7 +8,7 @@ import {
   GitProviderNotFoundError,
   GitProviderVendors,
 } from '@packmind/types';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 
 describe('GetFileFromRepoUseCase', () => {
   let useCase: GetFileFromRepoUseCase;
@@ -32,16 +32,9 @@ describe('GetFileFromRepoUseCase', () => {
   } as unknown as GitProvider;
 
   beforeEach(() => {
-    gitProviderService = {
-      findGitProviderById: jest.fn(),
-    } as unknown as jest.Mocked<GitProviderService>;
+    gitProviderService = mockPort<GitProviderService>();
 
-    mockGitRepoInstance = {
-      getFileOnRepo: jest.fn(),
-      commitFiles: jest.fn(),
-      listDirectoriesOnRepo: jest.fn(),
-      checkDirectoryExists: jest.fn(),
-    } as unknown as jest.Mocked<IGitRepo>;
+    mockGitRepoInstance = mockPort<IGitRepo>();
 
     gitRepoFactory = {
       createGitRepo: jest.fn().mockImplementation((_gitRepo, provider) => {

--- a/packages/git/src/application/useCases/getTrackedRepository/GetTrackedRepositoryUseCase.spec.ts
+++ b/packages/git/src/application/useCases/getTrackedRepository/GetTrackedRepositoryUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   createGitProviderId,
   createGitRepoId,
@@ -57,10 +57,9 @@ describe('GetTrackedRepositoryUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(user);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new GetTrackedRepositoryUseCase(
       mockGitRepoService,

--- a/packages/git/src/application/useCases/listAvailableRepos/ListAvailableReposUseCase.spec.ts
+++ b/packages/git/src/application/useCases/listAvailableRepos/ListAvailableReposUseCase.spec.ts
@@ -6,14 +6,13 @@ import {
   createGitProviderId,
   createOrganizationId,
 } from '@packmind/types';
+import { invalidInput, mockPort } from '@packmind/test-utils';
 import { GitProviderService } from '../../GitProviderService';
 import { ListAvailableReposUseCase } from './ListAvailableReposUseCase';
 
 describe('ListAvailableReposUseCase', () => {
   let useCase: ListAvailableReposUseCase;
-  let mockGitProviderService: jest.Mocked<
-    Pick<GitProviderService, 'findGitProviderById' | 'getAvailableRepos'>
-  >;
+  let mockGitProviderService: jest.Mocked<GitProviderService>;
 
   const providerId: GitProviderId = createGitProviderId(
     'de754fed-7659-4816-95c6-12e3a0b9e3c9',
@@ -55,14 +54,9 @@ describe('ListAvailableReposUseCase', () => {
   } as GitProvider;
 
   beforeEach(() => {
-    mockGitProviderService = {
-      findGitProviderById: jest.fn(),
-      getAvailableRepos: jest.fn(),
-    };
+    mockGitProviderService = mockPort<GitProviderService>();
 
-    useCase = new ListAvailableReposUseCase(
-      mockGitProviderService as unknown as GitProviderService,
-    );
+    useCase = new ListAvailableReposUseCase(mockGitProviderService);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -182,7 +176,7 @@ describe('ListAvailableReposUseCase', () => {
         await expect(
           useCase.execute({
             ...baseCommand,
-            gitProviderId: undefined as unknown as GitProviderId,
+            gitProviderId: invalidInput<GitProviderId>(undefined),
           }),
         ).rejects.toThrow('Git provider ID is required');
       });
@@ -202,7 +196,7 @@ describe('ListAvailableReposUseCase', () => {
       it('rejects', async () => {
         mockGitProviderService.findGitProviderById.mockResolvedValue({
           ...tokenProvider,
-          source: undefined as unknown as GitProvider['source'],
+          source: invalidInput<GitProvider['source']>(undefined),
         });
 
         await expect(

--- a/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
+++ b/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   createOrganizationId,
@@ -46,10 +46,9 @@ describe('ListProvidersUseCase', () => {
       jest.Mocked<GitProviderService>
     > as jest.Mocked<GitProviderService>;
 
-    mockAccountsPort = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsPort = mockPort<IAccountsPort>();
+    mockAccountsPort.getUserById.mockResolvedValue(user);
+    mockAccountsPort.getOrganizationById.mockResolvedValue(organization);
 
     useCase = new ListProvidersUseCase(
       mockAccountsPort,

--- a/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
+++ b/packages/git/src/application/useCases/listProviders/ListProvidersUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger, mockPort } from '@packmind/test-utils';
+import { invalidInput, mockPort, stubLogger } from '@packmind/test-utils';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   createOrganizationId,
@@ -185,7 +185,7 @@ describe('ListProvidersUseCase', () => {
             organizationId,
             token: null,
             authMethod: 'app',
-            appInstallationId: '42' as unknown as number,
+            appInstallationId: invalidInput<number>('42'),
           });
           mockGitProviderService.findGitProvidersByOrganizationId.mockResolvedValue(
             [provider],

--- a/packages/git/src/application/useCases/removeTrackedRepository/RemoveTrackedRepositoryUseCase.spec.ts
+++ b/packages/git/src/application/useCases/removeTrackedRepository/RemoveTrackedRepositoryUseCase.spec.ts
@@ -1,6 +1,6 @@
 import { PackmindEventEmitterService } from '@packmind/node-utils';
 import { OrganizationAdminRequiredError } from '@packmind/node-utils';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   createGitProviderId,
   createGitRepoId,
@@ -61,10 +61,9 @@ describe('RemoveTrackedRepositoryUseCase', () => {
       name: 'PickMand',
       slug: 'pickmand',
     };
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(user);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
   };
 
   const buildUseCase = () =>
@@ -82,9 +81,7 @@ describe('RemoveTrackedRepositoryUseCase', () => {
       markTrackingRemoved: jest.fn(),
     } as Partial<jest.Mocked<GitRepoService>> as jest.Mocked<GitRepoService>;
 
-    mockEventEmitter = {
-      emit: jest.fn(),
-    } as unknown as jest.Mocked<PackmindEventEmitterService>;
+    mockEventEmitter = mockPort<PackmindEventEmitterService>();
 
     setupAccounts('admin');
     useCase = buildUseCase();

--- a/packages/git/src/application/useCases/setTrackedRepository/SetTrackedRepositoryUseCase.spec.ts
+++ b/packages/git/src/application/useCases/setTrackedRepository/SetTrackedRepositoryUseCase.spec.ts
@@ -1,6 +1,6 @@
 import { PackmindEventEmitterService } from '@packmind/node-utils';
 import { OrganizationAdminRequiredError } from '@packmind/node-utils';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   createGitProviderId,
   createGitRepoId,
@@ -55,10 +55,9 @@ describe('SetTrackedRepositoryUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(user);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
   };
 
   const buildUseCase = () =>
@@ -80,9 +79,7 @@ describe('SetTrackedRepositoryUseCase', () => {
       execute: jest.fn(),
     } as jest.Mocked<IFindOrCreateGitRepoUseCase>;
 
-    mockEventEmitter = {
-      emit: jest.fn(),
-    } as unknown as jest.Mocked<PackmindEventEmitterService>;
+    mockEventEmitter = mockPort<PackmindEventEmitterService>();
 
     setupAccounts('admin');
     useCase = buildUseCase();

--- a/packages/git/src/application/useCases/updateGitProvider/UpdateGitProviderUseCase.spec.ts
+++ b/packages/git/src/application/useCases/updateGitProvider/UpdateGitProviderUseCase.spec.ts
@@ -1,4 +1,4 @@
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { organizationFactory, userFactory } from '@packmind/accounts/test';
 import {
   GitProviderDisplayNameAlreadyUsedError,
@@ -62,10 +62,9 @@ describe('UpdateGitProviderUseCase', () => {
       jest.Mocked<GitProviderService>
     > as jest.Mocked<GitProviderService>;
 
-    accountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(adminUser),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    accountsAdapter = mockPort<IAccountsPort>();
+    accountsAdapter.getUserById.mockResolvedValue(adminUser);
+    accountsAdapter.getOrganizationById.mockResolvedValue(organization);
 
     useCase = makeUseCase('on-prem');
   });

--- a/packages/git/src/application/useCases/updateTrackedBranch/UpdateTrackedBranchUseCase.spec.ts
+++ b/packages/git/src/application/useCases/updateTrackedBranch/UpdateTrackedBranchUseCase.spec.ts
@@ -2,7 +2,7 @@ import {
   OrganizationAdminRequiredError,
   PackmindEventEmitterService,
 } from '@packmind/node-utils';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import {
   createGitProviderId,
   createGitRepoId,
@@ -71,10 +71,9 @@ describe('UpdateTrackedBranchUseCase', () => {
       name: 'Test Org',
       slug: 'test-org',
     };
-    mockAccountsAdapter = {
-      getUserById: jest.fn().mockResolvedValue(user),
-      getOrganizationById: jest.fn().mockResolvedValue(organization),
-    } as unknown as jest.Mocked<IAccountsPort>;
+    mockAccountsAdapter = mockPort<IAccountsPort>();
+    mockAccountsAdapter.getUserById.mockResolvedValue(user);
+    mockAccountsAdapter.getOrganizationById.mockResolvedValue(organization);
   };
 
   const buildUseCase = () =>
@@ -103,9 +102,7 @@ describe('UpdateTrackedBranchUseCase', () => {
       execute: jest.fn(),
     } as jest.Mocked<IFindOrCreateGitRepoUseCase>;
 
-    mockEventEmitter = {
-      emit: jest.fn(),
-    } as unknown as jest.Mocked<PackmindEventEmitterService>;
+    mockEventEmitter = mockPort<PackmindEventEmitterService>();
 
     setupAccounts('admin');
     useCase = buildUseCase();

--- a/packages/git/src/infra/repositories/github/GithubProvider.spec.ts
+++ b/packages/git/src/infra/repositories/github/GithubProvider.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { GithubProvider } from './GithubProvider';
 import { IGithubTokenResolver } from '../../../domain/repositories/IGithubTokenResolver';
 import { PackmindLogger } from '@packmind/logger';
@@ -33,8 +33,8 @@ describe('GithubProvider', () => {
     };
 
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
-    (mockedAxios.isAxiosError as unknown as jest.Mock).mockImplementation(
-      (payload) =>
+    mockedAxios.isAxiosError.mockImplementation(
+      (payload): payload is AxiosError =>
         typeof payload === 'object' &&
         payload !== null &&
         (payload as { isAxiosError?: boolean }).isAxiosError === true,

--- a/packages/git/src/infra/repositories/github/GithubProvider.spec.ts
+++ b/packages/git/src/infra/repositories/github/GithubProvider.spec.ts
@@ -1,10 +1,11 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { GithubProvider } from './GithubProvider';
 import { IGithubTokenResolver } from '../../../domain/repositories/IGithubTokenResolver';
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 
 jest.mock('axios');
+const actualAxios = jest.requireActual<typeof axios>('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const stubResolver = (
@@ -33,12 +34,7 @@ describe('GithubProvider', () => {
     };
 
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
-    mockedAxios.isAxiosError.mockImplementation(
-      (payload): payload is AxiosError =>
-        typeof payload === 'object' &&
-        payload !== null &&
-        (payload as { isAxiosError?: boolean }).isAxiosError === true,
-    );
+    mockedAxios.isAxiosError.mockImplementation(actualAxios.isAxiosError);
 
     githubProvider = new GithubProvider(stubResolver(), mockLogger);
   });

--- a/packages/git/src/infra/repositories/github/GithubRepository.spec.ts
+++ b/packages/git/src/infra/repositories/github/GithubRepository.spec.ts
@@ -3,7 +3,7 @@ import { GithubRepository, GithubRepositoryOptions } from './GithubRepository';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { IGithubTokenResolver } from '../../../domain/repositories/IGithubTokenResolver';
 import { PackmindLogger } from '@packmind/logger';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { gitBlobSha } from '@packmind/node-utils';
 import {
   PROVIDER_MAX_SOCKETS,
@@ -31,12 +31,12 @@ describe('GithubRepository', () => {
   };
 
   beforeEach(() => {
-    mockAxiosInstance = {
+    mockAxiosInstance = mockPort<typeof axios>({
       interceptors: {
-        request: { use: jest.fn() },
-        response: { use: jest.fn() },
+        request: { use: jest.fn(), eject: jest.fn(), clear: jest.fn() },
+        response: { use: jest.fn(), eject: jest.fn(), clear: jest.fn() },
       },
-    } as unknown as jest.Mocked<typeof axios>;
+    });
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
 
     stubbedLogger = stubLogger();

--- a/packages/git/src/infra/repositories/github/GithubRepository.spec.ts
+++ b/packages/git/src/infra/repositories/github/GithubRepository.spec.ts
@@ -3,7 +3,7 @@ import { GithubRepository, GithubRepositoryOptions } from './GithubRepository';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { IGithubTokenResolver } from '../../../domain/repositories/IGithubTokenResolver';
 import { PackmindLogger } from '@packmind/logger';
-import { stubLogger, mockPort } from '@packmind/test-utils';
+import { stubLogger } from '@packmind/test-utils';
 import { gitBlobSha } from '@packmind/node-utils';
 import {
   PROVIDER_MAX_SOCKETS,
@@ -31,12 +31,14 @@ describe('GithubRepository', () => {
   };
 
   beforeEach(() => {
-    mockAxiosInstance = mockPort<typeof axios>({
+    // An AxiosInstance is callable and mostly data, so it is mocked by hand
+    // rather than with mockPort: only what this suite drives is stubbed.
+    mockAxiosInstance = {
       interceptors: {
         request: { use: jest.fn(), eject: jest.fn(), clear: jest.fn() },
         response: { use: jest.fn(), eject: jest.fn(), clear: jest.fn() },
       },
-    });
+    } as Partial<jest.Mocked<typeof axios>> as jest.Mocked<typeof axios>;
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
 
     stubbedLogger = stubLogger();

--- a/packages/git/src/infra/repositories/github/auth/GithubTokenResolverFactory.spec.ts
+++ b/packages/git/src/infra/repositories/github/auth/GithubTokenResolverFactory.spec.ts
@@ -12,6 +12,7 @@ import {
   createOrganizationId,
   createOrganizationGitHubAppId,
 } from '@packmind/types';
+import { mockPort } from '@packmind/test-utils';
 import { IOrganizationGitHubAppRepository } from '../../../../domain/repositories/IOrganizationGitHubAppRepository';
 
 const makeProvider = (overrides: Partial<GitProvider> = {}): GitProvider =>
@@ -49,23 +50,14 @@ class StubConfig implements IConfigProvider {
   }
 }
 
-class StubOrgGitHubAppRepository implements Pick<
-  IOrganizationGitHubAppRepository,
-  'findActiveByOrganizationId' | 'findById'
-> {
-  constructor(
-    private readonly result: OrganizationGitHubApp | null,
-    private readonly findByIdResult: OrganizationGitHubApp | null = result,
-  ) {}
-
-  async findActiveByOrganizationId(): Promise<OrganizationGitHubApp | null> {
-    return this.result;
-  }
-
-  async findById(): Promise<OrganizationGitHubApp | null> {
-    return this.findByIdResult;
-  }
-}
+const stubOrgGitHubAppRepository = (
+  result: OrganizationGitHubApp | null,
+  findByIdResult: OrganizationGitHubApp | null = result,
+): jest.Mocked<IOrganizationGitHubAppRepository> =>
+  mockPort<IOrganizationGitHubAppRepository>({
+    findActiveByOrganizationId: async () => result,
+    findById: async () => findByIdResult,
+  });
 
 describe('GithubTokenResolverFactory', () => {
   afterEach(() => jest.clearAllMocks());
@@ -185,12 +177,12 @@ describe('GithubTokenResolverFactory', () => {
   describe('authMethod = "app", mode = "on-prem"', () => {
     it('looks up OrganizationGitHubApp by the provider FK and returns AppInstallationTokenResolver', async () => {
       const orgApp = makeOrgApp();
-      const repo = new StubOrgGitHubAppRepository(null, orgApp);
+      const repo = stubOrgGitHubAppRepository(null, orgApp);
       const factory = new GithubTokenResolverFactory(
         new StubConfig({}),
         'on-prem',
         undefined,
-        repo as unknown as IOrganizationGitHubAppRepository,
+        repo,
       );
       const provider = makeProvider({
         authMethod: 'app',
@@ -208,12 +200,12 @@ describe('GithubTokenResolverFactory', () => {
         const orgApp = makeOrgApp({
           revokedAt: new Date('2026-05-01T00:00:00Z'),
         });
-        const repo = new StubOrgGitHubAppRepository(null, orgApp);
+        const repo = stubOrgGitHubAppRepository(null, orgApp);
         const factory = new GithubTokenResolverFactory(
           new StubConfig({}),
           'on-prem',
           undefined,
-          repo as unknown as IOrganizationGitHubAppRepository,
+          repo,
         );
         const provider = makeProvider({
           authMethod: 'app',
@@ -229,12 +221,12 @@ describe('GithubTokenResolverFactory', () => {
 
     describe('when the referenced OrganizationGitHubApp does not exist', () => {
       it('throws', async () => {
-        const repo = new StubOrgGitHubAppRepository(null, null);
+        const repo = stubOrgGitHubAppRepository(null, null);
         const factory = new GithubTokenResolverFactory(
           new StubConfig({}),
           'on-prem',
           undefined,
-          repo as unknown as IOrganizationGitHubAppRepository,
+          repo,
         );
         const provider = makeProvider({
           authMethod: 'app',
@@ -251,12 +243,12 @@ describe('GithubTokenResolverFactory', () => {
     describe('when the GitProvider has no organizationGitHubAppId FK', () => {
       it('throws', async () => {
         const orgApp = makeOrgApp();
-        const repo = new StubOrgGitHubAppRepository(null, orgApp);
+        const repo = stubOrgGitHubAppRepository(null, orgApp);
         const factory = new GithubTokenResolverFactory(
           new StubConfig({}),
           'on-prem',
           undefined,
-          repo as unknown as IOrganizationGitHubAppRepository,
+          repo,
         );
         const provider = makeProvider({
           authMethod: 'app',
@@ -413,12 +405,12 @@ describe('GithubTokenResolverFactory', () => {
     describe('when GITHUB_APP_SLUG is not set', () => {
       it('uses on-prem mode and reads OrganizationGitHubApp via FK', async () => {
         const orgApp = makeOrgApp();
-        const repo = new StubOrgGitHubAppRepository(null, orgApp);
+        const repo = stubOrgGitHubAppRepository(null, orgApp);
         const factory = new GithubTokenResolverFactory(
           new StubConfig({}),
           undefined,
           undefined,
-          repo as unknown as IOrganizationGitHubAppRepository,
+          repo,
         );
         const provider = makeProvider({
           authMethod: 'app',

--- a/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
@@ -1,12 +1,13 @@
 import { GitlabProvider } from './GitlabProvider';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
-import { AxiosError, AxiosInstance } from 'axios';
+import { AxiosInstance } from 'axios';
 import { stubLogger } from '@packmind/test-utils';
 import axios from 'axios';
 
 // Mock axios
 jest.mock('axios');
+const actualAxios = jest.requireActual<typeof axios>('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 // An AxiosInstance is callable and mostly data, so it is mocked by hand rather
 // than with mockPort: only the verbs this suite drives are stubbed.
@@ -24,12 +25,7 @@ describe('GitlabProvider', () => {
   beforeEach(() => {
     mockLogger = stubLogger();
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
-    mockedAxios.isAxiosError.mockImplementation(
-      (payload): payload is AxiosError =>
-        typeof payload === 'object' &&
-        payload !== null &&
-        (payload as { isAxiosError?: boolean }).isAxiosError === true,
-    );
+    mockedAxios.isAxiosError.mockImplementation(actualAxios.isAxiosError);
     gitlabProvider = new GitlabProvider('test-token', '', mockLogger);
   });
 

--- a/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
@@ -1,7 +1,7 @@
 import { GitlabProvider } from './GitlabProvider';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
-import { AxiosInstance } from 'axios';
+import { AxiosError, AxiosInstance } from 'axios';
 import { stubLogger } from '@packmind/test-utils';
 import axios from 'axios';
 
@@ -24,8 +24,8 @@ describe('GitlabProvider', () => {
   beforeEach(() => {
     mockLogger = stubLogger();
     mockedAxios.create.mockReturnValue(mockAxiosInstance);
-    (mockedAxios.isAxiosError as unknown as jest.Mock).mockImplementation(
-      (payload) =>
+    mockedAxios.isAxiosError.mockImplementation(
+      (payload): payload is AxiosError =>
         typeof payload === 'object' &&
         payload !== null &&
         (payload as { isAxiosError?: boolean }).isAxiosError === true,

--- a/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
@@ -2,13 +2,20 @@ import { GitlabProvider } from './GitlabProvider';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
 import { AxiosInstance } from 'axios';
-import { stubLogger, mockPort } from '@packmind/test-utils';
+import { stubLogger } from '@packmind/test-utils';
 import axios from 'axios';
 
 // Mock axios
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-const mockAxiosInstance = mockPort<AxiosInstance>();
+// An AxiosInstance is callable and mostly data, so it is mocked by hand rather
+// than with mockPort: only the verbs this suite drives are stubbed.
+const mockAxiosInstance = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+} as Partial<jest.Mocked<AxiosInstance>> as jest.Mocked<AxiosInstance>;
 
 describe('GitlabProvider', () => {
   let gitlabProvider: GitlabProvider;

--- a/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabProvider.spec.ts
@@ -2,18 +2,13 @@ import { GitlabProvider } from './GitlabProvider';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
 import { AxiosInstance } from 'axios';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import axios from 'axios';
 
 // Mock axios
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-const mockAxiosInstance = {
-  get: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-  delete: jest.fn(),
-} as unknown as jest.Mocked<AxiosInstance>;
+const mockAxiosInstance = mockPort<AxiosInstance>();
 
 describe('GitlabProvider', () => {
   let gitlabProvider: GitlabProvider;

--- a/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
@@ -1,14 +1,21 @@
 import { GitlabRepository } from './GitlabRepository';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
-import { stubLogger, mockPort } from '@packmind/test-utils';
+import { stubLogger } from '@packmind/test-utils';
 import { GitlabRepositoryOptions } from './types';
 import axios, { AxiosInstance } from 'axios';
 
 // Mock axios
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-const mockAxiosInstance = mockPort<AxiosInstance>();
+// An AxiosInstance is callable and mostly data, so it is mocked by hand rather
+// than with mockPort: only the verbs this suite drives are stubbed.
+const mockAxiosInstance = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  patch: jest.fn(),
+} as Partial<jest.Mocked<AxiosInstance>> as jest.Mocked<AxiosInstance>;
 
 describe('GitlabRepository', () => {
   let gitlabRepository: GitlabRepository;

--- a/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
+++ b/packages/git/src/infra/repositories/gitlab/GitlabRepository.spec.ts
@@ -1,19 +1,14 @@
 import { GitlabRepository } from './GitlabRepository';
 import { PROVIDER_REQUEST_TIMEOUT_MS } from '../http/withTransientRetry';
 import { PackmindLogger } from '@packmind/logger';
-import { stubLogger } from '@packmind/test-utils';
+import { stubLogger, mockPort } from '@packmind/test-utils';
 import { GitlabRepositoryOptions } from './types';
 import axios, { AxiosInstance } from 'axios';
 
 // Mock axios
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
-const mockAxiosInstance = {
-  get: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-  patch: jest.fn(),
-} as unknown as jest.Mocked<AxiosInstance>;
+const mockAxiosInstance = mockPort<AxiosInstance>();
 
 describe('GitlabRepository', () => {
   let gitlabRepository: GitlabRepository;

--- a/packages/git/src/infra/repositories/http/withTransientRetry.spec.ts
+++ b/packages/git/src/infra/repositories/http/withTransientRetry.spec.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 import {
@@ -7,6 +7,7 @@ import {
 } from './withTransientRetry';
 
 jest.mock('axios');
+const actualAxios = jest.requireActual<typeof axios>('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const axiosError = (status?: number) => ({
@@ -19,12 +20,7 @@ describe('withTransientRetry', () => {
 
   beforeEach(() => {
     logger = stubLogger();
-    mockedAxios.isAxiosError.mockImplementation(
-      (payload): payload is AxiosError =>
-        typeof payload === 'object' &&
-        payload !== null &&
-        (payload as { isAxiosError?: boolean }).isAxiosError === true,
-    );
+    mockedAxios.isAxiosError.mockImplementation(actualAxios.isAxiosError);
   });
 
   afterEach(() => {

--- a/packages/git/src/infra/repositories/http/withTransientRetry.spec.ts
+++ b/packages/git/src/infra/repositories/http/withTransientRetry.spec.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { PackmindLogger } from '@packmind/logger';
 import { stubLogger } from '@packmind/test-utils';
 import {
@@ -19,8 +19,8 @@ describe('withTransientRetry', () => {
 
   beforeEach(() => {
     logger = stubLogger();
-    (mockedAxios.isAxiosError as unknown as jest.Mock).mockImplementation(
-      (payload) =>
+    mockedAxios.isAxiosError.mockImplementation(
+      (payload): payload is AxiosError =>
         typeof payload === 'object' &&
         payload !== null &&
         (payload as { isAxiosError?: boolean }).isAxiosError === true,

--- a/packages/test-utils/CLAUDE.md
+++ b/packages/test-utils/CLAUDE.md
@@ -46,6 +46,21 @@ const gitRepo = mockPort<IGitRepo>();
 gitRepo.getFileOnRepo.mockResolvedValue({ sha, content }); // checked against IGitRepo
 ```
 
+A complete mock is a quiet one: a member nobody stubbed answers `undefined`, so the day the code
+under test starts calling one this spec never set up, the call goes through and the test may still
+pass — where a hand-written partial mock would have thrown `is not a function`. Pass
+`{ strict: true }` where that silence would hide something, and the call is refused by name instead:
+
+```ts
+const gitRepo = mockPort<IGitRepo>({}, { strict: true });
+gitRepo.commitFiles(files, 'message');
+// Error: mockPort: 'commitFiles' was called but was never stubbed
+```
+
+The price is that every member the run reaches has to be stubbed, so it suits a spec asserting on a
+narrow interaction rather than one driving a whole use case. Note that `jest.resetAllMocks()` and
+`resetMocks` in a jest config drop the refusal along with every other implementation.
+
 `createTestDatasourceFixture` is the preferred shape for repository specs: `initialize()` in
 `beforeAll`, `cleanup()` in `afterEach`, `destroy()` in `afterAll`. Its own doc comment carries a
 worked example.

--- a/packages/test-utils/CLAUDE.md
+++ b/packages/test-utils/CLAUDE.md
@@ -28,8 +28,23 @@ own — most of what a new spec needs already exists.
 | `randomIn` | pick a random value from a set, for factory defaults |
 | `stubLogger` | fully typed `PackmindLogger` stub |
 | `createMockInstance` | typed mock of a whole class |
+| `mockPort` | typed mock of an interface — the counterpart for ports, which have no class to walk |
 | `skipWhenRoot` | skip specs that cannot run as `root` (filesystem-permission tests) |
 | `src/repository/` | shared repository-test helpers |
+
+## Mocking a port
+
+Reach for `mockPort<IPort>()` rather than an object literal cast with
+`as unknown as jest.Mocked<IPort>`. The cast switches off the structural check the spec type check
+exists for: members the mock omits are invisible until the test blows up at runtime, and a value
+stubbed inside the literal (`findById: jest.fn().mockResolvedValue(…)`) is never compared to the
+contract, because a bare `jest.fn()` is typed `any`. `mockPort` backs every member with a
+`jest.fn()` lazily, so the mock is complete by construction, and stubs are typed:
+
+```ts
+const gitRepo = mockPort<IGitRepo>();
+gitRepo.getFileOnRepo.mockResolvedValue({ sha, content }); // checked against IGitRepo
+```
 
 `createTestDatasourceFixture` is the preferred shape for repository specs: `initialize()` in
 `beforeAll`, `cleanup()` in `afterEach`, `destroy()` in `afterAll`. Its own doc comment carries a

--- a/packages/test-utils/project.json
+++ b/packages/test-utils/project.json
@@ -5,7 +5,11 @@
   "projectType": "library",
   "tags": ["type:util", "scope:test", "env:node"],
   "targets": {
-    "typecheck": {},
+    "typecheck": {
+      "options": {
+        "command": "tsc --noEmit --project packages/test-utils/tsconfig.lib.json && tsc --noEmit --project packages/test-utils/tsconfig.spec.json"
+      }
+    },
     "build": {
       "executor": "@nx/js:swc",
       "outputs": ["{options.outputPath}"],

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -12,3 +12,4 @@ export * from './logger/stubLogger';
 export * from './skipWhenRoot';
 export * from './repository';
 export * from './createMockInstance';
+export * from './mockPort';

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -13,3 +13,4 @@ export * from './skipWhenRoot';
 export * from './repository';
 export * from './createMockInstance';
 export * from './mockPort';
+export * from './invalidInput';

--- a/packages/test-utils/src/invalidInput.ts
+++ b/packages/test-utils/src/invalidInput.ts
@@ -1,0 +1,22 @@
+/**
+ * A value that breaks the contract of the parameter it is given to, for the
+ * tests that exercise what the code does when a caller sends one anyway: an
+ * untyped JavaScript caller, a wire payload, an older client, a route with no
+ * runtime validation behind it.
+ *
+ * ```ts
+ * await useCase.execute({
+ *   gitProviderId: invalidInput<GitProviderId>(undefined),
+ *   ...command,
+ * });
+ * ```
+ *
+ * The cast such a test needs lives here, once and under a name, rather than as
+ * an `as unknown as` in each spec. It buys no type safety - nothing can, since
+ * the whole point is a value the type forbids - but it tells a reader which
+ * casts are deliberate, so the ones that are merely a mock that stopped
+ * matching its port stand out instead of blending in.
+ */
+export function invalidInput<T>(value: unknown): T {
+  return value as T;
+}

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -10,10 +10,25 @@ interface IPortWithData {
   name: string;
 }
 
+interface IPortWithOptionalMethod {
+  close?(): void;
+}
+
+const iterate = Symbol('iterate');
+
+interface IPortWithSymbolMethod {
+  [iterate](): string[];
+}
+
 // A data member has no mock to fall back on, so the signature demands it.
 // @ts-expect-error 'name' is missing
 const rejectsAMissingDataMember = () => mockPort<IPortWithData>({});
 void rejectsAMissingDataMember;
+
+// A symbol-keyed member is never auto-mocked, so it is demanded the same way.
+// @ts-expect-error the symbol member is missing
+const rejectsAMissingSymbolMember = () => mockPort<IPortWithSymbolMethod>({});
+void rejectsAMissingSymbolMember;
 
 describe('mockPort', () => {
   afterEach(() => {
@@ -89,6 +104,34 @@ describe('mockPort', () => {
       const port = mockPort<IPortWithData>({ name: 'a name' });
 
       expect(jest.isMockFunction(port.findById)).toBe(true);
+    });
+  });
+
+  describe('when the port declares an optional method', () => {
+    it('takes an implementation for it', () => {
+      const port = mockPort<IPortWithOptionalMethod>({
+        close: () => undefined,
+      });
+
+      port.close?.();
+
+      expect(port.close).toHaveBeenCalled();
+    });
+
+    it('mocks it even when it is left out', () => {
+      const port = mockPort<IPortWithOptionalMethod>();
+
+      expect(jest.isMockFunction(port.close)).toBe(true);
+    });
+  });
+
+  describe('when the port declares a symbol-keyed method', () => {
+    it('records the calls made through the member it was given', () => {
+      const port = mockPort<IPortWithSymbolMethod>({ [iterate]: () => [] });
+
+      port[iterate]();
+
+      expect(port[iterate]).toHaveBeenCalled();
     });
   });
 

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -1,4 +1,4 @@
-import { mockPort } from './mockPort';
+import { mockPort, UnstubbedPortCallError } from './mockPort';
 
 interface ITestPort {
   findById(id: string): Promise<{ id: string } | null>;
@@ -167,15 +167,15 @@ describe('mockPort', () => {
     it('refuses a call to a member that was never stubbed', () => {
       const port = mockPort<ITestPort>({}, { strict: true });
 
-      expect(() => port.findById('id')).toThrow(
-        /was called but was never stubbed/,
-      );
+      expect(() => port.findById('id')).toThrow(UnstubbedPortCallError);
     });
 
     it('names the member it refused', () => {
       const port = mockPort<ITestPort>({}, { strict: true });
 
-      expect(() => port.findById('id')).toThrow(/findById/);
+      expect(() => port.findById('id')).toThrow(
+        new UnstubbedPortCallError('findById'),
+      );
     });
 
     it('lets a member seeded up front through', async () => {

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -1,0 +1,79 @@
+import { mockPort } from './mockPort';
+
+interface ITestPort {
+  findById(id: string): Promise<{ id: string } | null>;
+  save(value: { id: string }): Promise<void>;
+  name: string;
+}
+
+describe('mockPort', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('backs every member with a jest mock', () => {
+    const port = mockPort<ITestPort>();
+
+    expect(jest.isMockFunction(port.findById)).toBe(true);
+  });
+
+  it('returns the same mock on every access', () => {
+    const port = mockPort<ITestPort>();
+
+    expect(port.findById).toBe(port.findById);
+  });
+
+  it('records the calls made through the port', async () => {
+    const port = mockPort<ITestPort>();
+
+    await port.save({ id: 'id' });
+
+    expect(port.save).toHaveBeenCalledWith({ id: 'id' });
+  });
+
+  describe('when a member is stubbed with an implementation', () => {
+    it('resolves the value the implementation returns', async () => {
+      const port = mockPort<ITestPort>({
+        findById: async () => ({ id: 'stubbed' }),
+      });
+
+      await expect(port.findById('id')).resolves.toEqual({ id: 'stubbed' });
+    });
+
+    it('still records the calls', async () => {
+      const port = mockPort<ITestPort>({
+        findById: async () => ({ id: 'stubbed' }),
+      });
+
+      await port.findById('id');
+
+      expect(port.findById).toHaveBeenCalledWith('id');
+    });
+  });
+
+  describe('when a member is stubbed with a mock', () => {
+    it('keeps the mock as provided', () => {
+      const findById = jest.fn().mockResolvedValue(null);
+      const port = mockPort<ITestPort>({ findById });
+
+      expect(port.findById).toBe(findById);
+    });
+  });
+
+  describe('when a member is stubbed after construction', () => {
+    it('resolves the configured value', async () => {
+      const port = mockPort<ITestPort>();
+      port.findById.mockResolvedValue({ id: 'configured' });
+
+      await expect(port.findById('id')).resolves.toEqual({ id: 'configured' });
+    });
+  });
+
+  describe('when the mock is awaited', () => {
+    it('does not behave as a thenable', async () => {
+      const port = mockPort<ITestPort>();
+
+      await expect(Promise.resolve(port)).resolves.toBe(port);
+    });
+  });
+});

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -163,6 +163,44 @@ describe('mockPort', () => {
     });
   });
 
+  describe('when the mock is strict', () => {
+    it('refuses a call to a member that was never stubbed', () => {
+      const port = mockPort<ITestPort>({}, { strict: true });
+
+      expect(() => port.findById('id')).toThrow(
+        /was called but was never stubbed/,
+      );
+    });
+
+    it('names the member it refused', () => {
+      const port = mockPort<ITestPort>({}, { strict: true });
+
+      expect(() => port.findById('id')).toThrow(/findById/);
+    });
+
+    it('lets a member seeded up front through', async () => {
+      const port = mockPort<ITestPort>(
+        { findById: async () => ({ id: 'seeded' }) },
+        { strict: true },
+      );
+
+      await expect(port.findById('id')).resolves.toEqual({ id: 'seeded' });
+    });
+
+    it('lets a member stubbed afterwards through', async () => {
+      const port = mockPort<ITestPort>({}, { strict: true });
+      port.findById.mockResolvedValue({ id: 'stubbed' });
+
+      await expect(port.findById('id')).resolves.toEqual({ id: 'stubbed' });
+    });
+
+    it('still lets an unstubbed member be asserted on', () => {
+      const port = mockPort<ITestPort>({}, { strict: true });
+
+      expect(port.findById).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when the mock is awaited', () => {
     it('does not behave as a thenable', async () => {
       const port = mockPort<ITestPort>();

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -49,12 +49,6 @@ describe('mockPort', () => {
     jest.clearAllMocks();
   });
 
-  it('backs every member with a jest mock', () => {
-    const port = mockPort<ITestPort>();
-
-    expect(jest.isMockFunction(port.findById)).toBe(true);
-  });
-
   it('returns the same mock on every access', () => {
     const port = mockPort<ITestPort>();
 
@@ -114,10 +108,12 @@ describe('mockPort', () => {
       expect(port.name).toBe('a name');
     });
 
-    it('still mocks the methods around it', () => {
+    it('still records the calls made to the methods around it', async () => {
       const port = mockPort<IPortWithData>({ name: 'a name' });
 
-      expect(jest.isMockFunction(port.findById)).toBe(true);
+      await port.findById('id');
+
+      expect(port.findById).toHaveBeenCalledWith('id');
     });
   });
 
@@ -136,7 +132,9 @@ describe('mockPort', () => {
       it('mocks it anyway', () => {
         const port = mockPort<IPortWithOptionalMethod>();
 
-        expect(jest.isMockFunction(port.close)).toBe(true);
+        port.close?.();
+
+        expect(port.close).toHaveBeenCalled();
       });
     });
   });

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -20,10 +20,24 @@ interface IPortWithSymbolMethod {
   [iterate](): string[];
 }
 
+interface IPortWithOptionalExcludedMethods {
+  [iterate]?(): string[];
+  toJSON?(): unknown;
+}
+
+interface IPortWithOptionalData {
+  name?: string;
+}
+
 // A data member has no mock to fall back on, so the signature demands it.
 // @ts-expect-error 'name' is missing
 const rejectsAMissingDataMember = () => mockPort<IPortWithData>({});
 void rejectsAMissingDataMember;
+
+// Even an optional one: the proxy would answer the name with a jest.fn().
+// @ts-expect-error 'name' is missing
+const rejectsMissingOptionalData = () => mockPort<IPortWithOptionalData>({});
+void rejectsMissingOptionalData;
 
 // A symbol-keyed member is never auto-mocked, so it is demanded the same way.
 // @ts-expect-error the symbol member is missing
@@ -134,6 +148,20 @@ describe('mockPort', () => {
       port[iterate]();
 
       expect(port[iterate]).toHaveBeenCalled();
+    });
+  });
+
+  describe('when the methods it leaves alone are optional on the port', () => {
+    it('asks for nothing', () => {
+      const port = mockPort<IPortWithOptionalExcludedMethods>();
+
+      expect(port[iterate]).toBeUndefined();
+    });
+
+    it('leaves the probe-named one alone too', () => {
+      const port = mockPort<IPortWithOptionalExcludedMethods>();
+
+      expect(port.toJSON).toBeUndefined();
     });
   });
 

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -118,10 +118,12 @@ describe('mockPort', () => {
       expect(port.close).toHaveBeenCalled();
     });
 
-    it('mocks it even when it is left out', () => {
-      const port = mockPort<IPortWithOptionalMethod>();
+    describe('when it is left out', () => {
+      it('mocks it anyway', () => {
+        const port = mockPort<IPortWithOptionalMethod>();
 
-      expect(jest.isMockFunction(port.close)).toBe(true);
+        expect(jest.isMockFunction(port.close)).toBe(true);
+      });
     });
   });
 

--- a/packages/test-utils/src/mockPort.spec.ts
+++ b/packages/test-utils/src/mockPort.spec.ts
@@ -3,8 +3,17 @@ import { mockPort } from './mockPort';
 interface ITestPort {
   findById(id: string): Promise<{ id: string } | null>;
   save(value: { id: string }): Promise<void>;
+}
+
+interface IPortWithData {
+  findById(id: string): Promise<{ id: string } | null>;
   name: string;
 }
+
+// A data member has no mock to fall back on, so the signature demands it.
+// @ts-expect-error 'name' is missing
+const rejectsAMissingDataMember = () => mockPort<IPortWithData>({});
+void rejectsAMissingDataMember;
 
 describe('mockPort', () => {
   afterEach(() => {
@@ -66,6 +75,20 @@ describe('mockPort', () => {
       port.findById.mockResolvedValue({ id: 'configured' });
 
       await expect(port.findById('id')).resolves.toEqual({ id: 'configured' });
+    });
+  });
+
+  describe('when the port carries a member that is not a method', () => {
+    it('keeps the value it was given', () => {
+      const port = mockPort<IPortWithData>({ name: 'a name' });
+
+      expect(port.name).toBe('a name');
+    });
+
+    it('still mocks the methods around it', () => {
+      const port = mockPort<IPortWithData>({ name: 'a name' });
+
+      expect(jest.isMockFunction(port.findById)).toBe(true);
     });
   });
 

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -95,11 +95,23 @@ type PortStubsArgs<T> =
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 
-function refuseUnstubbedCall(member: string): UnknownFunction {
-  return () => {
-    throw new Error(
+/**
+ * Thrown by a strict mock when the code under test reaches for a member the
+ * spec never set up. Carries the member's name, so a test can assert on which
+ * one it was rather than on the wording of a message.
+ */
+export class UnstubbedPortCallError extends Error {
+  constructor(public readonly member: string) {
+    super(
       `mockPort: '${member}' was called but was never stubbed. Stub it, or drop the strict option if answering undefined is what this test wants.`,
     );
+    this.name = 'UnstubbedPortCallError';
+  }
+}
+
+function refuseUnstubbedCall(member: string): UnknownFunction {
+  return () => {
+    throw new UnstubbedPortCallError(member);
   };
 }
 

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -41,17 +41,24 @@ type MethodKeys<T> = {
  */
 type AutoMockedKeys<T> = Exclude<MethodKeys<T> & string, NeverMockedName>;
 
-type GivenKeys<T> = Exclude<keyof T, AutoMockedKeys<T>>;
+/** Methods the proxy leaves alone: the symbol-keyed and probe-named ones. */
+type ExcludedMethodKeys<T> = Exclude<MethodKeys<T>, AutoMockedKeys<T>>;
+
+type DataKeys<T> = Exclude<keyof T, MethodKeys<T>>;
 
 /**
  * An auto-mocked method can be seeded either with a real implementation - which
  * is type checked against the port and wrapped in a `jest.fn()` - or with a mock
  * built by hand, and may be left out entirely.
  *
- * Every other member has to be given, because nothing sensible can be conjured
- * for it: a data member would come back as a `jest.fn()` standing where the port
- * declares a value, and a symbol-keyed or probe-named method would come back
- * `undefined`.
+ * An excluded method may be left out too when the port declares it optional -
+ * `Pick` carries that optionality over, and the `undefined` the proxy answers
+ * with is exactly what such a port allows.
+ *
+ * A data member is always demanded, optional on the port or not. The proxy has
+ * only the member's name to go on, so an absent one would be answered with a
+ * `jest.fn()` - a function standing where the port declares a value, which is
+ * the very lie this helper exists to avoid.
  */
 export type PortStubs<T> = Partial<{
   [K in AutoMockedKeys<T>]: NonNullable<T[K]> extends (
@@ -59,11 +66,14 @@ export type PortStubs<T> = Partial<{
   ) => infer R
     ? NonNullable<T[K]> | jest.Mock<R, A>
     : never;
-}> & { [K in GivenKeys<T>]: T[K] };
+}> &
+  Pick<T, ExcludedMethodKeys<T>> &
+  Required<Pick<T, DataKeys<T>>>;
 
-type PortStubsArgs<T> = [GivenKeys<T>] extends [never]
-  ? [stubs?: PortStubs<T>]
-  : [stubs: PortStubs<T>];
+type PortStubsArgs<T> =
+  Record<never, never> extends PortStubs<T>
+    ? [stubs?: PortStubs<T>]
+    : [stubs: PortStubs<T>];
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -70,12 +70,38 @@ export type PortStubs<T> = Partial<{
   Pick<T, ExcludedMethodKeys<T>> &
   Required<Pick<T, DataKeys<T>>>;
 
+export type MockPortOptions = {
+  /**
+   * Make a member that was never stubbed throw when it is called, rather than
+   * answer `undefined`.
+   *
+   * A complete mock is quiet by default: the day the code under test starts
+   * calling a member this spec never set up, the call returns `undefined` and
+   * the test may well still pass. Strict mode trades that for a loud failure
+   * naming the member - at the cost of having to stub every member the run
+   * actually reaches.
+   *
+   * Beware `jest.resetAllMocks()` and `resetMocks` in a jest config: both drop
+   * the implementation behind a mock, the refusal included, which puts the
+   * member back to answering `undefined`.
+   */
+  strict?: boolean;
+};
+
 type PortStubsArgs<T> =
   Record<never, never> extends PortStubs<T>
-    ? [stubs?: PortStubs<T>]
-    : [stubs: PortStubs<T>];
+    ? [stubs?: PortStubs<T>, options?: MockPortOptions]
+    : [stubs: PortStubs<T>, options?: MockPortOptions];
 
 type UnknownFunction = (...args: unknown[]) => unknown;
+
+function refuseUnstubbedCall(member: string): UnknownFunction {
+  return () => {
+    throw new Error(
+      `mockPort: '${member}' was called but was never stubbed. Stub it, or drop the strict option if answering undefined is what this test wants.`,
+    );
+  };
+}
 
 function isJestMock(value: unknown): boolean {
   return (
@@ -108,11 +134,18 @@ function isJestMock(value: unknown): boolean {
  * cannot conjure - a data member such as an `AxiosInstance`'s `defaults`, a
  * symbol-keyed method, a method named after one of the probes above - has to be
  * supplied, and a type whose shape is mostly data is better mocked by hand.
+ *
+ * Pass `{ strict: true }` to make an unstubbed member refuse the call instead of
+ * answering `undefined`:
+ *
+ * ```ts
+ * const gitRepo = mockPort<IGitRepo>({}, { strict: true });
+ * ```
  */
 export function mockPort<T extends object>(
   ...args: PortStubsArgs<T>
 ): jest.Mocked<T> {
-  const [stubs = {} as PortStubs<T>] = args;
+  const [stubs = {} as PortStubs<T>, options = {}] = args;
   const members = new Map<string | symbol, unknown>();
 
   const isAutoMocked = (member: string | symbol): boolean =>
@@ -136,7 +169,12 @@ export function mockPort<T extends object>(
       if (!isAutoMocked(member)) {
         return undefined;
       }
-      members.set(member, jest.fn());
+      members.set(
+        member,
+        options.strict
+          ? jest.fn(refuseUnstubbedCall(member as string))
+          : jest.fn(),
+      );
       return members.get(member);
     },
     set(_target, member, value) {

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -1,0 +1,115 @@
+/**
+ * Members that must never be answered with a `jest.fn()`. The runtime probes
+ * some of them on any object it is handed - `await` looks for `then`,
+ * pretty-format looks for `toJSON` and `$$typeof`, `expect` looks for
+ * `asymmetricMatch` - and a mock answering them makes the port look like a
+ * thenable or breaks the failure output.
+ */
+const NEVER_MOCKED: ReadonlySet<string> = new Set([
+  'then',
+  'catch',
+  'finally',
+  'toJSON',
+  'toString',
+  'valueOf',
+  'inspect',
+  'constructor',
+  'asymmetricMatch',
+  '$$typeof',
+  'nodeType',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+]);
+
+/**
+ * A member of `T` can be seeded either with a real implementation - which is
+ * type checked against the port and wrapped in a `jest.fn()` - or with a mock
+ * built by hand.
+ */
+export type PortStubs<T> = Partial<{
+  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+    ? T[K] | jest.Mock<R, A>
+    : T[K];
+}>;
+
+type UnknownFunction = (...args: unknown[]) => unknown;
+
+function isJestMock(value: unknown): boolean {
+  return (
+    typeof value === 'function' &&
+    (value as { _isMockFunction?: boolean })._isMockFunction === true
+  );
+}
+
+/**
+ * Typed mock of an interface, the counterpart of `createMockInstance` for ports
+ * that have no class to walk at runtime.
+ *
+ * Every member is lazily backed by a `jest.fn()`, so the mock is complete by
+ * construction and never needs an `as unknown as jest.Mocked<T>` cast - which
+ * would switch off the structural checks the spec type check relies on. Stubs
+ * are typed against the port, so a fixture that drifts from the contract fails
+ * the build:
+ *
+ * ```ts
+ * const gitRepo = mockPort<IGitRepo>();
+ * gitRepo.getFileOnRepo.mockResolvedValue({ sha: 'sha', content: 'content' });
+ *
+ * // or seed implementations up front
+ * const accounts = mockPort<IAccountsPort>({
+ *   getUserById: async () => user,
+ * });
+ * ```
+ */
+export function mockPort<T extends object>(
+  stubs: PortStubs<T> = {},
+): jest.Mocked<T> {
+  const members = new Map<string, unknown>();
+
+  const isMockable = (member: string | symbol): member is string =>
+    typeof member === 'string' && !NEVER_MOCKED.has(member);
+
+  for (const [name, stub] of Object.entries(stubs)) {
+    members.set(
+      name,
+      typeof stub === 'function' && !isJestMock(stub)
+        ? jest.fn(stub as UnknownFunction)
+        : stub,
+    );
+  }
+
+  return new Proxy({} as jest.Mocked<T>, {
+    get(_target, member) {
+      if (!isMockable(member)) {
+        return undefined;
+      }
+      if (!members.has(member)) {
+        members.set(member, jest.fn());
+      }
+      return members.get(member);
+    },
+    set(_target, member, value) {
+      if (isMockable(member)) {
+        members.set(member, value);
+      }
+      return true;
+    },
+    has(_target, member) {
+      return isMockable(member);
+    },
+    ownKeys() {
+      return [...members.keys()];
+    },
+    getOwnPropertyDescriptor(_target, member) {
+      if (!isMockable(member)) {
+        return undefined;
+      }
+      return {
+        configurable: true,
+        enumerable: true,
+        value: members.get(member),
+      };
+    },
+  });
+}

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -22,16 +22,32 @@ const NEVER_MOCKED: ReadonlySet<string> = new Set([
   'propertyIsEnumerable',
 ]);
 
+type MethodKeys<T> = {
+  [K in keyof T]-?: NonNullable<T[K]> extends (...args: never[]) => unknown
+    ? K
+    : never;
+}[keyof T];
+
+type DataKeys<T> = Exclude<keyof T, MethodKeys<T>>;
+
 /**
- * A member of `T` can be seeded either with a real implementation - which is
- * type checked against the port and wrapped in a `jest.fn()` - or with a mock
- * built by hand.
+ * A method can be seeded either with a real implementation - which is type
+ * checked against the port and wrapped in a `jest.fn()` - or with a mock built
+ * by hand, and may be left out entirely.
+ *
+ * A member that is *not* a method has to be given: nothing sensible can be
+ * conjured for it, since the proxy cannot tell a data member from a method at
+ * runtime and would hand out a `jest.fn()` where the port declares a value.
  */
 export type PortStubs<T> = Partial<{
-  [K in keyof T]: T[K] extends (...args: infer A) => infer R
+  [K in MethodKeys<T>]: T[K] extends (...args: infer A) => infer R
     ? T[K] | jest.Mock<R, A>
-    : T[K];
-}>;
+    : never;
+}> & { [K in DataKeys<T>]: T[K] };
+
+type PortStubsArgs<T> = [DataKeys<T>] extends [never]
+  ? [stubs?: PortStubs<T>]
+  : [stubs: PortStubs<T>];
 
 type UnknownFunction = (...args: unknown[]) => unknown;
 
@@ -61,10 +77,15 @@ function isJestMock(value: unknown): boolean {
  *   getUserById: async () => user,
  * });
  * ```
+ *
+ * It fits ports whose members are all methods. A type that also carries data -
+ * an `AxiosInstance` and its `defaults`, say - has to have those members
+ * supplied, and one whose shape is mostly data is better mocked by hand.
  */
 export function mockPort<T extends object>(
-  stubs: PortStubs<T> = {},
+  ...args: PortStubsArgs<T>
 ): jest.Mocked<T> {
+  const [stubs = {} as PortStubs<T>] = args;
   const members = new Map<string, unknown>();
 
   const isMockable = (member: string | symbol): member is string =>

--- a/packages/test-utils/src/mockPort.ts
+++ b/packages/test-utils/src/mockPort.ts
@@ -5,7 +5,7 @@
  * `asymmetricMatch` - and a mock answering them makes the port look like a
  * thenable or breaks the failure output.
  */
-const NEVER_MOCKED: ReadonlySet<string> = new Set([
+const NEVER_MOCKED = [
   'then',
   'catch',
   'finally',
@@ -20,7 +20,11 @@ const NEVER_MOCKED: ReadonlySet<string> = new Set([
   'hasOwnProperty',
   'isPrototypeOf',
   'propertyIsEnumerable',
-]);
+] as const;
+
+type NeverMockedName = (typeof NEVER_MOCKED)[number];
+
+const neverMocked: ReadonlySet<string> = new Set(NEVER_MOCKED);
 
 type MethodKeys<T> = {
   [K in keyof T]-?: NonNullable<T[K]> extends (...args: never[]) => unknown
@@ -28,24 +32,36 @@ type MethodKeys<T> = {
     : never;
 }[keyof T];
 
-type DataKeys<T> = Exclude<keyof T, MethodKeys<T>>;
+/**
+ * The members a `jest.fn()` can stand in for without being asked: the methods
+ * the proxy is free to answer. A symbol-keyed member is not one of them - the
+ * runtime probes symbols such as `Symbol.iterator` on any object, so answering
+ * them would make the mock claim behaviour the port never declared - and nor is
+ * a member named after one of the probes above.
+ */
+type AutoMockedKeys<T> = Exclude<MethodKeys<T> & string, NeverMockedName>;
+
+type GivenKeys<T> = Exclude<keyof T, AutoMockedKeys<T>>;
 
 /**
- * A method can be seeded either with a real implementation - which is type
- * checked against the port and wrapped in a `jest.fn()` - or with a mock built
- * by hand, and may be left out entirely.
+ * An auto-mocked method can be seeded either with a real implementation - which
+ * is type checked against the port and wrapped in a `jest.fn()` - or with a mock
+ * built by hand, and may be left out entirely.
  *
- * A member that is *not* a method has to be given: nothing sensible can be
- * conjured for it, since the proxy cannot tell a data member from a method at
- * runtime and would hand out a `jest.fn()` where the port declares a value.
+ * Every other member has to be given, because nothing sensible can be conjured
+ * for it: a data member would come back as a `jest.fn()` standing where the port
+ * declares a value, and a symbol-keyed or probe-named method would come back
+ * `undefined`.
  */
 export type PortStubs<T> = Partial<{
-  [K in MethodKeys<T>]: T[K] extends (...args: infer A) => infer R
-    ? T[K] | jest.Mock<R, A>
+  [K in AutoMockedKeys<T>]: NonNullable<T[K]> extends (
+    ...args: infer A
+  ) => infer R
+    ? NonNullable<T[K]> | jest.Mock<R, A>
     : never;
-}> & { [K in DataKeys<T>]: T[K] };
+}> & { [K in GivenKeys<T>]: T[K] };
 
-type PortStubsArgs<T> = [DataKeys<T>] extends [never]
+type PortStubsArgs<T> = [GivenKeys<T>] extends [never]
   ? [stubs?: PortStubs<T>]
   : [stubs: PortStubs<T>];
 
@@ -78,20 +94,22 @@ function isJestMock(value: unknown): boolean {
  * });
  * ```
  *
- * It fits ports whose members are all methods. A type that also carries data -
- * an `AxiosInstance` and its `defaults`, say - has to have those members
- * supplied, and one whose shape is mostly data is better mocked by hand.
+ * It fits ports whose members are all plainly named methods. Anything the proxy
+ * cannot conjure - a data member such as an `AxiosInstance`'s `defaults`, a
+ * symbol-keyed method, a method named after one of the probes above - has to be
+ * supplied, and a type whose shape is mostly data is better mocked by hand.
  */
 export function mockPort<T extends object>(
   ...args: PortStubsArgs<T>
 ): jest.Mocked<T> {
   const [stubs = {} as PortStubs<T>] = args;
-  const members = new Map<string, unknown>();
+  const members = new Map<string | symbol, unknown>();
 
-  const isMockable = (member: string | symbol): member is string =>
-    typeof member === 'string' && !NEVER_MOCKED.has(member);
+  const isAutoMocked = (member: string | symbol): boolean =>
+    typeof member === 'string' && !neverMocked.has(member);
 
-  for (const [name, stub] of Object.entries(stubs)) {
+  for (const name of Reflect.ownKeys(stubs)) {
+    const stub = (stubs as Record<string | symbol, unknown>)[name];
     members.set(
       name,
       typeof stub === 'function' && !isJestMock(stub)
@@ -102,28 +120,27 @@ export function mockPort<T extends object>(
 
   return new Proxy({} as jest.Mocked<T>, {
     get(_target, member) {
-      if (!isMockable(member)) {
+      if (members.has(member)) {
+        return members.get(member);
+      }
+      if (!isAutoMocked(member)) {
         return undefined;
       }
-      if (!members.has(member)) {
-        members.set(member, jest.fn());
-      }
+      members.set(member, jest.fn());
       return members.get(member);
     },
     set(_target, member, value) {
-      if (isMockable(member)) {
-        members.set(member, value);
-      }
+      members.set(member, value);
       return true;
     },
     has(_target, member) {
-      return isMockable(member);
+      return members.has(member) || isAutoMocked(member);
     },
     ownKeys() {
       return [...members.keys()];
     },
     getOwnPropertyDescriptor(_target, member) {
-      if (!isMockable(member)) {
+      if (!members.has(member)) {
         return undefined;
       }
       return {


### PR DESCRIPTION
## Explanation

Introduces `mockPort<T>()`, a new test utility for creating fully-typed mocks of interfaces (ports) that have no class to walk at runtime. This complements the existing `createMockInstance` which works with classes.

The utility:
- Lazily backs every member with a `jest.fn()`, ensuring the mock is complete by construction
- Provides type-safe stub configuration that's checked against the port contract
- Avoids the pitfalls of `as unknown as jest.Mocked<T>` casts, which disable structural type checking
- Handles edge cases like thenable detection and special runtime properties that must never be mocked

Refactors 15+ test files across the git package to use `mockPort` instead of manual object literals with type casts, significantly reducing boilerplate and improving type safety.

## Type of Change

- [x] New feature
- [x] Refactoring
- [x] Documentation

## Affected Components

- **Domain packages affected**: `@packmind/test-utils`
- **Frontend / Backend / Both**: Both (test utilities)
- **Breaking changes**: None

## Testing

- [x] Unit tests added/updated
  - Added comprehensive test suite (`mockPort.spec.ts`) covering:
    - Lazy mock creation and identity preservation
    - Call recording through mocks
    - Stub implementations (both real functions and pre-built mocks)
    - Post-construction configuration
    - Data member handling
    - Thenable detection (ensuring mocks don't behave as thenables when awaited)
- [x] Integration tests via refactored specs
  - 15+ existing test files refactored to use `mockPort`, validating the utility works correctly in real test scenarios
  - All existing tests continue to pass with the new utility

**Test Details:**
The new `mockPort.spec.ts` validates all core behaviors: lazy initialization, mock identity, call tracking, stub wrapping, and special property handling. The refactored test files demonstrate the utility's effectiveness in reducing boilerplate while maintaining full type safety and test functionality.

## TODO List

- [x] CHANGELOG Updated (via documentation in CLAUDE.md)
- [x] Documentation Updated (added section to CLAUDE.md with usage examples)

## Reviewer Notes

The implementation uses a Proxy to lazily create mocks and carefully avoids mocking properties that the JavaScript runtime probes (like `then`, `toJSON`, `$$typeof`) which would break test behavior. The type system ensures data members must be provided while methods are optional, catching contract violations at build time rather than runtime.

https://claude.ai/code/session_01BXLu2mQf7NhTSS2q4TS4Lr